### PR TITLE
BUG fix, ensure that we only check tables in the right schema

### DIFF
--- a/mssql/introspection.py
+++ b/mssql/introspection.py
@@ -86,7 +86,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                     LEFT JOIN sys.tables t ON t.name = i.TABLE_NAME
                     LEFT JOIN sys.extended_properties ep ON t.object_id = ep.major_id
                     AND ((ep.name = 'MS_DESCRIPTION' AND ep.minor_id = 0) OR ep.value IS NULL)
-                    AND i.TABLE_SCHEMA = %s""" % (
+                    WHERE i.TABLE_SCHEMA = %s""" % (
                 get_schema_name())
         else:
             sql = 'SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = %s' % (get_schema_name())


### PR DESCRIPTION
If we don't use this `where` this query returns the tables from all the schemas and not just the schema we are looking for.  Filter applied in the `left join` does not have the expected result in this scenario.

Just run the queries  below and you see what I mean
```sql
SELECT
                        TABLE_NAME,
                        i.TABLE_SCHEMA,
                        TABLE_TYPE,
                        CAST(ep.value AS VARCHAR) AS COMMENT
                    FROM INFORMATION_SCHEMA.TABLES i
                    LEFT JOIN sys.tables t ON t.name = i.TABLE_NAME
                    LEFT JOIN sys.extended_properties ep ON t.object_id = ep.major_id
                    AND ((ep.name = 'MS_DESCRIPTION' AND ep.minor_id = 0) OR ep.value IS NULL)
                    AND i.TABLE_SCHEMA = 'my_dev_schema'
```
```sql
SELECT
                        TABLE_NAME,
                        i.TABLE_SCHEMA,
                        TABLE_TYPE,
                        CAST(ep.value AS VARCHAR) AS COMMENT
                    FROM INFORMATION_SCHEMA.TABLES i
                    LEFT JOIN sys.tables t ON t.name = i.TABLE_NAME
                    LEFT JOIN sys.extended_properties ep ON t.object_id = ep.major_id
                    AND ((ep.name = 'MS_DESCRIPTION' AND ep.minor_id = 0) OR ep.value IS NULL)
                    WHERE i.TABLE_SCHEMA = 'my_dev_schema'
```

If we have in the same database one schema the has the django_migrations but we are then running our application, that does not have migrations, against a different schema, this bit here breaks the application. The function has_table() will return True, but it should return False, because our schema does NOT have the table.