### PR TITLE
Allow overriding of Trusted_Connection parameter in connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ in DATABASES control the behavior of the backend:
    Boolean. Set this to `False` if you want to disable
    Django's transaction management and implement your own.
 
+-  Trusted_Connection
+
+   String. Default is `"yes"`. Can be set to `"no"` if required.
+
 and the following entries are also available in the `TEST` dictionary
 for any given database-level settings dictionary:
 

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -249,6 +249,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         user = conn_params.get('USER', None)
         password = conn_params.get('PASSWORD', None)
         port = conn_params.get('PORT', None)
+        trusted_connection = conn_params.get('Trusted_Connection', 'yes')
 
         options = conn_params.get('OPTIONS', {})
         driver = options.get('driver', 'ODBC Driver 13 for SQL Server')
@@ -289,7 +290,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             cstr_parts['PWD'] = password
         else:
             if ms_drivers.match(driver):
-                cstr_parts['Trusted_Connection'] = 'yes'
+                cstr_parts['Trusted_Connection'] = trusted_connection
             else:
                 cstr_parts['Integrated Security'] = 'SSPI'
 


### PR DESCRIPTION
User may want to override the Trusted_Connection parameter which currently is not possible when using ODBC drivers. In authentication methods such as ActiveDirectoryMsi when using azure sql, this can cause an authentication failure when using system managed identities.

This change does not changes the current behavior of the code but just gives an option to override the parameter when required to prevent authentication failures.