### PR TITLE
revert can_return_rows_from_bulk_insert to False

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -13,7 +13,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_introspect_small_integer_field = True
     can_return_columns_from_insert = True
     can_return_id_from_insert = True
-    can_return_rows_from_bulk_insert = True
+    can_return_rows_from_bulk_insert = False
     can_rollback_ddl = True
     can_use_chunked_reads = False
     for_update_after_from = True

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -15,7 +15,7 @@ DATABASES = {
         "PASSWORD": "MyPassword42",
         "HOST": "localhost",
         "PORT": "1433",
-        "OPTIONS": {"driver": "ODBC Driver 17 for SQL Server", },
+        "OPTIONS": {"driver": "ODBC Driver 17 for SQL Server", "return_rows_bulk_insert": True},
     },
     'other': {
         "ENGINE": "mssql",
@@ -24,7 +24,7 @@ DATABASES = {
         "PASSWORD": "MyPassword42",
         "HOST": "localhost",
         "PORT": "1433",
-        "OPTIONS": {"driver": "ODBC Driver 17 for SQL Server", },
+        "OPTIONS": {"driver": "ODBC Driver 17 for SQL Server", "return_rows_bulk_insert": True},
     },
 }
 

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -7,10 +7,6 @@ from ..models import Author
 class TestTableWithTrigger(TransactionTestCase):
     def test_insert_into_table_with_trigger(self):
         connection = connections['default']
-        # Change can_return_rows_from_bulk_insert to be the same as when
-        # has_trigger = True
-        connection.features_class.can_return_rows_from_bulk_insert = False
-
         with connection.schema_editor() as cursor:
             cursor.execute("""
                 CREATE TRIGGER TestTrigger
@@ -21,9 +17,13 @@ class TestTableWithTrigger(TransactionTestCase):
             """)
 
         try:
+            # Change can_return_rows_from_bulk_insert to be the same as when
+            # has_trigger = True
+            connection.features_class.can_return_rows_from_bulk_insert = False
             Author.objects.create(name='Foo')
         except django.db.utils.ProgrammingError as e:
             self.fail('Check for regression of issue #130. Insert with trigger failed with exception: %s' % e)
         finally:
             with connection.schema_editor() as cursor:
                 cursor.execute("DROP TRIGGER TestTrigger")
+            # connection.features_class.can_return_rows_from_bulk_insert = True

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -19,6 +19,7 @@ class TestTableWithTrigger(TransactionTestCase):
         try:
             # Change can_return_rows_from_bulk_insert to be the same as when
             # has_trigger = True
+            old_return_rows_flag = connection.features_class.can_return_rows_from_bulk_insert
             connection.features_class.can_return_rows_from_bulk_insert = False
             Author.objects.create(name='Foo')
         except django.db.utils.ProgrammingError as e:
@@ -26,4 +27,4 @@ class TestTableWithTrigger(TransactionTestCase):
         finally:
             with connection.schema_editor() as cursor:
                 cursor.execute("DROP TRIGGER TestTrigger")
-            # connection.features_class.can_return_rows_from_bulk_insert = True
+            connection.features_class.can_return_rows_from_bulk_insert = old_return_rows_flag


### PR DESCRIPTION
Changes default value of `can_return_rows_from_bulk_insert` in features.py back to False, sets `return_rows_bulk_insert` to True in settings.py for CI purposes