### PR TITLE
Fix left padding function to return strings with correct length

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -76,8 +76,9 @@ def _as_sql_lpad(self, compiler, connection):
     params.extend(length_arg)
     params.extend(expression_arg)
     params.extend(expression_arg)
-    template = ('LEFT(REPLICATE(%(fill_text)s, %(length)s), CASE WHEN %(length)s > LEN(%(expression)s) '
-                'THEN %(length)s - LEN(%(expression)s) ELSE 0 END) + %(expression)s')
+    params.extend(length_arg)
+    template = ('LEFT(LEFT(REPLICATE(%(fill_text)s, %(length)s), CASE WHEN %(length)s > LEN(%(expression)s) '
+                'THEN %(length)s - LEN(%(expression)s) ELSE 0 END) + %(expression)s, %(length)s)')
     return template % {'expression': expression, 'length': length, 'fill_text': fill_text}, params
 
 

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -137,7 +137,6 @@ EXCLUDED_TESTS = [
     'schema.tests.SchemaTests.test_unique_together_with_fk_with_existing_index',
     'aggregation.tests.AggregateTestCase.test_count_star',
     'aggregation_regress.tests.AggregationTests.test_values_list_annotation_args_ordering',
-    'db_functions.text.test_pad.PadTests.test_pad',
     'expressions.tests.FTimeDeltaTests.test_invalid_operator',
     'fixtures_regress.tests.TestFixtures.test_loaddata_raises_error_when_fixture_has_invalid_foreign_key',
     'invalid_models_tests.test_ordinary_fields.TextFieldTests.test_max_length_warning',


### PR DESCRIPTION
This PR fixes left padding to return strings with correct length, mostly in the case when new length is smaller than original length.

Resolves the following Django test:
```
'db_functions.text.test_pad.PadTests.test_pad'
```