### PR TITLE
Fix bug with sql_flush interpretation of argument reset_sequences

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -350,6 +350,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             return [
                 sequence
                 for sequence in self.connection.introspection.sequence_list()
+                if sequence['table'].lower() in [table.lower() for table in tables]
             ]
 
         return []


### PR DESCRIPTION
To give you a bit of context:

I stumbled on this bug while using `django_test_migrations`, which (at some point) basically drops all model tables, then does a `sql_flush` focused on `django_migrations` ("special" / last remaining table).
cf. https://github.com/wemake-services/django-test-migrations/blob/70f4c98812e776e9083d933e629cca328e7fa263/django_test_migrations/migrator.py#L47
So, there are no model tables anymore, only `django_migrations`, and we... somehow try to read data from other tables in order to get info about resetting sequences, so it fails.

Seems to me the problem is fairly obvious - in particular, compare:
https://github.com/microsoft/mssql-django/blob/d01c01e64274951d45489be65d96b76950ef0995/mssql/operations.py#L349-L353
with:
https://github.com/django/django/blob/795da6306a048b18c0158496b0d49e8e4f197a32/django/db/backends/oracle/operations.py#L493-L498
Hence the present fix, with my commit description:
**The `reset_sequences` argument in `sql_flush` must be understood as relative to the tables passed, not absolute**
