### PR TITLE
Add introspected field type for DurationField

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -65,3 +65,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def supports_json_field(self):
         return self.connection.sql_server_version >= 2016 or self.connection.to_azure_sql_db
+
+    @cached_property
+    def introspected_field_types(self):
+        return {
+            **super().introspected_field_types,
+            "DurationField": "BigIntegerField",
+        }


### PR DESCRIPTION
Add introspected field type for DurationField.

Fixes the following Django test:
```
schema.tests.SchemaTests.test_add_field_durationfield_with_default
```