### PR TITLE
Add check to see if `FROM` clause exists

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -281,7 +281,9 @@ class SQLCompiler(compiler.SQLCompiler):
                 if for_update_part and self.connection.features.for_update_after_from:
                     from_.insert(1, for_update_part)
 
-                result += [', '.join(out_cols), 'FROM', *from_]
+                result += [', '.join(out_cols)]
+                if from_:
+                    result += ['FROM', *from_]
                 params.extend(f_params)
 
                 if where:


### PR DESCRIPTION
Our driver was not trimming the `FROM` from the SQL when there is no `FROM clause. 

Fixes the following tests:
```
queries.test_query.TestQueryNoModel.test_rawsql_annotation
queries.test_query.TestQueryNoModel.test_subquery_annotation 
```