### PR TITLE
fix: use parameter data type instead of hardcoded nvarchar(32)

### DIFF
--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -126,7 +126,8 @@ def split_parameter_list_as_sql(self, compiler, connection):
 
     with connection.cursor() as cursor:
         cursor.execute("IF OBJECT_ID('tempdb.dbo.#Temp_params', 'U') IS NOT NULL DROP TABLE #Temp_params; ")
-        cursor.execute("CREATE TABLE #Temp_params (params nvarchar(32))")
+        parameter_data_type = self.lhs.field.db_type(connection)
+        cursor.execute(f"CREATE TABLE #Temp_params (params {parameter_data_type})")
         for offset in range(0, len(rhs_params), 1000):
             sqls_params = rhs_params[offset: offset + 1000]
             sqls_params = ", ".join("('{}')".format(item) for item in sqls_params)


### PR DESCRIPTION
This PR resosolves #46. Instead of using a hardcoded `nvarchar(36)` as a data type, the data type of the lhs is used for the temp table. The tests still pass.

It would be cool to get this in the next release as this is rather blocking for us. Let me know if you have any questions.