### PR TITLE
skip 5.0.6 generated field tests

### DIFF
--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -289,6 +289,11 @@ EXCLUDED_TESTS = [
     'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_with_select_related_and_order',
     'expressions_window.tests.WindowFunctionTests.test_limited_filter',
     'schema.tests.SchemaTests.test_remove_ignored_unique_constraint_not_create_fk_index',
+    
+    # Generated field 5.0.6 tests
+    'migrations.test_operations.OperationTests.test_invalid_generated_field_changes_on_rename_virtual',
+    'migrations.test_operations.OperationTests.test_invalid_generated_field_changes_on_rename_stored',
+    
 ]
 
 REGEX_TESTS = [


### PR DESCRIPTION
Skips the following tests:
```
    'migrations.test_operations.OperationTests.test_invalid_generated_field_changes_on_rename_virtual',
    'migrations.test_operations.OperationTests.test_invalid_generated_field_changes_on_rename_stored',
```
Both tests does this rename, which is not supported https://github.com/django/django/blob/3ac0e43207b4a1b9327ba12612005c285fbff7ee/tests/migrations/test_operations.py#L5993
It doesn't matter for db_presist =True/False. Because when the test trying to compute Pink+Pink here(https://github.com/django/django/blob/3ac0e43207b4a1b9327ba12612005c285fbff7ee/tests/migrations/test_operations.py#L5982), it creates a computed column which is difficult to modify with simple sp_rename or alter column. The doc is here(https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-ver16#alter-column) mentioned modified column can't be a computed column

