### PR TITLE
Declare dependencies explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ setup(
     license='BSD',
     packages=find_packages(),
     install_requires=[
+        'django>=2.2,<3.2',
         'pyodbc>=3.0',
+        'pytz',
     ],
     classifiers=CLASSIFIERS,
     keywords='django',


### PR DESCRIPTION
This project currently fails to declare its dependencies on django and pytz; and in particular per #25 django 3.2 is not yet supported.

Make those dependencies explicit.