### PR TITLE
FEAT: Support 5.1 - Enhance SQL Compilation and Parameterization for sqlserver_mod

### DIFF
--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -101,16 +101,14 @@ def sqlserver_mod(self, compiler, connection):
     sql1, params1 = compiler.compile(expr[0])
     # Compile the second argument (divisor) to SQL and parameters
     sql2, params2 = compiler.compile(expr[1])
-    # Build the SQL template for modulus using ABS, FLOOR, and SIGN to mimic Python's % operator
-    # This ensures correct sign handling for negative numbers, matching Python's behavior
-    # We cannot use the standard SQL modulus operator (%) here because Django expects a function call, not an operator,
-    template = '(ABS(%s) - FLOOR(ABS(%s) / ABS(%s)) * ABS(%s)) * SIGN(%s) * SIGN(%s)'   
+    # The template uses the SQL Server syntax for modulus
+    template = '(%s %% %s)'
     # Substitute the compiled SQL fragments into the template
-    sql = template % (sql1, sql1, sql2, sql2, sql1, sql2)   
+    sql= template % (sql1, sql2)
     # Combine all parameters in the correct order for the SQL statement
-    params = params1 + params1 + params2 + params2 + params1 + params2
+    params=params1+params2
     try:
-       # Try direct SQL and param return
+       # return SQL and params
        return sql, params
     except TypeError:
         # Fallback for older Django handling

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -94,18 +94,33 @@ def sqlserver_power(self, compiler, connection, **extra_context):
         )
 
 def sqlserver_mod(self, compiler, connection):
-    # MSSQL doesn't have keyword MOD
+    # Get the source expressions (the two arguments to the Mod function)
     expr = self.get_source_expressions()
-    number_a = compiler.compile(expr[0])
-    number_b = compiler.compile(expr[1])
-    return self.as_sql(
-        compiler, connection,
-        function="",
-        template='(ABS({a}) - FLOOR(ABS({a}) / ABS({b})) * ABS({b})) * SIGN({a}) * SIGN({b})'.format(
-            a=number_a[0], b=number_b[0]),
-        arg_joiner=""
-    )
-
+    # Compile the first argument (dividend) to SQL and parameters
+    sql1, params1 = compiler.compile(expr[0])
+    # Compile the second argument (divisor) to SQL and parameters
+    sql2, params2 = compiler.compile(expr[1])
+    # Build the SQL template for modulus using ABS, FLOOR, and SIGN to mimic Python's % operator
+    # This ensures correct sign handling for negative numbers, matching Python's behavior
+    # We cannot use the standard SQL modulus operator (%) here because Django expects a function call, not an operator,
+    template = '(ABS(%s) - FLOOR(ABS(%s) / ABS(%s)) * ABS(%s)) * SIGN(%s) * SIGN(%s)'   
+    # Substitute the compiled SQL fragments into the template
+    sql = template % (sql1, sql1, sql2, sql2, sql1, sql2)   
+    # Combine all parameters in the correct order for the SQL statement
+    params = params1 + params1 + params2 + params2 + params1 + params2
+    try:
+       # Try direct SQL and param return
+       return sql, params
+    except TypeError:
+        # Fallback for older Django handling
+        return self.as_sql(
+           compiler,
+           connection,
+           function="",
+           template=sql,
+           arg_joiner="",
+           params=params
+        )
 
 def sqlserver_nth_value(self, compiler, connection, **extra_content):
     raise NotSupportedError('This backend does not support the NthValue function')

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -94,31 +94,31 @@ def sqlserver_power(self, compiler, connection, **extra_context):
         )
 
 def sqlserver_mod(self, compiler, connection):
-    # MSSQL doesn't have keyword MOD
+    # MSSQL doesn't have the MOD keyword
     # Get the source expressions (the two arguments to the Mod function)
     expr = self.get_source_expressions()
