### PR TITLE
features: set can_rollback_ddl

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -12,6 +12,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_introspect_small_integer_field = True
     can_return_columns_from_insert = True
     can_return_id_from_insert = True
+    can_rollback_ddl = True
     can_use_chunked_reads = False
     for_update_after_from = True
     greatest_least_ignores_nulls = True


### PR DESCRIPTION
I might be missing something, but to me it seems that MSSQL does support rolling back DDL statements made inside of transactions, eg. in the following, the table created inside of the transaction does not exist after rollback:
```
1> BEGIN TRAN; CREATE TABLE Foo([bar] INT); SELECT * FROM Foo; ROLLBACK TRAN; SELECT * FROM Foo;
2> GO
bar        
-----------

(0 rows affected)
Msg 208, Level 16, State 1, Server d590d6d3008c, Line 1
Invalid object name 'Foo'.
```

If DDL rollback is indeed supported, the `can_rollback_ddl` feature should be set.