### PR TITLE
Fix aggregate queries with case expressions

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -9,6 +9,8 @@ import re
 import time
 import struct
 import datetime
+from decimal import Decimal
+from uuid import UUID
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
@@ -571,6 +573,36 @@ class CursorWrapper(object):
         self.last_sql = ''
         self.last_params = ()
 
+    def _as_sql_type(self, typ, value):
+        if value is None:
+            return 'INT'
+        elif isinstance(value, str):
+            length = len(value)
+            if length == 0:
+                return 'NVARCHAR'
+            return 'NVARCHAR(%s)' % len(value)
+        elif typ == int:
+            if value < 0x7FFFFFFF and value > -0x7FFFFFFF:
+                return 'INT'
+            else:
+                return 'BIGINT'
+        elif typ == float:
+            return 'FLOAT'
+        elif typ == bool:
+            return 'BIT'
+        elif isinstance(value, Decimal):
+            return 'NUMERIC'
+        elif isinstance(value, datetime.date):
+            return 'DATE'
+        elif isinstance(value, datetime.time):
+            return 'TIME'
+        elif isinstance(value, datetime.datetime):
+            return 'TIMESTAMP'
+        elif isinstance(value, UUID):
+            return 'uniqueidentifier'
+        else:
+            raise NotImplementedError('not support type %s (%s)' % (type(value), repr(value)))
+
     def close(self):
         if self.active:
             self.active = False
@@ -587,6 +619,22 @@ class CursorWrapper(object):
             sql = sql % tuple('?' * len(params))
 
         return sql
+
+    def format_group_by_params(self, query, params):
+        if params:
+            params = [(param, type(param)) for param in params]
+            params_dict = {param: '@var%d' % i for i, param in enumerate(set(params))}
+            args = [params_dict[param] for param in params]
+
+            variables = []
+            params = []
+            for key, value in params_dict.items():
+                datatype = self._as_sql_type(key[1], key[0])
+                variables.append("%s %s = %%s " % (value, datatype))
+                params.append(key[0])
+            query = ('DECLARE %s \n' % ','.join(variables)) + (query % tuple(args))
+
+        return query, params
 
     def format_params(self, params):
         fp = []
@@ -616,6 +664,8 @@ class CursorWrapper(object):
 
     def execute(self, sql, params=None):
         self.last_sql = sql
+        if 'GROUP BY' in sql:
+            sql, params = self.format_group_by_params(sql, params)
         sql = self.format_sql(sql, params)
         params = self.format_params(params)
         self.last_params = params


### PR DESCRIPTION
Addresses issue: https://github.com/microsoft/mssql-django/issues/316

Params in the SELECT clause are interpreted differently than the params in the GROUP BY clause. 

Example:
The following query fails
```sql
SELECT count(1) , case when name = ? then 1 else 2 end from TABLE group by case when name = ? then 1 else 2 end;
```
 Results:
```
[42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Column 'name' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause. (8120) (SQLExecDirectW)"
```

However, grouping these params avoids the error:

```sql
DECLARE @var1 NVARCHAR(64);
SET @var1 = ?
SELECT count(1) , case when name = @var1 then 1 else 2 end 
FROM TABLE 
GROUP BY case when name = @var1 then 1 else 2 end;
``` 
 
