### PR TITLE
Fix schema db default test

### DIFF
--- a/mssql/introspection.py
+++ b/mssql/introspection.py
@@ -138,6 +138,17 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                     column[1] = SQL_AUTOFIELD
             if column[1] == Database.SQL_WVARCHAR and column[3] < 4000:
                 column[1] = Database.SQL_WCHAR
+            # Remove surrounding parentheses for default values
+            if column[7]:
+                default_value = column[7]
+                start = 0
+                end = -1
+                for _ in range(2):
+                    if default_value[start] == '(' and default_value[end] == ')':
+                        start += 1
+                        end -= 1
+                column[7] = default_value[start:end + 1]
+
             items.append(FieldInfo(*column))
         return items
 


### PR DESCRIPTION
Fix `schema.tests.SchemaTests.test_rename_keep_db_default` introduced in Django 5.0

Django does not expect parentheses surrounding default values in SQL Server.

See here - https://stackoverflow.com/questions/2911953/sql-server-default-values-why-with-one-or-two-parentheses