### PR TITLE
Right bit shift fix

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -2,6 +2,7 @@
 # Licensed under the BSD license.
 
 import datetime
+import math
 import uuid
 import warnings
 import sys
@@ -105,7 +106,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         elif connector == '<<':
             return '%s * (2 * %s)' % tuple(sub_expressions)
         elif connector == '>>':
-            return '%s / (2 * %s)' % tuple(sub_expressions)
+            return 'FLOOR(CONVERT(float, %s) / POWER(2, %s))' % tuple(sub_expressions)
         return super().combine_expression(connector, sub_expressions)
 
     def convert_datetimefield_value(self, value, expression, connection):

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -2,7 +2,6 @@
 # Licensed under the BSD license.
 
 import datetime
-import math
 import uuid
 import warnings
 import sys
@@ -106,7 +105,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         elif connector == '<<':
             return '%s * (2 * %s)' % tuple(sub_expressions)
         elif connector == '>>':
-            return 'FLOOR(CONVERT(float, %s) / POWER(2, %s))' % tuple(sub_expressions)
+            return 'FLOOR(CONVERT(float, %s) / (2 * %s))' % tuple(sub_expressions)
         return super().combine_expression(connector, sub_expressions)
 
     def convert_datetimefield_value(self, value, expression, connection):

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -142,7 +142,6 @@ EXCLUDED_TESTS = [
     'db_functions.math.test_radians.RadiansTests.test_integer',
     'db_functions.text.test_pad.PadTests.test_pad',
     'db_functions.text.test_replace.ReplaceTests.test_case_sensitive',
-    'expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_right_shift_operator',
     'expressions.tests.FTimeDeltaTests.test_invalid_operator',
     'fixtures_regress.tests.TestFixtures.test_loaddata_raises_error_when_fixture_has_invalid_foreign_key',
     'invalid_models_tests.test_ordinary_fields.TextFieldTests.test_max_length_warning',


### PR DESCRIPTION
This PR fixes bitwise right shift operator.

Resolves the following Django test:
```
'expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_right_shift_operator',
```