### PR TITLE
Fix last_executed_query() to properly replace placeholders with params

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -418,7 +418,13 @@ class DatabaseOperations(BaseDatabaseOperations):
         exists for database backends to provide a better implementation
         according to their own quoting schemes.
         """
-        return super().last_executed_query(cursor, cursor.last_sql, cursor.last_params)
+        if params:
+            if isinstance(params, list):
+                params = tuple(params)
+            return sql % params
+        # Just return sql when there are no parameters.
+        else:
+            return sql
 
     def savepoint_create_sql(self, sid):
         """

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -152,7 +152,6 @@ EXCLUDED_TESTS = [
     'schema.tests.SchemaTests.test_unique_and_reverse_m2m',
     'schema.tests.SchemaTests.test_unique_no_unnecessary_fk_drops',
     'select_for_update.tests.SelectForUpdateTests.test_for_update_after_from',
-    'backends.tests.LastExecutedQueryTest.test_last_executed_query',
     'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_year_exact_lookup',
     'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_year_greaterthan_lookup',
     'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_year_lessthan_lookup',


### PR DESCRIPTION
This PR fixes the last_executed_query() function to properly replace placeholders with params.

Fixes the following Django 4.2 test:
```
`backends.tests.LastExecutedQueryTest.test_last_executed_query_with_duplicate_params`
```

Also resolves the following Django test:
```
`backends.tests.LastExecutedQueryTest.test_last_executed_query`
```