### PR TITLE
Allow partial support for filtering against window functions

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -230,6 +230,9 @@ class SQLCompiler(compiler.SQLCompiler):
                 if not getattr(features, 'supports_select_{}'.format(combinator)):
                     raise NotSupportedError('{} is not supported on this database backend.'.format(combinator))
                 result, params = self.get_combinator_sql(combinator, self.query.combinator_all)
+            elif django.VERSION >= (4, 2) and self.qualify:
+                result, params = self.get_qualify_sql()
+                order_by = None
             else:
                 distinct_fields, distinct_params = self.get_distinct()
                 # This must come after 'select', 'ordering', and 'distinct' -- see


### PR DESCRIPTION
This PR allows partial support for filtering against window functions, which was added in Django 4.2.

Fixes the following Django 4.2 tests:

```
expressions_window.tests.WindowFunctionTests.test_exclude,
expressions_window.tests.WindowFunctionTests.test_filter,
expressions_window.tests.WindowFunctionTests.test_filter_alias,
expressions_window.tests.WindowFunctionTests.test_filter_column_ref_rhs,
expressions_window.tests.WindowFunctionTests.test_filter_conditional_annotation,
expressions_window.tests.WindowFunctionTests.test_filter_conditional_expression,
expressions_window.tests.WindowFunctionTests.test_filter_count,
expressions_window.tests.WindowFunctionTests.test_filter_select_related,
expressions_window.tests.WindowFunctionTests.test_filter_values,
expressions_window.tests.WindowFunctionTests.test_heterogeneous_filter,
```

The following Django 4.2 WindowFunction test failure still remains open:

```
expressions_window.tests.WindowFunctionTests.test_limited_filter
```