### PR TITLE
Enable support for window functions

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -33,6 +33,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_index_on_text_field = False
     supports_json_field_contains = False
     supports_order_by_nulls_modifier = False
+    supports_over_clause = True
     supports_paramstyle_pyformat = False
     supports_primitives_in_json_field = False
     supports_regex_backreferencing = True

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -4,8 +4,9 @@
 import json
 
 from django import VERSION
+from django.db import NotSupportedError
 from django.db.models import BooleanField, Value
-from django.db.models.functions import Cast
+from django.db.models.functions import Cast, NthValue
 from django.db.models.functions.math import ATan2, Log, Ln, Mod, Round
 from django.db.models.expressions import Case, Exists, OrderBy, When, Window
 from django.db.models.lookups import Lookup, In
@@ -49,6 +50,10 @@ def sqlserver_mod(self, compiler, connection):
             a=number_a[0], b=number_b[0]),
         arg_joiner=""
     )
+
+
+def sqlserver_nth_value(self, compiler, connection, **extra_content):
+    raise NotSupportedError('This backend does not support the NthValue function')
 
 
 def sqlserver_round(self, compiler, connection, **extra_context):
@@ -186,6 +191,7 @@ if VERSION >= (3, 1):
 Ln.as_microsoft = sqlserver_ln
 Log.as_microsoft = sqlserver_log
 Mod.as_microsoft = sqlserver_mod
+NthValue.as_microsoft = sqlserver_nth_value
 Round.as_microsoft = sqlserver_round
 Window.as_microsoft = sqlserver_window
 

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -56,6 +56,7 @@ EXCLUDED_TESTS = ['aggregation.tests.AggregateTestCase.test_expression_on_aggreg
                   'expressions_case.tests.CaseExpressionTests.test_annotate_with_in_clause',
                   'expressions_window.tests.WindowFunctionTests.test_nth_returns_null',
                   'expressions_window.tests.WindowFunctionTests.test_nthvalue',
+                  'expressions_window.tests.WindowFunctionTests.test_range_n_preceding_and_following',
                   'ordering.tests.OrderingTests.test_orders_nulls_first_on_filtered_subquery',
                   'queries.test_bulk_update.BulkUpdateNoteTests.test_set_field_to_null',
                   'get_or_create.tests.UpdateOrCreateTransactionTests.test_creation_in_transaction',

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -54,6 +54,8 @@ EXCLUDED_TESTS = ['aggregation.tests.AggregateTestCase.test_expression_on_aggreg
                   'expressions.tests.FTimeDeltaTests.test_duration_with_datetime_microseconds',
                   'expressions.tests.IterableLookupInnerExpressionsTests.test_expressions_in_lookups_join_choice',
                   'expressions_case.tests.CaseExpressionTests.test_annotate_with_in_clause',
+                  'expressions_window.tests.WindowFunctionTests.test_nth_returns_null',
+                  'expressions_window.tests.WindowFunctionTests.test_nthvalue',
                   'ordering.tests.OrderingTests.test_orders_nulls_first_on_filtered_subquery',
                   'queries.test_bulk_update.BulkUpdateNoteTests.test_set_field_to_null',
                   'get_or_create.tests.UpdateOrCreateTransactionTests.test_creation_in_transaction',


### PR DESCRIPTION
It seems that while this backend can support window functions out of the box, the flag hasn't been set, so a NotSupportError is thrown (see https://github.com/ESSolutions/django-mssql-backend/issues/67)

I've just tried some common uses (rank over a partition, average over a row range frame), and they worked perfectly.