### PR TITLE
add additional parameters argument to runshell as required by Django 3.1

### DIFF
--- a/mssql/client.py
+++ b/mssql/client.py
@@ -10,8 +10,8 @@ from django.db.backends.base.client import BaseDatabaseClient
 class DatabaseClient(BaseDatabaseClient):
     executable_name = 'sqlcmd'
 
-    def runshell(self):
-        settings_dict = self.connection.settings_dict
+    @classmethod
+    def settings_to_cmd_args(cls, settings_dict, parameters):
         options = settings_dict['OPTIONS']
         user = options.get('user', settings_dict['USER'])
         password = options.get('passwd', settings_dict['PASSWORD'])
@@ -19,15 +19,15 @@ class DatabaseClient(BaseDatabaseClient):
         driver = options.get('driver', 'ODBC Driver 13 for SQL Server')
         ms_drivers = re.compile('^ODBC Driver .* for SQL Server$|^SQL Server Native Client')
         if not ms_drivers.match(driver):
-            self.executable_name = 'isql'
+            cls.executable_name = 'isql'
 
-        if self.executable_name == 'sqlcmd':
+        if cls.executable_name == 'sqlcmd':
             db = options.get('db', settings_dict['NAME'])
             server = options.get('host', settings_dict['HOST'])
             port = options.get('port', settings_dict['PORT'])
             defaults_file = options.get('read_default_file')
 
-            args = [self.executable_name]
+            args = [cls.executable_name]
             if server:
                 if port:
                     server = ','.join((server, str(port)))
@@ -44,9 +44,11 @@ class DatabaseClient(BaseDatabaseClient):
                 args += ["-i", defaults_file]
         else:
             dsn = options.get('dsn', '')
-            args = ['%s -v %s %s %s' % (self.executable_name, dsn, user, password)]
+            args = ['%s -v %s %s %s' % (cls.executable_name, dsn, user, password)]
 
-        try:
-            subprocess.check_call(args)
-        except KeyboardInterrupt:
-            pass
+        args.extend(parameters)
+        return args
+
+    def runshell(self, parameters=[]):
+        args = DatabaseClient.settings_to_cmd_args(self.connection.settings_dict, parameters)
+        subprocess.run(args, check=True)


### PR DESCRIPTION
This fix by @morlandi fixes a backwards incompatible change in 3.1 to the `dbshell` manage.py command

See https://github.com/ESSolutions/django-mssql-backend/pull/109