### PR TITLE
Changed getting system datetime to cached_property

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -11,6 +11,7 @@ import struct
 import datetime
 
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.functional import cached_property
 
 try:
     import pyodbc as Database
@@ -430,7 +431,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         if (options.get('return_rows_bulk_insert', False)):
             self.features_class.can_return_rows_from_bulk_insert = True
 
-        val = self.get_system_datetime()
+        val = self.get_system_datetime
         if isinstance(val, str):
             raise ImproperlyConfigured(
                 "The database driver doesn't support modern datatime types.")
@@ -443,6 +444,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         else:
             return True
 
+    @cached_property
     def get_system_datetime(self):
         # http://blogs.msdn.com/b/sqlnativeclient/archive/2008/02/27/microsoft-sql-server-native-client-and-microsoft-sql-server-2008-native-client.aspx
         with self.temporary_connection() as cursor:


### PR DESCRIPTION
A potential fix for issue #196. Currently there is a `SELECT SYSDATETIME()` query that is getting executed for every query. This is being used to check if `"The database driver doesn't support modern datetime types."`.

I've updated `self.get_system_datetime` to  be a Django `@cached_property` that will reduce the number of times this query is called. This method is already used with similar methods like `sql_server_version` and `to_azure_sql_db`. Also fixed a minor typo in the error message.

<img width="746" alt="image" src="https://user-images.githubusercontent.com/5122866/209582843-72ff2920-4486-4588-8fa8-18952b415116.png">


