### PR TITLE
Changed inserting into table with trigger to work by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,23 +204,24 @@ Dictionary. Current available keys are:
             },
     ```
 
-- has_trigger
+- return_rows_bulk_insert
 
   Boolean. Sets if backend can return rows from bulk insert.
-  Default value is False which allows for the backend to
-  return rows from bulk insert.
+  Default value is False which doesn't allows for the backend to
+  return rows from bulk insert. Must be set to False if database
+  has tables with triggers to prevent errors when inserting.
 
   ```python
   # Examples
   "OPTIONS": {
-      # This database has triggers so set has_trigger to True
-      # to prevent errors related to returning rows from bulk insert
-      "has_trigger": True
+      # This database doesn't have any triggers so can use return
+      # rows from bulk insert feature
+      "return_rows_bulk_insert": True
   }
 
   "OPTIONS": {
-      # This database doesn't have any triggers so don't need to 
-      # add has_trigger since it is False by default
+      # This database has triggers so leave return_rows_bulk_insert as blank (False)
+      # to prevent errors related to inserting and returning rows from bulk insert
   }
   ```
 

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -421,10 +421,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         datefirst = options.get('datefirst', 7)
         cursor.execute('SET DATEFORMAT ymd; SET DATEFIRST %s' % datefirst)
 
-        # If there are triggers set can_return_rows_from_bulk_insert to
-        # False to prevent errors when inserting. See issue #130
-        if (options.get('has_trigger', False)):
-            self.features_class.can_return_rows_from_bulk_insert = False
+        # Let user choose if driver can return rows from bulk insert since
+        # inserting into tables with triggers causes errors. See issue #130
+        if (options.get('return_rows_bulk_insert', False)):
+            self.features_class.can_return_rows_from_bulk_insert = True
 
         val = self.get_system_datetime()
         if isinstance(val, str):

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -12,7 +12,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_introspect_small_integer_field = True
     can_return_columns_from_insert = True
     can_return_id_from_insert = True
-    can_return_rows_from_bulk_insert = True
+    can_return_rows_from_bulk_insert = False
     can_rollback_ddl = True
     can_use_chunked_reads = False
     for_update_after_from = True


### PR DESCRIPTION
- Changes PR #158 so that by default the behaviour of inserting into a table with triggers is the same as in v1.1.2 of mssql-django without changing any settings.
- Introduces `return_rows_bulk_insert` into the `OPTIONS` dictionary and removes the `has_trigger` key, value pair. 
- When `return_rows_bulk_insert` = `True` returning rows from bulk insert is available
- When `return_rows_bulk_insert` = `False` returning rows from bulk insert is not available
- By default `return_rows_bulk_insert` is set to `False`
- `return_rows_bulk_insert` must be set to `False` to be able to insert into tables with triggers without an error being thrown