### PR TITLE
Fix param format bug

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -618,11 +618,14 @@ class CursorWrapper(object):
         return sql
 
     def format_group_by_params(self, query, params):
+        # Prepare query for string formatting
+        query = re.sub(r'%\w+', '{}', query)
+
         if params:
             # Insert None params directly into the query
             if None in params:
                 null_params = ['NULL' if param is None else '%s' for param in params]
-                query = query % tuple(null_params)
+                query = query.format(*null_params)
                 params = tuple(p for p in params if p is not None)
             params = [(param, type(param)) for param in params]
             params_dict = {param: '@var%d' % i for i, param in enumerate(set(params))}
@@ -634,7 +637,7 @@ class CursorWrapper(object):
                 datatype = self._as_sql_type(key[1], key[0])
                 variables.append("%s %s = %%s " % (value, datatype))
                 params.append(key[0])
-            query = ('DECLARE %s \n' % ','.join(variables)) + (query % tuple(args))
+            query = ('DECLARE %s \n' % ','.join(variables)) + (query.format(*args))
 
         return query, params
 

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -624,7 +624,7 @@ class CursorWrapper(object):
         if params:
             # Insert None params directly into the query
             if None in params:
-                null_params = ['NULL' if param is None else '%s' for param in params]
+                null_params = ['NULL' if param is None else '{}' for param in params]
                 query = query.format(*null_params)
                 params = tuple(p for p in params if p is not None)
             params = [(param, type(param)) for param in params]
@@ -638,7 +638,6 @@ class CursorWrapper(object):
                 variables.append("%s %s = %%s " % (value, datatype))
                 params.append(key[0])
             query = ('DECLARE %s \n' % ','.join(variables)) + (query.format(*args))
-
         return query, params
 
     def format_params(self, params):


### PR DESCRIPTION
Addresses: https://github.com/microsoft/mssql-django/issues/369

Multiple string formatting using % (e.g. string % param) requires additional % for escaping %