-    # Compile the first argument (dividend) to SQL and parameters
-    sql1, params1 = compiler.compile(expr[0])
-    # Compile the second argument (divisor) to SQL and parameters
-    sql2, params2 = compiler.compile(expr[1])
-    # The template uses the SQL Server syntax for modulus
-    template = '(%s %% %s)'
-    # Substitute the compiled SQL fragments into the template
-    sql= template % (sql1, sql2)
-    # Combine all parameters in the correct order for the SQL statement
-    params=params1+params2
+    # Compile the left-hand side (lhs) expression to SQL and parameters.
+    lhs_sql, lhs_params = compiler.compile(expr[0])
+    # Compile the right-hand side (rhs) expression to SQL and parameters.
+    rhs_sql, rhs_params = compiler.compile(expr[1])   
+    # Build the SQL template for modulo using ABS, FLOOR, and SIGN functions.
+    template = '(ABS(%s) - FLOOR(ABS(%s) / ABS(%s)) * ABS(%s)) * SIGN(%s) * SIGN(%s)'  
+    # Substitute the compiled SQL expressions into the template.
+    sql = template % (lhs_sql, lhs_sql, rhs_sql, rhs_sql, lhs_sql, rhs_sql)   
+    # Combine all parameters in the correct order for the SQL statement.
+    params = lhs_params + lhs_params + rhs_params + rhs_params + lhs_params + rhs_params    
     try:
-       # return SQL and params
-       return sql, params
+        # return sql,params
+        return sql, params
     except TypeError:
         # Fallback for older Django handling
         return self.as_sql(
-           compiler,
-           connection,
-           function="",
-           template=sql,
-           arg_joiner="",
-           params=params
+            compiler,
+            connection,
+            function="",
+            template=sql,
+            arg_joiner="",
+            params=params
         )
 
 def sqlserver_nth_value(self, compiler, connection, **extra_content):

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -94,6 +94,7 @@ def sqlserver_power(self, compiler, connection, **extra_context):
         )
 
 def sqlserver_mod(self, compiler, connection):
+    # MSSQL doesn't have keyword MOD
     # Get the source expressions (the two arguments to the Mod function)
     expr = self.get_source_expressions()
     # Compile the first argument (dividend) to SQL and parameters


### PR DESCRIPTION
This pull request refines the `sqlserver_mod` function in `mssql/functions.py` to improve the handling of modulus operations in Microsoft SQL Server. The changes ensure compatibility with Python's `%` operator behavior and provide a more robust implementation for compiling SQL and parameters.

### Improvements to modulus operation handling:

* **Refined SQL template for modulus operation**: Updated the function to use a custom SQL template with `ABS`, `FLOOR`, and `SIGN` functions to mimic Python's `%` operator, ensuring correct sign handling for negative numbers. This change replaces the previous implementation that directly compiled arguments without considering Python's behavior.
* **Enhanced parameter handling**: Introduced logic to compile SQL and parameters separately for each argument, combining them into a single SQL statement and parameter list. This ensures proper handling of parameters in the generated SQL.
* **Fallback for older Django versions**: Added a `try-except` block to handle potential `TypeError` exceptions, providing compatibility with older versions of Django by falling back to the previous `as_sql` method.
* **Doc Link** :[MOD() FUNCTION.loop](https://microsoft.sharepoint.com/:fl:/g/contentstorage/CSP_b7c217ea-274e-4dad-9f29-6a25ac50eb56/Ef_L7b4yEUxDsjK7aZ7IysEB9R-1lidXa3sURrXStP8nHg?e=gzJ8vd&nav=cz0lMkZjb250ZW50c3RvcmFnZSUyRkNTUF9iN2MyMTdlYS0yNzRlLTRkYWQtOWYyOS02YTI1YWM1MGViNTYmZD1iJTIxNmhmQ3QwNG5yVTJmS1dvbHJGRHJWZzF3cHo0ZUhHRkZwQk51eFg0WlVTZHBVQ2lEYVlTTFQ2aURLdXJSWmdpcSZmPTAxSFEyUk9NUDdaUFczNE1RUkpSQjNFTVYzTkdQTVJTV0ImYz0lMkYmYT1Mb29wQXBwJnA9JTQwZmx1aWR4JTJGbG9vcC1wYWdlLWNvbnRhaW5lciZ4PSU3QiUyMnclMjIlM0ElMjJUMFJUVUh4dGFXTnliM052Wm5RdWMyaGhjbVZ3YjJsdWRDNWpiMjE4WWlFMmFHWkRkREEwYm5KVk1tWkxWMjlzY2taRWNsWm5NWGR3ZWpSbFNFZEdSbkJDVG5WNFdEUmFWVk5rY0ZWRGFVUmhXVk5NVkRacFJFdDFjbEphWjJseGZEQXhTRkV5VWs5TlRFRkpVMUZKV0VKQk5saFdRMXBLVjFsQ1JVcFVWRXRRVjFvJTNEJTIyJTJDJTIyaSUyMiUzQSUyMmE2NzMzZmVlLWY0OTctNDIzYi1iM2U5LWRiYWExZWQ3ZTliNyUyMiU3RA%3D%3D)