### PR TITLE
Add skipped tests to Django 4.1

### DIFF
--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -814,6 +814,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             model._meta.db_table, columns, unique=True, unique_constraint=False, primary_key=False,
             **constraint_names_kwargs)
         constraint_names = constraint_names_normal + constraint_names_index
+        if constraint_names and self.connection.features.allows_multiple_constraints_on_same_fields:
+            # Constraint matching the unique_together name.
+            default_name = str(
+                self._unique_constraint_name(model._meta.db_table, columns, quote=False)
+            )
+            if default_name in constraint_names:
+                constraint_names = [default_name]
         if strict and len(constraint_names) != 1:
             raise ValueError("Found wrong number (%s) of unique constraints for columns %s" % (
                 len(constraint_names),

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -814,13 +814,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             model._meta.db_table, columns, unique=True, unique_constraint=False, primary_key=False,
             **constraint_names_kwargs)
         constraint_names = constraint_names_normal + constraint_names_index
-        if constraint_names and self.connection.features.allows_multiple_constraints_on_same_fields:
-            # Constraint matching the unique_together name.
-            default_name = str(
-                self._unique_constraint_name(model._meta.db_table, columns, quote=False)
-            )
-            if default_name in constraint_names:
-                constraint_names = [default_name]
         if strict and len(constraint_names) != 1:
             raise ValueError("Found wrong number (%s) of unique constraints for columns %s" % (
                 len(constraint_names),

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -289,6 +289,9 @@ EXCLUDED_TESTS = [
     'queries.test_q.QCheckTests.test_expression',
     'constraints.tests.CheckConstraintTests.test_validate',
     'constraints.tests.CheckConstraintTests.test_validate_boolean_expressions',
+    'constraints.tests.UniqueConstraintTests.test_model_validation_with_condition',
+    'constraints.tests.UniqueConstraintTests.test_validate_condition',
+    'constraints.tests.UniqueConstraintTests.test_validate_expression_condition',
 ]
 
 REGEX_TESTS = [

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -284,9 +284,11 @@ EXCLUDED_TESTS = [
     'schema.tests.SchemaTests.test_autofield_to_o2o',
     'schema.tests.SchemaTests.test_add_auto_field',
     'prefetch_related.tests.PrefetchRelatedTests.test_m2m_prefetching_iterator_with_chunks',
-     'queries.test_q.QCheckTests.test_basic',
-     'queries.test_q.QCheckTests.test_boolean_expression',
-     'queries.test_q.QCheckTests.test_expression'
+    'queries.test_q.QCheckTests.test_basic',
+    'queries.test_q.QCheckTests.test_boolean_expression',
+    'queries.test_q.QCheckTests.test_expression',
+    'constraints.tests.CheckConstraintTests.test_validate',
+    'constraints.tests.CheckConstraintTests.test_validate_boolean_expressions',
 ]
 
 REGEX_TESTS = [

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -282,6 +282,7 @@ EXCLUDED_TESTS = [
     'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_lookup_name_sql_injection',
     'schema.tests.SchemaTests.test_autofield_to_o2o',
     'schema.tests.SchemaTests.test_add_auto_field',
+    'prefetch_related.tests.PrefetchRelatedTests.test_m2m_prefetching_iterator_with_chunks',
 ]
 
 REGEX_TESTS = [

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -289,6 +289,7 @@ EXCLUDED_TESTS = [
     'constraints.tests.UniqueConstraintTests.test_validate_condition',
     'constraints.tests.UniqueConstraintTests.test_validate_expression_condition',
     'migrations.test_operations.OperationTests.test_create_model_with_boolean_expression_in_check_constraint',
+    'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_in_subquery_related_outerref'
     # These tests pass on SQL Server 2022 or newer
     'model_fields.test_jsonfield.TestQuerying.test_has_key_list',
     'model_fields.test_jsonfield.TestQuerying.test_has_key_null_value',

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -292,6 +292,7 @@ EXCLUDED_TESTS = [
     'constraints.tests.UniqueConstraintTests.test_model_validation_with_condition',
     'constraints.tests.UniqueConstraintTests.test_validate_condition',
     'constraints.tests.UniqueConstraintTests.test_validate_expression_condition',
+    'migrations.test_operations.OperationTests.test_create_model_with_boolean_expression_in_check_constraint',
 ]
 
 REGEX_TESTS = [

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -276,8 +276,12 @@ EXCLUDED_TESTS = [
     'timezones.tests.NewDatabaseTests.test_cursor_execute_returns_aware_datetime',
 
     # Django 4.1
+    'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_aggregate_on_exists',
+    'annotations.tests.NonAggregateAnnotationTestCase.test_full_expression_annotation_with_aggregation',
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_lookup_name_sql_injection',
-    'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_lookup_name_sql_injection'
+    'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_lookup_name_sql_injection',
+    'schema.tests.SchemaTests.test_autofield_to_o2o',
+    'schema.tests.SchemaTests.test_add_auto_field',
 ]
 
 REGEX_TESTS = [

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -289,7 +289,7 @@ EXCLUDED_TESTS = [
     'constraints.tests.UniqueConstraintTests.test_validate_condition',
     'constraints.tests.UniqueConstraintTests.test_validate_expression_condition',
     'migrations.test_operations.OperationTests.test_create_model_with_boolean_expression_in_check_constraint',
-    'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_in_subquery_related_outerref'
+    'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_in_subquery_related_outerref',
     # These tests pass on SQL Server 2022 or newer
     'model_fields.test_jsonfield.TestQuerying.test_has_key_list',
     'model_fields.test_jsonfield.TestQuerying.test_has_key_null_value',

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -284,6 +284,9 @@ EXCLUDED_TESTS = [
     'schema.tests.SchemaTests.test_autofield_to_o2o',
     'schema.tests.SchemaTests.test_add_auto_field',
     'prefetch_related.tests.PrefetchRelatedTests.test_m2m_prefetching_iterator_with_chunks',
+     'queries.test_q.QCheckTests.test_basic',
+     'queries.test_q.QCheckTests.test_boolean_expression',
+     'queries.test_q.QCheckTests.test_expression'
 ]
 
 REGEX_TESTS = [

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -277,6 +277,7 @@ EXCLUDED_TESTS = [
 
     # Django 4.1
     'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_aggregate_on_exists',
+    'aggregation.tests.AggregateTestCase.test_aggregation_exists_multivalued_outeref',
     'annotations.tests.NonAggregateAnnotationTestCase.test_full_expression_annotation_with_aggregation',
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_lookup_name_sql_injection',
     'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_lookup_name_sql_injection',


### PR DESCRIPTION
This PR adds the following skipped tests to settings.py, mainly due to database limitation:
```
'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_aggregate_on_exists',
'aggregation.tests.AggregateTestCase.test_aggregation_exists_multivalued_outeref',

'annotations.tests.NonAggregateAnnotationTestCase.test_full_expression_annotation_with_aggregation',

'constraints.tests.CheckConstraintTests.test_validate',
'constraints.tests.CheckConstraintTests.test_validate_boolean_expressions',

'constraints.tests.UniqueConstraintTests.test_model_validation_with_condition',
'constraints.tests.UniqueConstraintTests.test_validate_condition',
'constraints.tests.UniqueConstraintTests.test_validate_expression_condition',

'prefetch_related.tests.PrefetchRelatedTests.test_m2m_prefetching_iterator_with_chunks',

'queries.test_q.QCheckTests.test_basic',
'queries.test_q.QCheckTests.test_boolean_expression',
'queries.test_q.QCheckTests.test_expression',

'schema.tests.SchemaTests.test_autofield_to_o2o',
'schema.tests.SchemaTests.test_add_auto_field',

'migrations.test_operations.OperationTests.test_create_model_with_boolean_expression_in_check_constraint',

'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_in_subquery_related_outerref',
```
