### PR TITLE
FIX: Resolve dpkg lock error on linux pipeline by adding a retry mechanism

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,6 +225,10 @@ jobs:
             echo "Waiting for dpkg lock to be released..."
             sleep 10
           done
+          if ! sudo apt-get update; then
+            echo "Failed to update packages after 30 attempts. Exiting."
+            exit 1
+          fi
 
           # Add retry logic for installing package
           for i in {1..30}; do

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,8 +216,25 @@ jobs:
           sudo dpkg -i packages-microsoft-prod.deb
           rm packages-microsoft-prod.deb
 
-          sudo apt-get update
-          sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17
+          # Add retry logic for handling dpkg lock
+          for i in {1..30}; do
+            echo "Attempt $i of 30 to update packages..."
+            if sudo apt-get update; then
+              break
+            fi
+            echo "Waiting for dpkg lock to be released..."
+            sleep 10
+          done
+
+          # Add retry logic for installing package
+          for i in {1..30}; do
+            echo "Attempt $i of 30 to install ODBC driver..."
+            if sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17; then
+              break
+            fi
+            echo "Waiting for dpkg lock to be released..."
+            sleep 10
+          done
         displayName: Install ODBC Driver
 
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,6 +239,11 @@ jobs:
             echo "Waiting for dpkg lock to be released..."
             sleep 10
           done
+          # Exit with a non-zero status if installation fails after all retries
+          if ! sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17; then
+            echo "Failed to install ODBC driver after 30 attempts. Exiting."
+            exit 1
+          fi
         displayName: Install ODBC Driver
 
       - script: |


### PR DESCRIPTION
This pull request introduces retry logic to the `azure-pipelines.yml` file to handle potential issues with the `dpkg` lock during package updates and installations. This change improves the reliability of the pipeline by ensuring that transient errors do not cause the build to fail.

### Improvements to pipeline reliability:

* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L219-R237): Added retry logic with a maximum of 30 attempts for both the `apt-get update` and `apt-get install` commands to handle cases where the `dpkg` lock is in use. Each attempt includes a 10-second wait before retrying.