### PR TITLE
Skip constraint tests

### DIFF
--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -301,6 +301,11 @@ EXCLUDED_TESTS = [
     'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_with_select_related_and_order',
     'expressions_window.tests.WindowFunctionTests.test_limited_filter',
     'schema.tests.SchemaTests.test_remove_ignored_unique_constraint_not_create_fk_index',
+
+    #Django 5.0
+    'constraints.tests.CheckConstraintTests.test_validate_custom_error',
+    'constraints.tests.CheckConstraintTests.test_validate_nullable_jsonfield',
+    'constraints.tests.CheckConstraintTests.test_validate_pk_field',
 ]
 
 REGEX_TESTS = [


### PR DESCRIPTION
Django 5.0 introduces 3 new constraint tests that fail with:

`AssertionError: ValidationError not raised`

In Django 4.1, we encountered tests that failed for the same reason and added them to the list of skipped tests:

```
Django 4.1 added a new function to CheckConstraint class which calls Q.check() which is also new. 

SQL generated by Q.check:

SELECT 1 AS [_check] FROM WHERE COALESCE((10 > (42)), True) = True

SQL server does not support booleans being used in SQL

coalesce class/function probably needs an `as_microsoft`.
```