### PR TITLE
Only drop necessary indexes during field rename

### DIFF
--- a/testapp/migrations/0002_test_unique_nullable_part1.py
+++ b/testapp/migrations/0002_test_unique_nullable_part1.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('test_field', models.CharField(max_length=100, null=True, unique=True)),
+                ('y', models.IntegerField(unique=True, null=True)),
             ],
         ),
     ]

--- a/testapp/migrations/0003_test_unique_nullable_part2.py
+++ b/testapp/migrations/0003_test_unique_nullable_part2.py
@@ -16,4 +16,10 @@ class Migration(migrations.Migration):
             field=models.CharField(default='', max_length=100, unique=True),
             preserve_default=False,
         ),
+        # Test for renaming of a unique+nullable column
+        migrations.RenameField(
+            model_name='testuniquenullablemodel',
+            old_name='y',
+            new_name='y_renamed',
+        ),
     ]

--- a/testapp/migrations/0011_test_unique_constraints.py
+++ b/testapp/migrations/0011_test_unique_constraints.py
@@ -25,6 +25,9 @@ class Migration(migrations.Migration):
                 ('_type', models.CharField(max_length=50)),
                 ('status', models.CharField(max_length=50)),
             ],
+            # Stop Django attempting to automatically create migrations for this table. Instead
+            # migrations are attempted manually in `test_unsupportable_unique_constraint` where
+            # they are expected to fail.
             options={
                 'managed': False,
             },

--- a/testapp/migrations/0012_test_indexes_retained_part1.py
+++ b/testapp/migrations/0012_test_indexes_retained_part1.py
@@ -7,7 +7,7 @@ class Migration(migrations.Migration):
         ('testapp', '0011_test_unique_constraints'),
     ]
 
