### PR TITLE
Add support for SQL Variant fields

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -81,6 +81,9 @@ def encode_value(v):
         return '{%s}' % (v.replace('}', '}}'),)
     return v
 
+def handle_sql_variant_as_string(value):
+    # SQL variant of type 150 is not supported, convert it to string and return
+    return value.decode('utf-16le')
 
 def handle_datetimeoffset(dto_value):
     # Decode bytes returned from SQL Server
@@ -379,6 +382,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         # Handling values from DATETIMEOFFSET columns
         # source: https://github.com/mkleehammer/pyodbc/wiki/Using-an-Output-Converter-function
         conn.add_output_converter(SQL_TIMESTAMP_WITH_TIMEZONE, handle_datetimeoffset)
+        
+        # add support for sql_variant fields
+        conn.add_output_converter(-150, handle_sql_variant_as_string)
+        
         conn.timeout = query_timeout
         if setencoding:
             for entry in setencoding:


### PR DESCRIPTION
Adds support for _sql_variant_ field which causes the following error: 
**"ODBC SQL type -150 is not yet supported.  column-index=0  type=-150', 'HY106'"**

This commit converts these fields into a string