### PR TITLE
FIX: Devskim workflow upgrade to latest ubuntu

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   lint:
     name: DevSkim
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/devskim.yml` file. The change updates the `runs-on` configuration to use `ubuntu-latest` instead of `ubuntu-20.04`.