### PR TITLE
Allow `bash` with allowlist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
 
 [testenv]
 allowlist_externals =
+    bash
     /bin/bash
     /usr/bin/bash
     C:\Program Files\Git\bin\bash.EXE

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,6 @@ envlist =
 [testenv]
 allowlist_externals =
     bash
-    /bin/bash
-    /usr/bin/bash
-    C:\Program Files\Git\bin\bash.EXE
 
 commands =
     python manage.py test --noinput


### PR DESCRIPTION
This PR adds `bash` to the allowlist_externals, which works for tox 4.0.0 and above. 