### PR TITLE
Fixed migration issues from adding timezone support

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -103,7 +103,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'BooleanField': 'bit',
         'CharField': 'nvarchar(%(max_length)s)',
         'DateField': 'date',
-        'DateTimeField': 'datetimeoffset',
+        'DateTimeField': 'datetime2',
         'DecimalField': 'numeric(%(max_digits)s, %(decimal_places)s)',
         'DurationField': 'bigint',
         'FileField': 'nvarchar(%(max_length)s)',
@@ -241,6 +241,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                 if sql.startswith('LIKE '):
                     ops[op] = '%s COLLATE %s' % (sql, collation)
             self.operators.update(ops)
+
+        if (settings.USE_TZ):
+            self.data_types['DateTimeField'] ='datetimeoffset'
 
     def create_cursor(self, name=None):
         return CursorWrapper(self.connection.cursor(), self)

--- a/mssql/introspection.py
+++ b/mssql/introspection.py
@@ -42,6 +42,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Database.SQL_TINYINT: 'SmallIntegerField',
         Database.SQL_TYPE_DATE: 'DateField',
         Database.SQL_TYPE_TIME: 'TimeField',
+        Database.SQL_TYPE_TIMESTAMP: 'DateTimeField',
         SQL_TIMESTAMP_WITH_TIMEZONE: 'DateTimeField',
         Database.SQL_VARBINARY: 'BinaryField',
         Database.SQL_VARCHAR: 'TextField',

--- a/testapp/tests/test_timezones.py
+++ b/testapp/tests/test_timezones.py
@@ -2,8 +2,9 @@
 # Licensed under the BSD license.
 
 import datetime
-
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from ..models import TimeZone
 
@@ -21,3 +22,86 @@ class TestDateTimeField(TestCase):
         }
         for k, v in days.items():
             self.assertSequenceEqual(TimeZone.objects.filter(date__iso_week_day=k), [v])
+
+class TestDateTimeToDateTimeOffsetMigration(TestCase):
+
+    def setUp(self):
+        # Want this to be a naive datetime so don't want
+        # to override settings before TimeZone creation
+        self.time = TimeZone.objects.create()
+
+    def tearDown(self):
+        TimeZone.objects.all().delete()
+
+    @override_settings(USE_TZ=True)
+    def test_datetime_to_datetimeoffset_utc(self):
+        dt = self.time.date
+
+        # Do manual migration from DATETIME2 to DATETIMEOFFSET
+        # and local time to UTC
+        with connection.schema_editor() as cursor:
+            cursor.execute("""
+                ALTER TABLE [testapp_timezone]
+                   ALTER COLUMN [date] DATETIMEOFFSET;
+
+                UPDATE [testapp_timezone]
+                   SET [date] = TODATETIMEOFFSET([date], 0) AT TIME ZONE 'UTC'
+            """)
+
+        dto = TimeZone.objects.get(id=self.time.id).date
+
+        try:
+            self.assertEquals(dt, dto.replace(tzinfo=None))
+        finally:
+            # Migrate back to DATETIME2 for other unit tests
+            with connection.schema_editor() as cursor:
+                cursor.execute("ALTER TABLE [testapp_timezone] ALTER column [date] datetime2")
+
+    @override_settings(USE_TZ=True, TIME_ZONE="Africa/Nairobi")
+    def test_datetime_to_datetimeoffset_local_timezone(self):
+        dt = self.time.date
+
+        # Do manual migration from DATETIME2 to DATETIMEOFFSET
+        # and local time to UTC
+        with connection.schema_editor() as cursor:
+            cursor.execute("""
+                ALTER TABLE [testapp_timezone]
+                   ALTER COLUMN [date] DATETIMEOFFSET;
+
+                UPDATE [testapp_timezone]
+                   SET [date] = TODATETIMEOFFSET([date], 180) AT TIME ZONE 'UTC'
+            """)
+
+        dto = TimeZone.objects.get(id=self.time.id).date
+
+        try:
+            # Africa/Nairobi (EAT) offset is +03:00
+            self.assertEquals(dt - datetime.timedelta(hours=3), dto.replace(tzinfo=None))
+        finally:
+            # Migrate back to DATETIME2 for other unit tests
+            with connection.schema_editor() as cursor:
+                cursor.execute("ALTER TABLE [testapp_timezone] ALTER column [date] datetime2")
+
+    @override_settings(USE_TZ=True, TIME_ZONE="Africa/Nairobi")
+    def test_datetime_to_datetimeoffset_other_timezone(self):
+        dt = self.time.date
+
+        # Do manual migration from DATETIME2 to DATETIMEOFFSET
+        # and local time to UTC
+        with connection.schema_editor() as cursor:
+            cursor.execute("""
+                ALTER TABLE [testapp_timezone]
+                   ALTER COLUMN [date] DATETIMEOFFSET;
+
+                UPDATE [testapp_timezone]
+                   SET [date] = TODATETIMEOFFSET([date], 420) AT TIME ZONE 'UTC'
+            """)
+
+        dto = TimeZone.objects.get(id=self.time.id).date
+
+        try:
+            self.assertEquals(dt - datetime.timedelta(hours=7), dto.replace(tzinfo=None))
+        finally:
+            # Migrate back to DATETIME2 for other unit tests
+            with connection.schema_editor() as cursor:
+                cursor.execute("ALTER TABLE [testapp_timezone] ALTER column [date] datetime2")

--- a/testapp/tests/test_timezones.py
+++ b/testapp/tests/test_timezones.py
@@ -51,7 +51,7 @@ class TestDateTimeToDateTimeOffsetMigration(TestCase):
         dto = TimeZone.objects.get(id=self.time.id).date
 
         try:
-            self.assertEquals(dt, dto.replace(tzinfo=None))
+            self.assertEqual(dt, dto.replace(tzinfo=None))
         finally:
             # Migrate back to DATETIME2 for other unit tests
             with connection.schema_editor() as cursor:
@@ -76,7 +76,7 @@ class TestDateTimeToDateTimeOffsetMigration(TestCase):
 
         try:
             # Africa/Nairobi (EAT) offset is +03:00
-            self.assertEquals(dt - datetime.timedelta(hours=3), dto.replace(tzinfo=None))
+            self.assertEqual(dt - datetime.timedelta(hours=3), dto.replace(tzinfo=None))
         finally:
             # Migrate back to DATETIME2 for other unit tests
             with connection.schema_editor() as cursor:
@@ -100,7 +100,7 @@ class TestDateTimeToDateTimeOffsetMigration(TestCase):
         dto = TimeZone.objects.get(id=self.time.id).date
 
         try:
-            self.assertEquals(dt - datetime.timedelta(hours=7), dto.replace(tzinfo=None))
+            self.assertEqual(dt - datetime.timedelta(hours=7), dto.replace(tzinfo=None))
         finally:
             # Migrate back to DATETIME2 for other unit tests
             with connection.schema_editor() as cursor:


### PR DESCRIPTION
- Changes `DateTimeField` back to `DATETIME2` by default. When `USE_TZ=True` then `DatetimeField` is `DATETIMEOFFSET`
- Added some unit test that tests migration process for projects wanting to set `USE_TZ=True`