### PR TITLE
Fixed failing timezone unit test for Django 4.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,16 @@ jobs:
 
     strategy:
       matrix:
+        Python3.10 - Django 4.1:
+          python.version: '3.10'
+          tox.env: 'py310-django41'
+        Python 3.9 - Django 4.1:
+          python.version: '3.9'
+          tox.env: 'py39-django41'
+        Python 3.8 - Django 4.1:
+          python.version: '3.8'
+          tox.env: 'py38-django41'
+
         Python3.10 - Django 4.0:
           python.version: '3.10'
           tox.env: 'py310-django40'
@@ -101,6 +111,16 @@ jobs:
 
     strategy:
       matrix:
+        Python3.10 - Django 4.1:
+          python.version: '3.10'
+          tox.env: 'py310-django41'
+        Python 3.9 - Django 4.1:
+          python.version: '3.9'
+          tox.env: 'py39-django41'
+        Python 3.8 - Django 4.1:
+          python.version: '3.8'
+          tox.env: 'py38-django41'
+
         Python3.10 - Django 4.0:
           python.version: '3.10'
           tox.env: 'py310-django40'

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -15,6 +15,8 @@ from django.utils.encoding import force_str
 from django import VERSION as django_version
 import pytz
 
+DJANGO41 = django_version >= (4, 1)
+
 
 class DatabaseOperations(BaseDatabaseOperations):
     compiler_module = 'mssql.compiler'
@@ -31,6 +33,12 @@ class DatabaseOperations(BaseDatabaseOperations):
             offset = self._get_utcoffset(tzname)
             field_name = 'DATEADD(second, %d, %s)' % (offset, field_name)
         return field_name
+
+    def _convert_sql_to_tz(self, sql, params, tzname):
+        if tzname and settings.USE_TZ and self.connection.timezone_name != tzname:
+            offset = self._get_utcoffset(tzname)
+            sql = 'DATEADD(second, %d, %s)' % (offset, sql)
+        return sql, params
 
     def _get_utcoffset(self, tzname):
         """
@@ -125,17 +133,32 @@ class DatabaseOperations(BaseDatabaseOperations):
     def convert_booleanfield_value(self, value, expression, connection):
         return bool(value) if value in (0, 1) else value
 
-    def date_extract_sql(self, lookup_type, field_name):
-        if lookup_type == 'week_day':
-            return "DATEPART(weekday, %s)" % field_name
-        elif lookup_type == 'week':
-            return "DATEPART(iso_week, %s)" % field_name
-        elif lookup_type == 'iso_week_day':
-            return "DATEPART(weekday, DATEADD(day, -1, %s))" % field_name
-        elif lookup_type == 'iso_year':
-            return "YEAR(DATEADD(day, 26 - DATEPART(isoww, %s), %s))" % (field_name, field_name)
-        else:
-            return "DATEPART(%s, %s)" % (lookup_type, field_name)
+
+    if DJANGO41:
+        def date_extract_sql(self, lookup_type, sql, params):
+            if lookup_type == 'week_day':
+                sql = "DATEPART(weekday, %s)" % sql
+            elif lookup_type == 'week':
+                sql = "DATEPART(iso_week, %s)" % sql
+            elif lookup_type == 'iso_week_day':
+                sql = "DATEPART(weekday, DATEADD(day, -1, %s))" % sql
+            elif lookup_type == 'iso_year':
+                sql = "YEAR(DATEADD(day, 26 - DATEPART(isoww, %s), %s))" % (sql, sql)
+            else:
+                sql = "DATEPART(%s, %s)" % (lookup_type, sql)
+            return sql, params
+    else:
+        def date_extract_sql(self, lookup_type, field_name):
+            if lookup_type == 'week_day':
+                return "DATEPART(weekday, %s)" % field_name
+            elif lookup_type == 'week':
+                return "DATEPART(iso_week, %s)" % field_name
+            elif lookup_type == 'iso_week_day':
+                return "DATEPART(weekday, DATEADD(day, -1, %s))" % field_name
+            elif lookup_type == 'iso_year':
+                return "YEAR(DATEADD(day, 26 - DATEPART(isoww, %s), %s))" % (field_name, field_name)
+            else:
+                return "DATEPART(%s, %s)" % (lookup_type, field_name)
 
     def date_interval_sql(self, timedelta):
         """
@@ -147,50 +170,100 @@ class DatabaseOperations(BaseDatabaseOperations):
             sql = 'DATEADD(microsecond, %d%%s, CAST(%s AS datetime2))' % (timedelta.microseconds, sql)
         return sql
 
