### PR TITLE
fix issue #409

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -361,7 +361,7 @@ class SQLCompiler(compiler.SQLCompiler):
                     params.extend(h_params)
 
             explain = self.query.explain_info if django.VERSION >= (4, 0) else self.query.explain_query
-            if explain:
+            if explain and hasattr(self.query, 'explain_format'):
                 result.insert(0, self.connection.ops.explain_query_prefix(
                     self.query.explain_format,
                     **self.query.explain_options

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -224,7 +224,6 @@ EXCLUDED_TESTS = [
     'lookup.tests.LookupTests.test_lookup_rhs',
     'order_with_respect_to.tests.OrderWithRespectToBaseTests.test_previous_and_next_in_order',
     'ordering.tests.OrderingTests.test_default_ordering_does_not_affect_group_by',
-    'queries.test_explain.ExplainUnsupportedTests.test_message',
     'aggregation.tests.AggregateTestCase.test_coalesced_empty_result_set',
     'aggregation.tests.AggregateTestCase.test_empty_result_optimization',
     'queries.tests.Queries6Tests.test_col_alias_quoted',


### PR DESCRIPTION
Fixes a bug when using the `.explain()` function, see #409 