### PR TITLE
Fix removing unique_together constraint if exists primary key/unique constraint on the same field.

### DIFF
--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -814,6 +814,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             model._meta.db_table, columns, unique=True, unique_constraint=False, primary_key=False,
             **constraint_names_kwargs)
         constraint_names = constraint_names_normal + constraint_names_index
+        if constraint_names and self.connection.features.allows_multiple_constraints_on_same_fields:
+            # Constraint matching the unique_together name.
+            default_name = str(
+                self._unique_constraint_name(model._meta.db_table, columns, quote=False)
+            )
+            if default_name in constraint_names:
+                constraint_names = [default_name]
         if strict and len(constraint_names) != 1:
             raise ValueError("Found wrong number (%s) of unique constraints for columns %s" % (
                 len(constraint_names),

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -814,13 +814,14 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             model._meta.db_table, columns, unique=True, unique_constraint=False, primary_key=False,
             **constraint_names_kwargs)
         constraint_names = constraint_names_normal + constraint_names_index
-        if constraint_names and self.connection.features.allows_multiple_constraints_on_same_fields:
-            # Constraint matching the unique_together name.
-            default_name = str(
-                self._unique_constraint_name(model._meta.db_table, columns, quote=False)
-            )
-            if default_name in constraint_names:
-                constraint_names = [default_name]
+        if django_version >= (4, 1):
+            if constraint_names and self.connection.features.allows_multiple_constraints_on_same_fields:
+                # Constraint matching the unique_together name.
+                default_name = str(
+                    self._unique_constraint_name(model._meta.db_table, columns, quote=False)
+                )
+                if default_name in constraint_names:
+                    constraint_names = [default_name]
         if strict and len(constraint_names) != 1:
             raise ValueError("Found wrong number (%s) of unique constraints for columns %s" % (
                 len(constraint_names),


### PR DESCRIPTION
This PR fixes removing unique_together constraint if primary key or unique constraint exists on the same field.

Fixes the following Django 4.1 tests:
```
migrations.test_operations.OperationTests.test_remove_unique_together_on_unique_field,
migrations.test_operations.OperationTests.test_remove_unique_together_on_pk_field
```