-    def date_trunc_sql(self, lookup_type, field_name, tzname=None):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        CONVERT_YEAR = 'CONVERT(varchar, DATEPART(year, %s))' % field_name
-        CONVERT_QUARTER = 'CONVERT(varchar, 1+((DATEPART(quarter, %s)-1)*3))' % field_name
-        CONVERT_MONTH = 'CONVERT(varchar, DATEPART(month, %s))' % field_name
-        CONVERT_WEEK = "DATEADD(DAY, (DATEPART(weekday, %s) + 5) %%%% 7 * -1, %s)" % (field_name, field_name)
+    if DJANGO41:
+        def date_trunc_sql(self, lookup_type, sql, params, tzname=None):
+            sql, params = self._convert_sql_to_tz(sql, params, tzname)
+            CONVERT_YEAR = 'CONVERT(varchar, DATEPART(year, %s))' % sql
+            CONVERT_QUARTER = 'CONVERT(varchar, 1+((DATEPART(quarter, %s)-1)*3))' % sql
+            CONVERT_MONTH = 'CONVERT(varchar, DATEPART(month, %s))' % sql
+            CONVERT_WEEK = "DATEADD(DAY, (DATEPART(weekday, %s) + 5) %%%% 7 * -1, %s)" % (sql, sql)
 
-        if lookup_type == 'year':
-            return "CONVERT(datetime2, %s + '/01/01')" % CONVERT_YEAR
-        if lookup_type == 'quarter':
-            return "CONVERT(datetime2, %s + '/' + %s + '/01')" % (CONVERT_YEAR, CONVERT_QUARTER)
-        if lookup_type == 'month':
-            return "CONVERT(datetime2, %s + '/' + %s + '/01')" % (CONVERT_YEAR, CONVERT_MONTH)
-        if lookup_type == 'week':
-            return "CONVERT(datetime2, CONVERT(varchar, %s, 112))" % CONVERT_WEEK
-        if lookup_type == 'day':
-            return "CONVERT(datetime2, CONVERT(varchar(12), %s, 112))" % field_name
+            if lookup_type == 'year':
+                sql = "CONVERT(datetime2, %s + '/01/01')" % CONVERT_YEAR
+            if lookup_type == 'quarter':
+                sql = "CONVERT(datetime2, %s + '/' + %s + '/01')" % (CONVERT_YEAR, CONVERT_QUARTER)
+            if lookup_type == 'month':
+                sql = "CONVERT(datetime2, %s + '/' + %s + '/01')" % (CONVERT_YEAR, CONVERT_MONTH)
+            if lookup_type == 'week':
+                sql = "CONVERT(datetime2, CONVERT(varchar, %s, 112))" % CONVERT_WEEK
+            if lookup_type == 'day':
+                sql = "CONVERT(datetime2, CONVERT(varchar(12), %s, 112))" % sql
+            return sql, params
+    else:
+        def date_trunc_sql(self, lookup_type, field_name, tzname=None):
+            field_name = self._convert_field_to_tz(field_name, tzname)
+            CONVERT_YEAR = 'CONVERT(varchar, DATEPART(year, %s))' % field_name
+            CONVERT_QUARTER = 'CONVERT(varchar, 1+((DATEPART(quarter, %s)-1)*3))' % field_name
+            CONVERT_MONTH = 'CONVERT(varchar, DATEPART(month, %s))' % field_name
+            CONVERT_WEEK = "DATEADD(DAY, (DATEPART(weekday, %s) + 5) %%%% 7 * -1, %s)" % (field_name, field_name)
 
-    def datetime_cast_date_sql(self, field_name, tzname):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        sql = 'CAST(%s AS date)' % field_name
-        return sql
+            if lookup_type == 'year':
+                return "CONVERT(datetime2, %s + '/01/01')" % CONVERT_YEAR
+            if lookup_type == 'quarter':
+                return "CONVERT(datetime2, %s + '/' + %s + '/01')" % (CONVERT_YEAR, CONVERT_QUARTER)
+            if lookup_type == 'month':
+                return "CONVERT(datetime2, %s + '/' + %s + '/01')" % (CONVERT_YEAR, CONVERT_MONTH)
+            if lookup_type == 'week':
+                return "CONVERT(datetime2, CONVERT(varchar, %s, 112))" % CONVERT_WEEK
+            if lookup_type == 'day':
+                return "CONVERT(datetime2, CONVERT(varchar(12), %s, 112))" % field_name
 
