### PR TITLE
Assign value to display_size for get_table_description()

### DIFF
--- a/mssql/introspection.py
+++ b/mssql/introspection.py
@@ -107,7 +107,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """
 
         # map pyodbc's cursor.columns to db-api cursor description
-        columns = [[c[3], c[4], None, c[6], c[6], c[8], c[10], c[12]] for c in cursor.columns(table=table_name)]
+        columns = [[c[3], c[4], c[6], c[6], c[6], c[8], c[10], c[12]] for c in cursor.columns(table=table_name)]
 
         if not columns:
             raise DatabaseError(f"Table {table_name} does not exist.")


### PR DESCRIPTION
This PR assigns value to display_size. Django 4.2's inspectdb uses Cursor.description.display_size for CharFields' max_length.

Fixes the following Django 4.2 test:
```
introspection.tests.IntrospectionTests.test_get_table_description_col_lengths
```