### PR TITLE
FIX:Replaced pytz with Zoneinfo because it is an efficient and modular wa…

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -13,7 +13,7 @@ from django.db.models.sql.where import WhereNode
 from django.utils import timezone
 from django.utils.encoding import force_str
 from django import VERSION as django_version
-import pytz
+from zoneinfo import ZoneInfo
 
 DJANGO41 = django_version >= (4, 1)
 
@@ -46,11 +46,10 @@ class DatabaseOperations(BaseDatabaseOperations):
         """
         # SQL Server has no built-in support for tz database, see:
         # http://blogs.msdn.com/b/sqlprogrammability/archive/2008/03/18/using-time-zone-data-in-sql-server-2008.aspx
-        zone = pytz.timezone(tzname)
-        # no way to take DST into account at this point
-        now = datetime.datetime.now()
-        delta = zone.localize(now, is_dst=False).utcoffset()
-        return delta.days * 86400 + delta.seconds - zone.dst(now).seconds
+        zone = ZoneInfo(tzname)  # Create a time zone object using the standard library's zoneinfo module.
+        now = datetime.datetime.now(zone)  # Get the current local time as a timezone-aware datetime.
+        delta = now.utcoffset()  # Get the UTC offset (as a timedelta) for this aware datetime.
+        return int(delta.total_seconds())  # Return the total offset in seconds.
 
     def bulk_batch_size(self, fields, objs):
         """

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
     install_requires=[
         'django>=3.2,<5.1',
         'pyodbc>=3.0',
-        'pytz',
     ],
     package_data={'mssql': ['regex_clr.dll']},
     classifiers=CLASSIFIERS,

--- a/testapp/tests/test_timezones.py
+++ b/testapp/tests/test_timezones.py
@@ -5,9 +5,9 @@ import datetime
 from django.db import connection
 from django.test import TestCase
 from django.test.utils import override_settings
-
+from zoneinfo import ZoneInfo
 from ..models import TimeZone
-
+from mssql.operations import DatabaseOperations
 class TestDateTimeField(TestCase):
 
     def test_iso_week_day(self):
@@ -105,3 +105,25 @@ class TestDateTimeToDateTimeOffsetMigration(TestCase):
             # Migrate back to DATETIME2 for other unit tests
             with connection.schema_editor() as cursor:
                 cursor.execute("ALTER TABLE [testapp_timezone] ALTER column [date] datetime2")
+class DummyConnection:
+    timezone_name = 'UTC'
+    timezone = ZoneInfo('UTC')
+
+class TestGetUTCOffset(TestCase):
+    def setUp(self):
+        self.ops = DatabaseOperations(None)
+        self.ops.connection = DummyConnection()
+
+    def test_utc(self):
+        offset = self.ops._get_utcoffset('UTC')
+        self.assertEqual(offset, 0)
+
+    def test_new_york(self):
+        # Offset will depend on DST, so check it's either -18000 or -14400
+        offset = self.ops._get_utcoffset('America/New_York')
+        self.assertIn(offset, (-18000, -14400))
+
+    def test_london(self):
+        # Offset will depend on DST, so check it's either 0 or 3600
+        offset = self.ops._get_utcoffset('Europe/London')
+        self.assertIn(offset, (0, 3600))


### PR DESCRIPTION
This pull request refactors the handling of time zones in the `mssql` package by replacing the `pytz` library with Python's standard library `zoneinfo` module. Additionally, it updates the test suite to reflect these changes and removes `pytz` from the package dependencies.

### Time zone handling updates:
* Replaced the `pytz` library with the `zoneinfo` module for time zone operations in `mssql/operations.py`, including updates to the `_get_utcoffset` method to use `ZoneInfo` for calculating UTC offsets. [[1]](diffhunk://#diff-1c064528b2e94caf8c8d70295322c1250bba4eb55d8205a27ce4db75878d5dacL16-R16) [[2]](diffhunk://#diff-1c064528b2e94caf8c8d70295322c1250bba4eb55d8205a27ce4db75878d5dacL49-R52)

### Dependency updates:
* Removed `pytz` from the `install_requires` list in `setup.py`, as it is no longer required.

### Test suite updates:
* Updated `testapp/tests/test_timezones.py` to import and use `ZoneInfo`. Added a new `TestGetUTCOffset` test class to validate the `_get_utcoffset` method with various time zones. [[1]](diffhunk://#diff-803ff703e3e69ef28782d46902472045122bb79ec07b9ee341a4e5820380daceL8-R10) [[2]](diffhunk://#diff-803ff703e3e69ef28782d46902472045122bb79ec07b9ee341a4e5820380daceR108-R129)