### PR TITLE
Fixes BasicExpressionTests startswith_lookup()

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -17,6 +17,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_use_chunked_reads = False
     for_update_after_from = True
     greatest_least_ignores_nulls = True
+    has_case_insensitive_like = True
     has_json_object_function = False
     has_json_operators = False
     has_native_json_field = False


### PR DESCRIPTION
This PR sets has_case_insensitive_like to True, and fixes the following test:
```
expressions.tests.BasicExpressionsTests.test_ticket_16731_startswith_lookup
```