### PR TITLE
Allow partial support for filtering against window functions.

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -264,7 +264,6 @@ class SQLCompiler(compiler.SQLCompiler):
                 # SQL Server requires the keword for limitting at the begenning
                 if do_limit and not do_offset:
                     result.append('TOP %d' % high_mark)
-                
                 out_cols = []
                 col_idx = 1
                 for _, (s_sql, s_params), alias in self.select + extra_select:

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -230,7 +230,7 @@ class SQLCompiler(compiler.SQLCompiler):
                 if not getattr(features, 'supports_select_{}'.format(combinator)):
                     raise NotSupportedError('{} is not supported on this database backend.'.format(combinator))
                 result, params = self.get_combinator_sql(combinator, self.query.combinator_all)
-            elif self.qualify:
+            elif django.VERSION >= (4, 2) and self.qualify:
                 result, params = self.get_qualify_sql()
                 order_by = None
             else:

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -261,6 +261,10 @@ class SQLCompiler(compiler.SQLCompiler):
                     result += distinct_result
                     params += distinct_params
 
+                # SQL Server requires the keword for limitting at the begenning
+                if do_limit and not do_offset:
+                    result.append('TOP %d' % high_mark)
+                
                 out_cols = []
                 col_idx = 1
                 for _, (s_sql, s_params), alias in self.select + extra_select:
@@ -273,7 +277,7 @@ class SQLCompiler(compiler.SQLCompiler):
                     out_cols.append(s_sql)
 
                 # SQL Server requires an order-by clause for offsetting
-                if do_limit:
+                if do_offset:
                     meta = self.query.get_meta()
                     qn = self.quote_name_unless_alias
                     offsetting_order_by = '%s.%s' % (qn(meta.db_table), qn(meta.pk.db_column or meta.pk.column))
@@ -381,7 +385,7 @@ class SQLCompiler(compiler.SQLCompiler):
 
             # SQL Server requires the backend-specific emulation (2008 or earlier)
             # or an offset clause (2012 or newer) for offsetting
-            if do_limit:
+            if do_offset:
                 if do_offset_emulation:
                     # Construct the final SQL clause, using the initial select SQL
                     # obtained above.

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -230,6 +230,9 @@ class SQLCompiler(compiler.SQLCompiler):
                 if not getattr(features, 'supports_select_{}'.format(combinator)):
                     raise NotSupportedError('{} is not supported on this database backend.'.format(combinator))
                 result, params = self.get_combinator_sql(combinator, self.query.combinator_all)
+            elif self.qualify:
+                result, params = self.get_qualify_sql()
+                order_by = None
             else:
                 distinct_fields, distinct_params = self.get_distinct()
                 # This must come after 'select', 'ordering', and 'distinct' -- see
@@ -258,10 +261,6 @@ class SQLCompiler(compiler.SQLCompiler):
                     result += distinct_result
                     params += distinct_params
 
-                # SQL Server requires the keword for limitting at the begenning
-                if do_limit and not do_offset:
-                    result.append('TOP %d' % high_mark)
-
                 out_cols = []
                 col_idx = 1
                 for _, (s_sql, s_params), alias in self.select + extra_select:
@@ -274,7 +273,7 @@ class SQLCompiler(compiler.SQLCompiler):
                     out_cols.append(s_sql)
 
                 # SQL Server requires an order-by clause for offsetting
-                if do_offset:
+                if do_limit:
                     meta = self.query.get_meta()
                     qn = self.quote_name_unless_alias
                     offsetting_order_by = '%s.%s' % (qn(meta.db_table), qn(meta.pk.db_column or meta.pk.column))
@@ -382,7 +381,7 @@ class SQLCompiler(compiler.SQLCompiler):
 
             # SQL Server requires the backend-specific emulation (2008 or earlier)
             # or an offset clause (2012 or newer) for offsetting
-            if do_offset:
+            if do_limit:
                 if do_offset_emulation:
                     # Construct the final SQL clause, using the initial select SQL
                     # obtained above.


### PR DESCRIPTION
This PR allows partial support for filtering against window functions, which was added in Django 4.2.

Fixes the following Django 4.2 tests:

```
expressions_window.tests.WindowFunctionTests.test_exclude,
expressions_window.tests.WindowFunctionTests.test_filter,
expressions_window.tests.WindowFunctionTests.test_filter_alias,
expressions_window.tests.WindowFunctionTests.test_filter_column_ref_rhs,
expressions_window.tests.WindowFunctionTests.test_filter_conditional_annotation,
expressions_window.tests.WindowFunctionTests.test_filter_conditional_expression,
expressions_window.tests.WindowFunctionTests.test_filter_count,
expressions_window.tests.WindowFunctionTests.test_filter_select_related,
expressions_window.tests.WindowFunctionTests.test_filter_values,
expressions_window.tests.WindowFunctionTests.test_heterogeneous_filter,
expressions_window.tests.WindowFunctionTests.test_limited_filter
```