### PR TITLE
CHORE: Support 5.2 - Test & Pipeline Changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,19 @@ jobs:
 
     strategy:
       matrix:
+        Python3.13 - Django 5.2:
+          python.version: '3.13'
+          tox.env: 'py313-django52'
+        Python3.12 - Django 5.2:
+          python.version: '3.12'
+          tox.env: 'py312-django52'
+        Python3.11 - Django 5.2:
+          python.version: '3.11'
+          tox.env: 'py311-django52'
+        Python3.10 - Django 5.2:
+          python.version: '3.10'
+          tox.env: 'py310-django52'
+
         Python3.13 - Django 5.1:
           python.version: '3.13'
           tox.env: 'py313-django51'
@@ -151,6 +164,19 @@ jobs:
 
     strategy:
       matrix:
+        Python3.13 - Django 5.2:
+          python.version: '3.13'
+          tox.env: 'py313-django52'
+        Python3.12 - Django 5.2:
+          python.version: '3.12'
+          tox.env: 'py312-django52'
+        Python3.11 - Django 5.2:
+          python.version: '3.11'
+          tox.env: 'py311-django52'
+        Python3.10 - Django 5.2:
+          python.version: '3.10'
+          tox.env: 'py310-django52'
+          
         Python3.13 - Django 5.1:
           python.version: '3.13'
           tox.env: 'py313-django51'

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,14 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.0',
     'Framework :: Django :: 4.1',
     'Framework :: Django :: 4.2',
     'Framework :: Django :: 5.0',
     'Framework :: Django :: 5.1',
+    'Framework :: Django :: 5.2',
 ]
 
 this_directory = path.abspath(path.dirname(__file__))
@@ -43,7 +45,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     install_requires=[
-        'django>=3.2,<5.2',
+        'django>=3.2,<5.3',
         'pyodbc>=3.0',
         'pytz',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ allowlist_externals =
     bash
 
 commands =
-   # python manage.py test --noinput
+    python manage.py test --noinput
     bash test.sh
 
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,15 @@ envlist =
        {py38, py39, py310}-django41,
        {py38, py39, py310}-django42,
        {py310, py311, py312}-django50
-       {py310, py311, py312,py313}-django51
+       {py310, py311, py312, py313}-django51
+       {py310, py311, py312, py313}-django52
 
 [testenv]
 allowlist_externals =
     bash
 
 commands =
-    python manage.py test --noinput
+   # python manage.py test --noinput
     bash test.sh
 
 deps =
@@ -25,3 +26,4 @@ deps =
     django42: django>=4.2,<4.3
     django50: django>=5.0,<5.1
     django51: django>=5.1,<5.2
+    django52: django>=5.2,<5.3


### PR DESCRIPTION
This pull request introduces support for Django 5.2 across the project, including updates to CI/CD pipelines, dependencies, and testing configurations. The most important changes are grouped below by theme:

### CI/CD Pipeline Updates:
* Added new matrix entries in `azure-pipelines.yml` to test compatibility with Python versions 3.10, 3.11, 3.12, and 3.13 for Django 5.2. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5R27-R39) [[2]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5R167-R179)

### Dependency Updates:
* Updated `setup.py` to declare support for Python 3.13 and Django 5.2 in the `classifiers` section.
* Adjusted the `install_requires` in `setup.py` to allow Django versions up to `<5.3`.

### Testing Configuration Updates:
* Added a new environment (`{py310, py311, py312, py313}-django52`) to the `envlist` in `tox.ini` for testing Django 5.2.
* Defined dependencies for Django 5.2 in `tox.ini` to specify `django>=5.2,<5.3`.