### PR TITLE
fix incorrect saved datetime when TIME_ZONE is not UTC.

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -581,12 +581,15 @@ class DatabaseOperations(BaseDatabaseOperations):
                 # When support for time zones is enabled, Django stores datetime information
                 # in UTC in the database and uses time-zone-aware objects internally
                 # source: https://docs.djangoproject.com/en/dev/topics/i18n/timezones/#overview
-                value = value.astimezone(datetime.timezone.utc)
+                value = timezone.make_naive(value, self.connection.timezone)
             else:
                 # When USE_TZ is False, settings.TIME_ZONE is the time zone in
                 # which Django will store all datetimes
                 # source: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-TIME_ZONE
-                value = timezone.make_naive(value, self.connection.timezone)
+                raise ValueError(
+                    "MSSQL backend does not support timezone-aware datetimes when "
+                    "USE_TZ is False."
+                )
         return value
 
     if DJANGO41:


### PR DESCRIPTION
This is my first time opening a pull request, sorry if I do anything wrong.

Please let me know if I am wrong, as far as I know, the datetime field in the SQL server doesn't store timezone.

So, for the database `TIME_ZONE` setting, the method `adapt_datetimefield_value` should implement like `django.db.backends.mysql.operations` which also doesn't have timezone support.