-    def datetime_cast_time_sql(self, field_name, tzname):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        sql = 'CAST(%s AS time)' % field_name
-        return sql
+    if DJANGO41:
+        def datetime_cast_date_sql(self, sql, params, tzname):
+            sql, params = self._convert_sql_to_tz(sql, params, tzname)
+            sql = 'CAST(%s AS date)' % sql
+            return sql, params
+    else:
+        def datetime_cast_date_sql(self, field_name, tzname):
+            field_name = self._convert_field_to_tz(field_name, tzname)
+            sql = 'CAST(%s AS date)' % field_name
+            return sql
 
-    def datetime_extract_sql(self, lookup_type, field_name, tzname):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        return self.date_extract_sql(lookup_type, field_name)
+    if DJANGO41:
+        def datetime_cast_time_sql(self, sql, params, tzname):
+            sql, params = self._convert_sql_to_tz(sql, params, tzname)
+            sql = 'CAST(%s AS time)' % sql
+            return sql, params
+    else:
+        def datetime_cast_time_sql(self, field_name, tzname):
+            field_name = self._convert_field_to_tz(field_name, tzname)
+            sql = 'CAST(%s AS time)' % field_name
+            return sql
 
-    def datetime_trunc_sql(self, lookup_type, field_name, tzname):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        sql = ''
-        if lookup_type in ('year', 'quarter', 'month', 'week', 'day'):
-            sql = self.date_trunc_sql(lookup_type, field_name)
-        elif lookup_type == 'hour':
-            sql = "CONVERT(datetime2, SUBSTRING(CONVERT(varchar, %s, 20), 0, 14) + ':00:00')" % field_name
-        elif lookup_type == 'minute':
-            sql = "CONVERT(datetime2, SUBSTRING(CONVERT(varchar, %s, 20), 0, 17) + ':00')" % field_name
-        elif lookup_type == 'second':
-            sql = "CONVERT(datetime2, CONVERT(varchar, %s, 20))" % field_name
-        return sql
+    if DJANGO41:
+        def datetime_extract_sql(self, lookup_type, sql, params, tzname):
+            sql, params = self._convert_sql_to_tz(sql, params, tzname)
+            return self.date_extract_sql(lookup_type, sql, params)
+    else:
+        def datetime_extract_sql(self, lookup_type, field_name, tzname):
+            field_name = self._convert_field_to_tz(field_name, tzname)
+            return self.date_extract_sql(lookup_type, field_name)
+
+    if DJANGO41:
+        def datetime_trunc_sql(self, lookup_type, sql, params, tzname):
+            sql, params = self._convert_sql_to_tz(sql, params, tzname)
+            if lookup_type in ('year', 'quarter', 'month', 'week', 'day'):
+                return self.date_trunc_sql(lookup_type, sql, params)
+            elif lookup_type == 'hour':
+                sql = "CONVERT(datetime2, SUBSTRING(CONVERT(varchar, %s, 20), 0, 14) + ':00:00')" % sql
+            elif lookup_type == 'minute':
+                sql = "CONVERT(datetime2, SUBSTRING(CONVERT(varchar, %s, 20), 0, 17) + ':00')" % sql
+            elif lookup_type == 'second':
+                sql = "CONVERT(datetime2, CONVERT(varchar, %s, 20))" % sql
+            return sql, params
+    else:
+        def datetime_trunc_sql(self, lookup_type, field_name, tzname):
+            field_name = self._convert_field_to_tz(field_name, tzname)
+            sql = ''
+            if lookup_type in ('year', 'quarter', 'month', 'week', 'day'):
+                sql = self.date_trunc_sql(lookup_type, field_name)
+            elif lookup_type == 'hour':
+                sql = "CONVERT(datetime2, SUBSTRING(CONVERT(varchar, %s, 20), 0, 14) + ':00:00')" % field_name
+            elif lookup_type == 'minute':
+                sql = "CONVERT(datetime2, SUBSTRING(CONVERT(varchar, %s, 20), 0, 17) + ':00')" % field_name
+            elif lookup_type == 'second':
+                sql = "CONVERT(datetime2, CONVERT(varchar, %s, 20))" % field_name
+            return sql
 
     def fetch_returned_insert_rows(self, cursor):
         """
@@ -494,7 +567,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                 # When support for time zones is enabled, Django stores datetime information
                 # in UTC in the database and uses time-zone-aware objects internally
                 # source: https://docs.djangoproject.com/en/dev/topics/i18n/timezones/#overview
-                value = value.astimezone(timezone.utc)
+                value = value.astimezone(datetime.timezone.utc)
             else:
                 # When USE_TZ is False, settings.TIME_ZONE is the time zone in
                 # which Django will store all datetimes
@@ -502,21 +575,38 @@ class DatabaseOperations(BaseDatabaseOperations):
                 value = timezone.make_naive(value, self.connection.timezone)
         return value
 
-    def time_trunc_sql(self, lookup_type, field_name, tzname=''):
-        # if self.connection.sql_server_version >= 2012:
-        #    fields = {
-        #        'hour': 'DATEPART(hour, %s)' % field_name,
-        #        'minute': 'DATEPART(minute, %s)' % field_name if lookup_type != 'hour' else '0',
-        #        'second': 'DATEPART(second, %s)' % field_name if lookup_type == 'second' else '0',
-        #    }
-        #    sql = 'TIMEFROMPARTS(%(hour)s, %(minute)s, %(second)s, 0, 0)' % fields
-        if lookup_type == 'hour':
-            sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 3) + ':00:00')" % field_name
-        elif lookup_type == 'minute':
-            sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 6) + ':00')" % field_name
-        elif lookup_type == 'second':
-            sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 9))" % field_name
-        return sql
+    if DJANGO41:
+        def time_trunc_sql(self, lookup_type, sql, params, tzname=None):
+            # if self.connection.sql_server_version >= 2012:
+            #    fields = {
+            #        'hour': 'DATEPART(hour, %s)' % field_name,
+            #        'minute': 'DATEPART(minute, %s)' % field_name if lookup_type != 'hour' else '0',
+            #        'second': 'DATEPART(second, %s)' % field_name if lookup_type == 'second' else '0',
+            #    }
+            #    sql = 'TIMEFROMPARTS(%(hour)s, %(minute)s, %(second)s, 0, 0)' % fields
+            if lookup_type == 'hour':
+                sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 3) + ':00:00')" % sql
+            elif lookup_type == 'minute':
+                sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 6) + ':00')" % sql
+            elif lookup_type == 'second':
+                sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 9))" % sql
+            return sql, params
+    else:
+        def time_trunc_sql(self, lookup_type, field_name, tzname=''):
+            # if self.connection.sql_server_version >= 2012:
+            #    fields = {
+            #        'hour': 'DATEPART(hour, %s)' % field_name,
+            #        'minute': 'DATEPART(minute, %s)' % field_name if lookup_type != 'hour' else '0',
+            #        'second': 'DATEPART(second, %s)' % field_name if lookup_type == 'second' else '0',
+            #    }
+            #    sql = 'TIMEFROMPARTS(%(hour)s, %(minute)s, %(second)s, 0, 0)' % fields
+            if lookup_type == 'hour':
+                sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 3) + ':00:00')" % field_name
+            elif lookup_type == 'minute':
+                sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 6) + ':00')" % field_name
+            elif lookup_type == 'second':
+                sql = "CONVERT(time, SUBSTRING(CONVERT(varchar, %s, 114), 0, 9))" % field_name
+            return sql
 
     def conditional_expression_supported_in_where_clause(self, expression):
         """

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.9',
     'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.0',
