### PR TITLE
Tweak bulk insert

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -459,6 +459,7 @@ class SQLInsertCompiler(compiler.SQLInsertCompiler, SQLCompiler):
         fields = self.query.fields or [opts.pk]
 
         if self.can_return_rows_from_bulk_insert() and not(self.query.fields) and isinstance(fields[0], django.db.models.fields.AutoField):
+            # https://dba.stackexchange.com/questions/254771/insert-multiple-rows-into-a-table-with-only-an-identity-column
             result = ['MERGE INTO %s' % qn(opts.db_table)]
             result.append("""
                 USING (SELECT TOP %s * FROM master..spt_values) T

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -12,6 +12,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_introspect_small_integer_field = True
     can_return_columns_from_insert = True
     can_return_id_from_insert = True
+    can_return_rows_from_bulk_insert = True
     can_rollback_ddl = True
     can_use_chunked_reads = False
     for_update_after_from = True

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -188,6 +188,24 @@ class DatabaseOperations(BaseDatabaseOperations):
             sql = "CONVERT(datetime2, CONVERT(varchar, %s, 20))" % field_name
         return sql
 
+    def fetch_returned_insert_rows(self, cursor):
+        """
+        Given a cursor object that has just performed an INSERT...
+        statement into a table, return the list of returned data.
+        """
+        return cursor.fetchall()
+
+    def return_insert_columns(self, fields):
+        if not fields:
+            return '', ()
+        columns = [
+            '%s.%s' % (
+                'INSERTED',
+                self.quote_name(field.column),
+            ) for field in fields
+        ]
+        return 'OUTPUT %s' % ', '.join(columns), ()
+
     def for_update_sql(self, nowait=False, skip_locked=False, of=()):
         if skip_locked:
             return 'WITH (ROWLOCK, UPDLOCK, READPAST)'


### PR DESCRIPTION
@jean-frenette-optel 

Don't really look at the diff visible in this PR, it's a bit ugly; it's much better to diff my proposed file against the microsoft file.
It makes it clear we're essentially just adding two "paragraphs":
- one paragraph to bulk-insert-with-returning-fields (similar to PostgreSQL except that our OUTPUT clause is before VALUES)
- and one paragraph for the workaround when there are returning fields but no fields (in which case, thanks SQL SERVER, we do not have any non-hack statement available to us to bulk insert full-default values)

I'll run tests on my side too.