### PR TITLE
Skip nullable textfield constraint test

### DIFF
--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -301,6 +301,7 @@ EXCLUDED_TESTS = [
     'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_with_select_related_and_order',
     'expressions_window.tests.WindowFunctionTests.test_limited_filter',
     'schema.tests.SchemaTests.test_remove_ignored_unique_constraint_not_create_fk_index',
+    'constraints.tests.UniqueConstraintTests.test_validate_nullable_textfield_with_isnull_true',
 ]
 
 REGEX_TESTS = [


### PR DESCRIPTION
Django 4.2.6 introduced a new constraint test that attempts to validate nullable textfields.

SQL Server is unable to execute the query involved in validating the textfield because of the `Q()` conditional statements.