### PR TITLE
Add case-sensitive feature for Replace function

### DIFF
--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -48,15 +48,13 @@ def sqlserver_ln(self, compiler, connection, **extra_context):
 
 def sqlserver_replace(self, compiler, connection, **extra_context):
     current_db = "CONVERT(varchar, (SELECT DB_NAME()))"
-    default_collation = "CONVERT (varchar, DATABASEPROPERTYEX(%s, 'collation'))" % current_db
-
     with connection.cursor() as cursor:
-        cursor.execute("SELECT REPLACE(%s, 'CI', 'CS')" % default_collation)
-        case_sensitive = cursor.fetchone()[0]
-
+        cursor.execute("SELECT CONVERT(varchar, DATABASEPROPERTYEX(%s, 'collation'))" % current_db)
+        default_collation = cursor.fetchone()[0]
+    current_collation = default_collation.replace('_CI', '_CS')
     return self.as_sql(
             compiler, connection, function='REPLACE',
-            template = 'REPLACE(%s COLLATE %s)' % ('%(expressions)s', case_sensitive),
+            template = 'REPLACE(%s COLLATE %s)' % ('%(expressions)s', current_collation),
             **extra_context
         )
 

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -138,7 +138,6 @@ EXCLUDED_TESTS = [
     'aggregation.tests.AggregateTestCase.test_count_star',
     'aggregation_regress.tests.AggregationTests.test_values_list_annotation_args_ordering',
     'db_functions.text.test_pad.PadTests.test_pad',
-    'db_functions.text.test_replace.ReplaceTests.test_case_sensitive',
     'expressions.tests.FTimeDeltaTests.test_invalid_operator',
     'fixtures_regress.tests.TestFixtures.test_loaddata_raises_error_when_fixture_has_invalid_foreign_key',
     'invalid_models_tests.test_ordinary_fields.TextFieldTests.test_max_length_warning',


### PR DESCRIPTION
This PR adds case-sensitive feature for the Replace function.

Resolves the following Django test:
```
'db_functions.text.test_replace.ReplaceTests.test_case_sensitive'
```