### PR TITLE
Fix combinator `ORDER BY` alias

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -209,7 +209,8 @@ class SQLCompiler(compiler.SQLCompiler):
         """
         refcounts_before = self.query.alias_refcount.copy()
         try:
-            extra_select, order_by, group_by = self.pre_sql_setup()
+            combinator = self.query.combinator
+            extra_select, order_by, group_by = self.pre_sql_setup(with_col_aliases=with_col_aliases or bool(combinator))
             for_update_part = None
             # Is a LIMIT/OFFSET clause needed?
             with_limit_offset = with_limits and (self.query.high_mark is not None or self.query.low_mark)


### PR DESCRIPTION
This PR fixes the following Django 4.2 test:
```
queries.test_qs_combinators.QuerySetSetOperationTests.test_union_with_select_related_and_order
```