### PR TITLE
Support GeneratedField

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -60,6 +60,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_default_keyword_in_insert = True
     supports_expression_defaults = True
     supports_default_keyword_in_bulk_insert = True
+    supports_stored_generated_columns = True
+    supports_virtual_generated_columns = True
 
     @cached_property
     def has_zoneinfo_database(self):

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -1229,6 +1229,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             definition, extra_params = self.column_sql(model, field)
             if definition is None:
                 continue
+            # Remove column type from definition if field is generated
+            if (django_version >= (5,0) and field.generated):
+                definition = definition[definition.find('AS'):]
 
             if (self.connection.features.supports_nullable_unique_constraints and
                     not field.many_to_many and field.null and field.unique):

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -1025,7 +1025,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if definition is None:
             return
         # Remove column type from definition if field is generated
-        if field.generated:
+        if (django_version >= (5,0) and field.generated):
             definition = definition[definition.find('AS'):]
         # Nullable columns with default values require 'WITH VALUES' to set existing rows
         if 'DEFAULT' in definition and field.null:


### PR DESCRIPTION
Support for GeneratedField introduced in Django 5.0:

https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.GeneratedField


Implemented using SQL Server's computed columns functionality: 
https://learn.microsoft.com/en-us/sql/relational-databases/tables/specify-computed-columns-in-a-table?view=sql-server-ver16