### PR TITLE
Add xor bit shift support

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -100,6 +100,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         """
         if connector == '^':
             return 'POWER(%s)' % ','.join(sub_expressions)
+        elif connector == '#':
+            return '%s ^ %s' % tuple(sub_expressions)
         elif connector == '<<':
             return '%s * (2 * %s)' % tuple(sub_expressions)
         elif connector == '>>':

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -188,8 +188,6 @@ EXCLUDED_TESTS = [
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_func',
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_iso_weekday_func',
     'datetimes.tests.DateTimesTests.test_datetimes_ambiguous_and_invalid_times',
-    'expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor',
-    'expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor_null',
     'inspectdb.tests.InspectDBTestCase.test_number_field_types',
     'inspectdb.tests.InspectDBTestCase.test_json_field',
     'ordering.tests.OrderingTests.test_default_ordering_by_f_expression',


### PR DESCRIPTION
Django default operator for XOR is `#`. This PR converts it to SQL Server's `^` operator. 

Resolves the following Django tests: 
```
    'expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor',
    'expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor_null',
```