### PR TITLE
FIX:getting data post creation in test_bulk_update_different_column_t…

### DIFF
--- a/testapp/tests/test_expressions.py
+++ b/testapp/tests/test_expressions.py
@@ -121,9 +121,16 @@ class TestBulkUpdate(TestCase):
             (1, 'a', datetime.datetime(year=2024, month=1, day=1)),
             (2, 'b', datetime.datetime(year=2023, month=12, day=31))
         )
-        objs = ModelWithNullableFieldsOfDifferentTypes.objects.bulk_create(ModelWithNullableFieldsOfDifferentTypes(int_value=row_data[0],
-                                                                                                                   name=row_data[1],
-                                                                                                                   date=row_data[2]) for row_data in data)
+        objs = ModelWithNullableFieldsOfDifferentTypes.objects.bulk_create(
+            (ModelWithNullableFieldsOfDifferentTypes(int_value=row_data[0],
+                                                     name=row_data[1],
+                                                     date=row_data[2]) for row_data in data),
+        )
+        #since bulk_create does not return the created objects, we need to fetch them again
+        # to be able to update them
+        # and we need to set the values to None to be able to test the bulk_update
+        # since the fields are nullable
+        objs = list(ModelWithNullableFieldsOfDifferentTypes.objects.all())
         for obj in objs:
             obj.int_value = None
             obj.name = None


### PR DESCRIPTION
This pull request includes a minor update to the `test_bulk_update_different_column_types` test in `testapp/tests/test_expressions.py`. The primary change involves modifying the handling of objects created via `bulk_create` to ensure they can be properly updated and tested for nullable fields.

Changes to test logic:

* Updated the `bulk_create` call to fetch the created objects again using a query, as `bulk_create` does not return the id of the  created objects. Added comments explaining the need to reset field values to `None` for testing `bulk_update` with nullable fields. 