### PR TITLE
Fix an issue of adding OFFSET keyword for legacy SQL Server versions

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -364,7 +364,7 @@ class SQLCompiler(compiler.SQLCompiler):
                 # Django 2.x.  See https://github.com/microsoft/mssql-django/issues/12
                 # Add OFFSET for all Django versions.
                 # https://github.com/microsoft/mssql-django/issues/109
-                if not (do_offset or do_limit):
+                if not (do_offset or do_limit) and supports_offset_clause:
                     result.append("OFFSET 0 ROWS")
 
             # SQL Server requires the backend-specific emulation (2008 or earlier)


### PR DESCRIPTION
I was getting the following exception when trying to access legacy SQL Server 2008 R2 database: pyodbc.ProgrammingError: 

('42000', "[42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Incorrect syntax near 'OFFSET'. (102) (SQLExecDirectW)")

I only added one more condition before adding the OFFSET keyword.