### PR TITLE
FEAT:Support 5.1-Removed Deprecated Fields

### DIFF
--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -377,7 +377,12 @@ def _get_check_sql(self, model, schema_editor):
         query = Query(model=model, alias_cols=False)
     else:
         query = Query(model=model)
-    where = query.build_where(self.check)
+    # Build the query to check the condition of the CheckConstraint.    
+    if VERSION >= (5, 1):
+        where = query.build_where(self.condition)
+    else:
+        # use check for backwards compatibility    
+        where = query.build_where(self.check)    
     compiler = query.get_compiler(connection=schema_editor.connection)
     sql, params = where.as_sql(compiler, schema_editor.connection)
     if schema_editor.connection.vendor == 'microsoft':

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -377,7 +377,11 @@ def _get_check_sql(self, model, schema_editor):
         query = Query(model=model, alias_cols=False)
     else:
         query = Query(model=model)
-    # Build the query to check the condition of the CheckConstraint.    
+    # Build the query to check the condition of the CheckConstraint.
+    # Note: Starting from Django 5.1, the CheckConstraint API changed:
+    # the attribute 'self.check' was replaced by 'self.condition'.
+    # For backwards compatibility, we use 'self.check' for versions < 5.1,
+    # and 'self.condition' for 5.1 and above.
     if VERSION >= (5, 1):
         where = query.build_where(self.condition)
     else:


### PR DESCRIPTION
This pull request includes a backward-compatible update to the `_get_check_sql` method in `mssql/functions.py` to support a new version of the Django framework.

Backward compatibility and version support:

* Updated the `_get_check_sql` method to use `self.condition` when the Django version is 5.1 or higher, while retaining the use of `self.check` for older versions to ensure backward compatibility. (`mssql/functions.py`, [mssql/functions.pyR380-R384](diffhunk://#diff-18a67edd87e19a2f28789fdf047daa1bf12bf13e150bf50dcd6cf6f73fd3c171R380-R384))