### PR TITLE
Add support for Django 4.1.x updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     install_requires=[
-        'django>=2.2,<=4.1',
+        'django>=2.2,<4.2',
         'pyodbc>=3.0',
         'pytz',
     ],


### PR DESCRIPTION
Was previously restricted to versions 4.1 and below. This allows for 4.1.x updates to be used as a requirement.