### PR TITLE
fix jsonfield test in sql server 2022 and newer

### DIFF
--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -204,7 +204,7 @@ def json_HasKeyLookup(self, compiler, connection):
     else:
         lhs, _ = self.process_lhs(compiler, connection)
         lhs_json_path = '$'
-    if connection.sql_server_version == 2022:
+    if connection.sql_server_version >= 2022:
         sql = "JSON_PATH_EXISTS(%s, '%%s') > 0" % lhs
     else:
         sql = lhs + ' IN (SELECT ' + lhs + ' FROM ' + self.lhs.output_field.model._meta.db_table + \

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -204,8 +204,11 @@ def json_HasKeyLookup(self, compiler, connection):
     else:
         lhs, _ = self.process_lhs(compiler, connection)
         lhs_json_path = '$'
-    sql = lhs + ' IN (SELECT ' + lhs + ' FROM ' + self.lhs.output_field.model._meta.db_table + \
-    ' CROSS APPLY OPENJSON(' + lhs + ') WITH ( [json_path_value] char(1) \'%s\') WHERE [json_path_value] IS NOT NULL)'
+    if connection.sql_server_version == 2022:
+        sql = "JSON_PATH_EXISTS(%s, '%%s') > 0" % lhs
+    else:
+        sql = lhs + ' IN (SELECT ' + lhs + ' FROM ' + self.lhs.output_field.model._meta.db_table + \
+        ' CROSS APPLY OPENJSON(' + lhs + ') WITH ( [json_path_value] char(1) \'%s\') WHERE [json_path_value] IS NOT NULL)'
     # Process JSON path from the right-hand side.
     rhs = self.rhs
     rhs_params = []

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -196,11 +196,7 @@ EXCLUDED_TESTS = [
     'datetimes.tests.DateTimesTests.test_21432',
 
     # JSONFields
-    'model_fields.test_jsonfield.TestQuerying.test_has_key_list',
-    'model_fields.test_jsonfield.TestQuerying.test_has_key_null_value',
     'model_fields.test_jsonfield.TestQuerying.test_key_quoted_string',
-    'model_fields.test_jsonfield.TestQuerying.test_lookups_with_key_transform',
-    'model_fields.test_jsonfield.TestQuerying.test_ordering_grouping_by_count',
     'model_fields.test_jsonfield.TestQuerying.test_isnull_key',
     'model_fields.test_jsonfield.TestQuerying.test_none_key',
     'model_fields.test_jsonfield.TestQuerying.test_none_key_and_exact_lookup',
@@ -277,7 +273,15 @@ EXCLUDED_TESTS = [
 
     # Django 4.1
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_lookup_name_sql_injection',
-    'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_lookup_name_sql_injection'
+    'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_lookup_name_sql_injection',
+
+    # These tests pass on SQL Server 2022 or newer
+    'model_fields.test_jsonfield.TestQuerying.test_has_key_list',
+    'model_fields.test_jsonfield.TestQuerying.test_has_key_null_value',
+    'model_fields.test_jsonfield.TestQuerying.test_lookups_with_key_transform',
+    'model_fields.test_jsonfield.TestQuerying.test_ordering_grouping_by_count',
+    'model_fields.test_jsonfield.TestQuerying.test_has_key_number',
+
 ]
 
 REGEX_TESTS = [


### PR DESCRIPTION
The fix uses `JSON_PATH_EXISTS` which was introduced in SQL Server 2022.

This fixes the following test from the Django 4.1 list:
```
'model_fields.test_jsonfield.TestQuerying.test_has_key_number',
```

Also fixes the following tests:
```
'model_fields.test_jsonfield.TestQuerying.test_has_key_list',
'model_fields.test_jsonfield.TestQuerying.test_has_key_null_value',
'model_fields.test_jsonfield.TestQuerying.test_lookups_with_key_transform',
'model_fields.test_jsonfield.TestQuerying.test_ordering_grouping_by_count',
```