### PR TITLE
Increase max bulk_batch_size

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -49,12 +49,20 @@ class DatabaseOperations(BaseDatabaseOperations):
         are the fields going to be inserted in the batch, the objs contains
         all the objects to be inserted.
         """
-        objs_len, fields_len, max_row_values = len(objs), len(fields), 1000
-        if (objs_len * fields_len) <= max_row_values:
-            size = objs_len
-        else:
-            size = max_row_values // fields_len
-        return size
+        max_insert_rows = 1000
+        fields_len = len(fields)
+        if fields_len == 0:
+            # Required for empty model
+            # (bulk_create.tests.BulkCreateTests.test_empty_model)
+            return max_insert_rows
+
+        # MSSQL allows a query to have 2100 parameters but some parameters are
+        # taken up defining `NVARCHAR` parameters to store the query text and
+        # query parameters for the `sp_executesql` call. This should only take
+        # up 2 parameters but I've had this error when sending 2098 parameters.
+        max_query_params = 2050
+        # inserts are capped at 1000 rows regardless of number of query params.
+        return min(max_insert_rows, max_query_params // fields_len)
 
     def bulk_insert_sql(self, fields, placeholder_rows):
         placeholder_rows_sql = (", ".join(row) for row in placeholder_rows)


### PR DESCRIPTION
The previous limit was a max of 1000 query parameters. This is changed
to a max of 1000 rows (the max number of rows allowed for inserting in a
single statement by mssql) or however many rows can be inserted while
keeping the number of query parameters below 2050 per insert statement
(mssql reports a max allowed of 2100 parameters but a few parameters are
reserved for executing the query).