### PR TITLE
Add workaround for insert into table with trigger error

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,20 @@ Dictionary. Current available keys are:
   Default value is False which allows for the backend to
   return rows from bulk insert.
 
+  ```python
+  # Examples
+  "OPTIONS": {
+      # This database has triggers so set has_trigger to True
+      # to prevent errors related to returning rows from bulk insert
+      "has_trigger": True
+  }
+
+  "OPTIONS": {
+      # This database doesn't have any triggers so don't need to 
+      # add has_trigger since it is False by default
+  }
+  ```
+
 ### Backend-specific settings
 
 The following project-level settings also control the behavior of the backend:

--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ Dictionary. Current available keys are:
             },
     ```
 
+- has_trigger
+
+  Boolean. Sets if backend can return rows from bulk insert.
+  Default value is False which allows for the backend to
+  return rows from bulk insert.
+
 ### Backend-specific settings
 
 The following project-level settings also control the behavior of the backend:
@@ -252,7 +258,7 @@ The following features are currently not fully supported:
 - Bit-shift operators
 - Filtered index
 - Date extract function
-- Hashing functions
+- Bulk insert into a table with a trigger and returning the rows inserted
 
 JSONField lookups have limitations, more details [here](https://github.com/microsoft/mssql-django/wiki/JSONField).
 

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -421,6 +421,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         datefirst = options.get('datefirst', 7)
         cursor.execute('SET DATEFORMAT ymd; SET DATEFIRST %s' % datefirst)
 
+        # If there are triggers set can_return_rows_from_bulk_insert to
+        # False to prevent errors when inserting. See issue #130
+        if (options.get('has_trigger', False)):
+            self.features_class.can_return_rows_from_bulk_insert = False
+
         val = self.get_system_datetime()
         if isinstance(val, str):
             raise ImproperlyConfigured(

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -1,0 +1,29 @@
+import django.db.utils
+from django.db import connections
+from django.test import TransactionTestCase
+
+from ..models import Author
+
+class TestTableWithTrigger(TransactionTestCase):
+    def test_insert_into_table_with_trigger(self):
+        connection = connections['default']
+        # Change can_return_rows_from_bulk_insert since it is
+        # initially calculated before trigger get created by this test
+        connection.features_class.can_return_rows_from_bulk_insert = False
+
+        with connection.schema_editor() as cursor:
+            cursor.execute("""
+                CREATE TRIGGER TestTrigger
+                ON [testapp_author]
+                FOR INSERT
+                AS
+                INSERT INTO [testapp_editor]([name]) VALUES ('Bar')
+            """)
+
+        try:
+            Author.objects.create(name='Foo')
+        except django.db.utils.ProgrammingError as e:
+            self.fail('Check for regression of issue #130. Insert with trigger failed with exception: %s' % e)
+        finally:
+            with connection.schema_editor() as cursor:
+                cursor.execute("DROP TRIGGER TestTrigger")

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -7,8 +7,8 @@ from ..models import Author
 class TestTableWithTrigger(TransactionTestCase):
     def test_insert_into_table_with_trigger(self):
         connection = connections['default']
-        # Change can_return_rows_from_bulk_insert since it is
-        # initially calculated before trigger get created by this test
+        # Change can_return_rows_from_bulk_insert to be the same as when
+        # has_trigger = True
         connection.features_class.can_return_rows_from_bulk_insert = False
 
         with connection.schema_editor() as cursor:


### PR DESCRIPTION
Adds a workaround for issue #130 by adding a new key, value pair (`has_trigger`) into the `OPTIONS` dictionary that allows the user to prevent returning rows from bulk insert in scenarios that cause the error seen in that issue.
- When `has_trigger` = True returning rows from bulk insert is not available
- When `has_trigger` = False returning rows from bulk insert is available
- By default `has_trigger` is set to `False`