### PR TITLE
Avoid invalid SQL syntax from OrderBy.as_sql

### DIFF
--- a/testapp/tests/test_expressions.py
+++ b/testapp/tests/test_expressions.py
@@ -4,11 +4,12 @@
 from unittest import skipUnless
 
 from django import VERSION
-from django.db.models import IntegerField
+from django.db.models import IntegerField, F
 from django.db.models.expressions import Case, Exists, OuterRef, Subquery, Value, When
-from django.test import TestCase
+from django.test import TestCase, skipUnlessDBFeature
 
-from ..models import Author, Comment, Post
+
+from ..models import Author, Comment, Post, Editor
 
 DJANGO3 = VERSION[0] >= 3
 
@@ -54,3 +55,25 @@ class TestExists(TestCase):
 
         authors_by_posts = Author.objects.order_by(Exists(Post.objects.filter(author=OuterRef('pk'))).asc())
         self.assertSequenceEqual(authors_by_posts, [author_without_posts, self.author])
+
+
+@skipUnless(DJANGO3, "Django 3 specific tests")
+@skipUnlessDBFeature("order_by_nulls_first")
+class TestOrderBy(TestCase):
+    def setUp(self):
+        self.author = Author.objects.create(name="author")
+        self.post = Post.objects.create(title="foo", author=self.author)
+        self.editor = Editor.objects.create(name="editor")
+        self.post_alt = Post.objects.create(title="Post with editor", author=self.author, alt_editor=self.editor)
+
+    def test_order_by_nulls_last(self):
+        results = Post.objects.order_by(F("alt_editor").asc(nulls_last=True)).all()
+        self.assertEqual(len(results), 2)
+        self.assertIsNotNone(results[0].alt_editor)
+        self.assertIsNone(results[1].alt_editor)
+
+    def test_order_by_nulls_first(self):
+        results = Post.objects.order_by(F("alt_editor").desc(nulls_first=True)).all()
+        self.assertEqual(len(results), 2)
+        self.assertIsNone(results[0].alt_editor)
+        self.assertIsNotNone(results[1].alt_editor)


### PR DESCRIPTION
By making a copy of the OrderBy expression and disabling its nulls_first/nulls_last flags, this prevents Django's core OrderBy.as_sql function from modifying the custom templates SQL Server requires (and thus avoiding the invalid SQL syntax core Django is creating, as mentioned in #31).  This adds tests to check the querying works correctly (throws a ProgrammingError previously without this PR) and restructures `sqlserver_orderby` into a simpler, DRYer form.

See <https://code.djangoproject.com/ticket/32584> for details on why this isn't implemented as a feature flag.

Fixes #31