### PR TITLE
Make MSSQL introspection raise DatabaseError on nonexistent tables

### DIFF
--- a/mssql/introspection.py
+++ b/mssql/introspection.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the BSD license.
 
+from django.db import DatabaseError
 import pyodbc as Database
 
 from django import VERSION
@@ -108,6 +109,9 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # map pyodbc's cursor.columns to db-api cursor description
         columns = [[c[3], c[4], None, c[6], c[6], c[8], c[10], c[12]] for c in cursor.columns(table=table_name)]
 
+        if not columns:
+            raise DatabaseError("Table does not exist (empty pragma)")
+            
         items = []
         for column in columns:
             if VERSION >= (3, 2):


### PR DESCRIPTION
This PR makes MSSQL introspection raise DatabaseError on nonexistent tables.

Fixes the following Django tests:
```
schema.tests.SchemaTests.test_m2m,
schema.tests.SchemaTests.test_m2m_create,
schema.tests.SchemaTests.test_m2m_custom,
schema.tests.SchemaTests.test_m2m_db_constraint,
schema.tests.SchemaTests.test_m2m_db_constraint_custom,
schema.tests.SchemaTests.test_m2m_db_constraint_inherited,
schema.tests.SchemaTests.test_m2m_inherited,
schema.tests.SchemaTests.test_m2m_repoint,
schema.tests.SchemaTests.test_m2m_repoint_custom,
schema.tests.SchemaTests.test_m2m_repoint_inherited
```