### PR TITLE
Fix limit_offset_sql to handle cases when there is no OFFSET

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -404,7 +404,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         """Return LIMIT/OFFSET SQL clause."""
         limit, offset = self._get_limit_offset_params(low_mark, high_mark)
         return '%s%s' % (
-            (' OFFSET %d ROWS' % offset) if offset else '',
+            (' OFFSET %d ROWS' % offset) if offset else ' OFFSET 0 ROWS',
             (' FETCH FIRST %d ROWS ONLY' % limit) if limit else '',
         )
 


### PR DESCRIPTION
This PR fixes limit_offset_sql() function to return the correct query when there is no OFFSET.

Resolves #224 