-    # Prep test for issue https://github.com/ESSolutions/django-mssql-backend/issues/58
+    # Prep test for issue https://github.com/microsoft/mssql-django/issues/14
     operations = [
         migrations.CreateModel(
             name='TestIndexesRetained',

--- a/testapp/migrations/0013_test_indexes_retained_part2.py
+++ b/testapp/migrations/0013_test_indexes_retained_part2.py
@@ -7,7 +7,7 @@ class Migration(migrations.Migration):
         ('testapp', '0012_test_indexes_retained_part1'),
     ]
 
-    # Run test for issue https://github.com/ESSolutions/django-mssql-backend/issues/58
+    # Run test for issue https://github.com/microsoft/mssql-django/issues/14
     # where the following operations should leave indexes intact
     operations = [
         migrations.AlterField(

--- a/testapp/models.py
+++ b/testapp/models.py
@@ -58,13 +58,17 @@ class TestUniqueNullableModel(models.Model):
     # Field used for testing changing the 'type' of a field that's both unique & nullable
     x = models.CharField(max_length=11, null=True, unique=True)
 
+    # A variant of Issue https://github.com/microsoft/mssql-django/issues/14 case (b)
+    # but for a unique index (not db_index)
+    y_renamed = models.IntegerField(null=True, unique=True)
+
 
 class TestNullableUniqueTogetherModel(models.Model):
     class Meta:
         unique_together = (('a', 'b', 'c'),)
 
     # Issue https://github.com/ESSolutions/django-mssql-backend/issues/45 (case 2)
-    # Fields used for testing changing the 'type of a field that is in a `unique_together`
+    # Fields used for testing changing the type of a field that is in a `unique_together`
     a = models.CharField(max_length=51, null=True)
     b = models.CharField(max_length=50)
     c = models.CharField(max_length=50)
@@ -79,7 +83,7 @@ class TestRemoveOneToOneFieldModel(models.Model):
 
 
 class TestIndexesRetainedRenamed(models.Model):
-    # Issue https://github.com/ESSolutions/django-mssql-backend/issues/58
+    # Issue https://github.com/microsoft/mssql-django/issues/14
     # In all these cases the column index should still exist afterwards
     # case (a) `a` starts out not nullable, but then is changed to be nullable
     a = models.IntegerField(db_index=True, null=True)

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the BSD license.
+import os
 
 DATABASES = {
     "default": {
@@ -19,6 +20,48 @@ DATABASES = {
         "HOST": "localhost",
         "PORT": "1433",
         "OPTIONS": {"driver": "ODBC Driver 17 for SQL Server", },
+    },
+}
+
+# Set to `True` locally if you want SQL queries logged to django_sql.log
+DEBUG = False
+
+# Logging
+LOG_DIR = os.path.join(os.path.dirname(__file__), '..', 'logs')
+os.makedirs(LOG_DIR, exist_ok=True)
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'myformatter': {
+            'format': '%(asctime)s P%(process)05dT%(thread)05d [%(levelname)s] %(name)s: %(message)s',
+        },
+    },
+    'handlers': {
+        'db_output': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': os.path.join(LOG_DIR, 'django_sql.log'),
+            'formatter': 'myformatter',
+        },
+        'default': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': os.path.join(LOG_DIR, 'default.log'),
+            'formatter': 'myformatter',
+        }
+    },
+    'loggers': {
+        '': {
+            'handlers': ['default'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'django.db': {
+            'handlers': ['db_output'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
     },
 }
 

--- a/testapp/tests/test_constraints.py
+++ b/testapp/tests/test_constraints.py
@@ -20,13 +20,13 @@ from ..models import (
 
 @skipUnlessDBFeature('supports_nullable_unique_constraints')
 class TestNullableUniqueColumn(TestCase):
-    def test_multiple_nulls(self):
+    def test_type_change(self):
         # Issue https://github.com/ESSolutions/django-mssql-backend/issues/45 (case 1)
         # After field `x` has had its type changed, the filtered UNIQUE INDEX which is
         # implementing the nullable unique constraint should still be correctly in place
         # i.e. allowing multiple NULLs but still enforcing uniqueness of non-NULLs
 
-        # Allowed
+        # Allowed (NULL != NULL)
         TestUniqueNullableModel.objects.create(x=None, test_field='randomness')
         TestUniqueNullableModel.objects.create(x=None, test_field='doesntmatter')
 
@@ -34,6 +34,22 @@ class TestNullableUniqueColumn(TestCase):
         TestUniqueNullableModel.objects.create(x="foo", test_field='irrelevant')
         with self.assertRaises(IntegrityError):
             TestUniqueNullableModel.objects.create(x="foo", test_field='nonsense')
+
+    def test_rename(self):
+        # Rename of a column which is both nullable & unique. Test that
+        # the constraint-enforcing unique index survived this migration
+        # Related to both:
+        # Issue https://github.com/microsoft/mssql-django/issues/67
+        # Issue https://github.com/microsoft/mssql-django/issues/14
+
+        # Allowed (NULL != NULL)
+        TestUniqueNullableModel.objects.create(y_renamed=None, test_field='something')
+        TestUniqueNullableModel.objects.create(y_renamed=None, test_field='anything')
+
+        # Disallowed
+        TestUniqueNullableModel.objects.create(y_renamed=42, test_field='nonimportant')
+        with self.assertRaises(IntegrityError):
+            TestUniqueNullableModel.objects.create(y_renamed=42, test_field='whocares')
 
 
 @skipUnlessDBFeature('supports_partially_nullable_unique_constraints')
@@ -76,6 +92,7 @@ class TestRenameManyToManyField(TestCase):
         other2 = M2MOtherModel.objects.create(name='2')
         thing1.others_renamed.set([other1, other2])
         # Check that the unique_together on the through table is still enforced
+        # (created by create_many_to_many_intermediary_model)
         ThroughModel = TestRenameManyToManyFieldModel.others_renamed.through
         with self.assertRaises(IntegrityError, msg='Through model fails to enforce uniqueness after m2m rename'):
             # This should fail due to the unique_together because (thing1, other1) is already in the through table

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -1,9 +1,24 @@
+import logging
+
 import django.db
+from django.apps import apps
+from django.db.models import UniqueConstraint
 from django.test import TestCase
 
 from ..models import (
     TestIndexesRetainedRenamed
 )
+
+
+logger = logging.getLogger('mssql.tests')
+
+
+def _get_constraints(table_name):
+    connection = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+    return connection.introspection.get_constraints(
+        connection.cursor(),
+        table_name=table_name,
+    )
 
 
 class TestIndexesRetained(TestCase):
@@ -18,11 +33,7 @@ class TestIndexesRetained(TestCase):
         super().setUpClass()
         # Pre-fetch which indexes exist for the relevant test model
         # now that all the test migrations have run
-        connection = django.db.connections[django.db.DEFAULT_DB_ALIAS]
-        cls.constraints = connection.introspection.get_constraints(
-            connection.cursor(),
-            table_name=TestIndexesRetainedRenamed._meta.db_table
-        )
+        cls.constraints = _get_constraints(table_name=TestIndexesRetainedRenamed._meta.db_table)
         cls.indexes = {k: v for k, v in cls.constraints.items() if v['index'] is True}
 
     def _assert_index_exists(self, columns):
@@ -46,3 +57,85 @@ class TestIndexesRetained(TestCase):
     def test_table_renamed(self):
         # case (c) of https://github.com/microsoft/mssql-django/issues/14
         self._assert_index_exists({'c'})
+
+def _get_all_models():
+    for app in apps.get_app_configs():
+        app_label = app.label
+        for model_name, model_class in app.models.items():
+            yield model_class, model_name, app_label
+
+
+class TestCorrectIndexes(TestCase):
+
+    def test_correct_indexes_exist(self):
+        """
+        Check there are the correct number of indexes for each field after all migrations
+        by comparing what the model says (e.g. `db_index=True` / `index_together` etc.)
+        with the actual constraints found in the database.
+        This acts as a general regression test for issues such as:
+         - duplicate index created (e.g. https://github.com/microsoft/mssql-django/issues/77)
+         - index dropped but accidentally not recreated
+         - index incorrectly 'recreated' when it was never actually dropped or required at all
+        Note of course that it only covers cases which exist in testapp/models.py and associated migrations
+        """
+        connection = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+        for model_cls, model_name, app_label in _get_all_models():
+            logger.debug('Checking model: %s.%s', app_label, model_name)
+            if not model_cls._meta.managed:
+                # Models where the table is not managed by Django migrations are irrelevant
+                continue
+            model_constraints = _get_constraints(table_name=model_cls._meta.db_table)
+            # Check correct indexes are in place for all fields in model
+            for field in model_cls._meta.get_fields():
+                if not hasattr(field, 'column'):
+                    # ignore things like reverse fields which don't have a column on this table
+                    continue
+                col_name = connection.introspection.identifier_converter(field.column)
+                field_str = f'{app_label}.{model_name}.{field.name} ({col_name})'
+                logger.debug('  > Checking field: %s', field_str)
+
+                # Find constraints which include this column
+                col_constraints = [
+                    dict(name=name, **infodict) for name, infodict in model_constraints.items()
+                    if col_name in infodict['columns']
+                ]
+                col_indexes = [c for c in col_constraints if c['index']]
+                for c in col_constraints:
+                    logger.debug('    > Column <%s> is involved in constraint: %s', col_name, c)
+
+                # There should be an explicit index for each of the following cases
+                expected_index_causes = []
+                if field.db_index:
+                    expected_index_causes.append('db_index=True')
+                for field_names in model_cls._meta.index_together:
+                    if field.name in field_names:
+                        expected_index_causes.append(f'index_together[{field_names}]')
+                if field._unique and field.null:
+                    # This is implemented using a (filtered) unique index (not a constraint) to get ANSI NULL behaviour
+                    expected_index_causes.append('unique=True & null=True')
+                for field_names in model_cls._meta.unique_together:
+                    if field.name in field_names:
+                        # unique_together results in an index because this backend implements it using a
+                        # (filtered) unique index rather than a constraint, to get ANSI NULL behaviour
+                        expected_index_causes.append(f'unique_together[{field_names}]')
+                for uniq_constraint in filter(lambda c: isinstance(c, UniqueConstraint), model_cls._meta.constraints):
+                    if field.name in uniq_constraint.fields and uniq_constraint.condition is not None:
+                        # Meta:constraints > UniqueConstraint with condition are implemented with filtered unique index
+                        expected_index_causes.append(f'UniqueConstraint (with condition) in Meta: constraints')
+
+                # Other cases like `unique=True, null=False` or `field.primary_key` do have index-like constraints
+                # but in those cases the introspection returns `"index": False` so they are not in the list of
+                # explicit indexes which we are checking here (`col_indexes`)
+
+                assert len(col_indexes) == len(expected_index_causes), \
+                    'Expected %s index(es) on %s but found %s.\n' \
+                    'Check for behaviour changes around index drop/recreate in methods like _alter_field.\n' \
+                    'Expected due to: %s\n' \
+                    'Found: %s' % (
+                        len(expected_index_causes),
+                        field_str,
+                        len(col_indexes),
+                        expected_index_causes,
+                        '\n'.join(str(i) for i in col_indexes),
+                    )
+                logger.debug('  Found %s index(es) as expected', len(col_indexes))

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -8,7 +8,7 @@ from ..models import (
 
 class TestIndexesRetained(TestCase):
     """
-    Issue https://github.com/ESSolutions/django-mssql-backend/issues/58
+    Issue https://github.com/microsoft/mssql-django/issues/14
     Indexes dropped during a migration should be re-created afterwards
     assuming the field still has `db_index=True`
     """
@@ -36,13 +36,13 @@ class TestIndexesRetained(TestCase):
         )
 
     def test_field_made_nullable(self):
-        # case (a) of https://github.com/ESSolutions/django-mssql-backend/issues/58
+        # case (a) of https://github.com/microsoft/mssql-django/issues/14
         self._assert_index_exists({'a'})
 
     def test_field_renamed(self):
-        # case (b) of https://github.com/ESSolutions/django-mssql-backend/issues/58
+        # case (b) of https://github.com/microsoft/mssql-django/issues/14
         self._assert_index_exists({'b_renamed'})
 
     def test_table_renamed(self):
-        # case (c) of https://github.com/ESSolutions/django-mssql-backend/issues/58
+        # case (c) of https://github.com/microsoft/mssql-django/issues/14
         self._assert_index_exists({'c'})


### PR DESCRIPTION
First commit is a proposed fix for https://github.com/microsoft/mssql-django/issues/85

The rest are test improvements.

See commit messages for details.