+    'Framework :: Django :: 4.1',
 ]
 
 this_directory = path.abspath(path.dirname(__file__))
@@ -38,7 +39,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     install_requires=[
-        'django>=2.2,<4.1',
+        'django>=2.2,<=4.1',
         'pyodbc>=3.0',
         'pytz',
     ],

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -280,6 +280,10 @@ EXCLUDED_TESTS = [
     'timezones.tests.NewDatabaseTests.test_cursor_execute_returns_naive_datetime',
     'timezones.tests.NewDatabaseTests.test_cursor_execute_accepts_aware_datetime',
     'timezones.tests.NewDatabaseTests.test_cursor_execute_returns_aware_datetime',
+
+    # Django 4.1
+    'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_lookup_name_sql_injection',
+    'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_lookup_name_sql_injection'
 ]
 
 REGEX_TESTS = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
        {py36,py37,py38,py39}-django32,
        {py38, py39, py310}-django40
+       {py38, py39, py310}-django41
 
 [testenv]
 allowlist_externals =
@@ -19,3 +20,4 @@ deps =
 
     django32: django==3.2.*
     django40: django>=4.0a1,<4.1
+    django41: django>=4.1*


### PR DESCRIPTION
Added Django 4.1 to pipeline and fixes the failing timezone test caused by upgrading to Django 4.1