### PR TITLE
disable allows_group_by_select_index

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -6,6 +6,7 @@ from django.utils.functional import cached_property
 
 
 class DatabaseFeatures(BaseDatabaseFeatures):
+    allows_group_by_select_index = False
     allow_sliced_subqueries_with_in = False
     can_introspect_autofield = True
     can_introspect_json_field = False

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -99,11 +99,8 @@ USE_TZ = False
 
 TEST_RUNNER = "testapp.runners.ExcludedTestSuiteRunner"
 EXCLUDED_TESTS = [
-    'aggregation.tests.AggregateTestCase.test_expression_on_aggregation',
-    'aggregation_regress.tests.AggregationTests.test_annotated_conditional_aggregate',
     'aggregation_regress.tests.AggregationTests.test_annotation_with_value',
     'aggregation.tests.AggregateTestCase.test_distinct_on_aggregate',
-    'annotations.tests.NonAggregateAnnotationTestCase.test_annotate_exists',
     'custom_lookups.tests.BilateralTransformTests.test_transform_order_by',
     'expressions.tests.BasicExpressionsTests.test_filtering_on_annotate_that_uses_q',
     'expressions.tests.BasicExpressionsTests.test_order_by_exists',
@@ -165,17 +162,13 @@ EXCLUDED_TESTS = [
     'backends.tests.BackendTestCase.test_queries',
     'introspection.tests.IntrospectionTests.test_smallautofield',
     'schema.tests.SchemaTests.test_inline_fk',
-    'aggregation.tests.AggregateTestCase.test_aggregation_subquery_annotation_exists',
-    'aggregation.tests.AggregateTestCase.test_aggregation_subquery_annotation_values_collision',
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_func_with_timezone',
     'expressions.tests.FTimeDeltaTests.test_date_subquery_subtraction',
     'expressions.tests.FTimeDeltaTests.test_datetime_subquery_subtraction',
     'expressions.tests.FTimeDeltaTests.test_time_subquery_subtraction',
     'migrations.test_operations.OperationTests.test_alter_field_reloads_state_on_fk_with_to_field_target_type_change',
     'schema.tests.SchemaTests.test_alter_smallint_pk_to_smallautofield_pk',
-    
     'annotations.tests.NonAggregateAnnotationTestCase.test_combined_expression_annotation_with_aggregation',
-    'db_functions.comparison.test_cast.CastTests.test_cast_to_integer',
     'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_func',
     'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_iso_weekday_func',
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_func',
@@ -271,7 +264,6 @@ EXCLUDED_TESTS = [
     # Django 4.1
     'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_aggregate_on_exists',
     'aggregation.tests.AggregateTestCase.test_aggregation_exists_multivalued_outeref',
-    'annotations.tests.NonAggregateAnnotationTestCase.test_full_expression_annotation_with_aggregation',
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_lookup_name_sql_injection',
     'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_lookup_name_sql_injection',
     'schema.tests.SchemaTests.test_autofield_to_o2o',

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -267,6 +267,7 @@ EXCLUDED_TESTS = [
     # Django 4.1
     'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_aggregate_on_exists',
     'aggregation.tests.AggregateTestCase.test_aggregation_exists_multivalued_outeref',
+    'annotations.tests.NonAggregateAnnotationTestCase.test_full_expression_annotation_with_aggregation',
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_lookup_name_sql_injection',
     'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_lookup_name_sql_injection',
     'schema.tests.SchemaTests.test_autofield_to_o2o',

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -101,6 +101,7 @@ TEST_RUNNER = "testapp.runners.ExcludedTestSuiteRunner"
 EXCLUDED_TESTS = [
     'aggregation_regress.tests.AggregationTests.test_annotation_with_value',
     'aggregation.tests.AggregateTestCase.test_distinct_on_aggregate',
+    'annotations.tests.NonAggregateAnnotationTestCase.test_annotate_exists',
     'custom_lookups.tests.BilateralTransformTests.test_transform_order_by',
     'expressions.tests.BasicExpressionsTests.test_filtering_on_annotate_that_uses_q',
     'expressions.tests.BasicExpressionsTests.test_order_by_exists',
@@ -162,6 +163,8 @@ EXCLUDED_TESTS = [
     'backends.tests.BackendTestCase.test_queries',
     'introspection.tests.IntrospectionTests.test_smallautofield',
     'schema.tests.SchemaTests.test_inline_fk',
+    'aggregation.tests.AggregateTestCase.test_aggregation_subquery_annotation_exists',
+    'aggregation.tests.AggregateTestCase.test_aggregation_subquery_annotation_values_collision',
     'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_extract_func_with_timezone',
     'expressions.tests.FTimeDeltaTests.test_date_subquery_subtraction',
     'expressions.tests.FTimeDeltaTests.test_datetime_subquery_subtraction',


### PR DESCRIPTION
Fixes the following Django 4.2 tests:

```
aggregation.tests.AggregateTestCase.test_aggregation_default_not_in_aggregate,
aggregation.tests.AggregateTestCase.test_annotate_over_annotate,
aggregation.tests.AggregateTestCase.test_dates_with_aggregation,
aggregation.tests.AggregateTestCase.test_more_aggregation,

aggregation_regress.tests.AggregationTests.test_aggregate_and_annotate_duplicate_columns,
aggregation_regress.tests.AggregationTests.test_aggregate_and_annotate_duplicate_columns_proxy, 
aggregation_regress.tests.AggregationTests.test_aggregate_and_annotate_duplicate_columns_unmanaged,
aggregation_regress.tests.AggregationTests.test_aggregate_annotation,
aggregation_regress.tests.AggregationTests.test_aggregate_on_relation, 
aggregation_regress.tests.AggregationTests.test_annotate_on_relation,
aggregation_regress.tests.AggregationTests.test_annotation,
aggregation_regress.tests.AggregationTests.test_more_more, 
aggregation_regress.tests.AggregationTests.test_more_more_more,

db_functions.comparison.test_cast.CastTests.test_cast_from_db_datetime_to_date_group_by,

expressions_case.tests.CaseExpressionTests.test_aggregation_empty_cases,

queries.tests.ValuesQuerysetTests.test_named_values_list_with_fields,
queries.tests.ValuesQuerysetTests.test_named_values_list_without_fields
```

Also fixes these tests:
```
'aggregation.tests.AggregateTestCase.test_expression_on_aggregation',

'aggregation_regress.tests.AggregationTests.test_annotated_conditional_aggregate',

'annotations.tests.NonAggregateAnnotationTestCase.test_full_expression_annotation_with_aggregation',

'db_functions.comparison.test_cast.CastTests.test_cast_to_integer',
```