### PR TITLE
FIX: Django 5.2 composite PK ordering fixes, tuple-lookup fallbacks, and tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,3 +146,18 @@ echo "yes" | python tests/runtests.py --settings=testapp.settings <module>
 3. Add appropriate test exclusions with comments explaining why
 4. Keep compiler.py and schema.py changes focused - they are complex and sensitive
 5. When adding SQL Server function overrides, use the `as_microsoft` pattern in `functions.py`
+
+## Development Workflow Rules
+
+### Git Hygiene
+- **Only commit files you intentionally changed.** Untracked files (e.g. `result.xml`, build artifacts) may exist in the workspace but not be in `.gitignore` — do not stage or commit them. Review `git diff` and `git status` before committing.
+- Do not modify `testapp/settings.py` database connection settings (ODBC driver version, passwords) as part of a PR — those are local dev environment changes.
+
+### Fix Quality
+- **Find the root cause, not a workaround.** Don't parse or manipulate compiled SQL strings when Django provides a structured expression API to solve the problem at the right level. Work at the expression/node level (e.g. override `get_order_by()`, use `as_microsoft` pattern) rather than post-hoc string surgery on generated SQL.
+- Follow existing codebase patterns: the `as_microsoft` monkey-patching pattern in `functions.py`, the `_as_microsoft()` dispatch in `compiler.py`, and compiler method overrides are the standard extension points.
+
+### Test Discipline
+- **All tests must be green before submitting.** If a test fails due to a SQL Server limitation (not a bug you introduced), add it to `EXCLUDED_TESTS` in `testapp/settings.py` with a comment explaining why.
+- If a failure is outside the scope of your PR, ask whether to fix it or exclude it — don't leave it failing silently.
+- Always run the specific Django test modules affected by your change (e.g. `ordering`, `db_functions`, `composite_pk`) in addition to the unit tests (`python manage.py test testapp.tests`).

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -315,11 +315,14 @@ class SQLCompiler(compiler.SQLCompiler):
                                     odir = 'DESC' if expr.descending else 'ASC'
                                     o_sql = '%s %s' % (o_sql, odir)
                                 # SQL Server doesn't allow duplicate columns in ORDER BY
+                                # Extract column reference (strip ASC/DESC)
                                 col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.endswith((' ASC', ' DESC')) else o_sql
-                                col_ref_upper = col_ref.upper()
-                                if col_ref_upper in seen_columns:
+                                # Extract just the column name (after last dot) to handle both
+                                # [col] and [table].[col] referring to the same column
+                                col_name = col_ref.rsplit('.', 1)[-1].upper()
+                                if col_name in seen_columns:
                                     continue
-                                seen_columns.add(col_ref_upper)
+                                seen_columns.add(col_name)
                                 ordering.append(o_sql)
                                 params.extend(o_params)
                             offsetting_order_by = ', '.join(ordering)
@@ -402,10 +405,12 @@ class SQLCompiler(compiler.SQLCompiler):
                     # in ORDER BY. Extract column reference (without ASC/DESC)
                     # and skip duplicates.
                     col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.endswith((' ASC', ' DESC')) else o_sql
-                    col_ref_upper = col_ref.upper()
-                    if col_ref_upper in seen_columns:
+                    # Extract just the column name (after last dot) to handle both
+                    # [col] and [table].[col] referring to the same column
+                    col_name = col_ref.rsplit('.', 1)[-1].upper()
+                    if col_name in seen_columns:
                         continue
-                    seen_columns.add(col_ref_upper)
+                    seen_columns.add(col_name)
                     ordering.append(o_sql)
                     params.extend(o_params)
                 result.append('ORDER BY %s' % ', '.join(ordering))

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -303,7 +303,8 @@ class SQLCompiler(compiler.SQLCompiler):
                     if do_offset_emulation:
                         if order_by:
                             ordering = []
-                            seen_columns = set()
+                            seen_full = set()  # Full column refs (qualified or unqualified)
+                            seen_unqualified = set()  # Just column names from unqualified refs
                             for expr, (o_sql, o_params, _) in order_by:
                                 # value_expression in OVER clause cannot refer to
                                 # expressions or aliases in the select list. See:
@@ -314,15 +315,21 @@ class SQLCompiler(compiler.SQLCompiler):
                                     o_sql, _ = src.as_sql(self, self.connection)
                                     odir = 'DESC' if expr.descending else 'ASC'
                                     o_sql = '%s %s' % (o_sql, odir)
-                                # SQL Server doesn't allow duplicate columns in ORDER BY
-                                # Extract column reference (strip ASC/DESC)
+                                # SQL Server doesn't allow duplicate columns in ORDER BY.
+                                # Handle the case where [col] and [table].[col] refer to
+                                # the same column (common with composite PK ordering).
                                 col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.endswith((' ASC', ' DESC')) else o_sql
-                                # Extract just the column name (after last dot) to handle both
-                                # [col] and [table].[col] referring to the same column
-                                col_name = col_ref.rsplit('.', 1)[-1].upper()
-                                if col_name in seen_columns:
+                                col_ref_upper = col_ref.upper()
+                                is_qualified = '.' in col_ref
+                                col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
+                                # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
+                                if col_ref_upper in seen_full:
                                     continue
-                                seen_columns.add(col_name)
+                                if is_qualified and col_name in seen_unqualified:
+                                    continue
+                                seen_full.add(col_ref_upper)
+                                if not is_qualified:
+                                    seen_unqualified.add(col_name)
                                 ordering.append(o_sql)
                                 params.extend(o_params)
                             offsetting_order_by = ', '.join(ordering)
@@ -393,7 +400,8 @@ class SQLCompiler(compiler.SQLCompiler):
 
             if order_by:
                 ordering = []
-                seen_columns = set()
+                seen_full = set()  # Full column refs (qualified or unqualified)
+                seen_unqualified = set()  # Just column names from unqualified refs
                 for expr, (o_sql, o_params, _) in order_by:
                     if expr:
                         src = next(iter(expr.get_source_expressions()))
@@ -402,15 +410,20 @@ class SQLCompiler(compiler.SQLCompiler):
                             # replace it with NEWID()
                             o_sql = o_sql.replace('RAND()', 'NEWID()')
                     # SQL Server doesn't allow the same column to appear twice
-                    # in ORDER BY. Extract column reference (without ASC/DESC)
-                    # and skip duplicates.
+                    # in ORDER BY. Handle the case where [col] and [table].[col]
+                    # refer to the same column (common with composite PK ordering).
                     col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.endswith((' ASC', ' DESC')) else o_sql
-                    # Extract just the column name (after last dot) to handle both
-                    # [col] and [table].[col] referring to the same column
-                    col_name = col_ref.rsplit('.', 1)[-1].upper()
-                    if col_name in seen_columns:
+                    col_ref_upper = col_ref.upper()
+                    is_qualified = '.' in col_ref
+                    col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
+                    # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
+                    if col_ref_upper in seen_full:
                         continue
-                    seen_columns.add(col_name)
+                    if is_qualified and col_name in seen_unqualified:
+                        continue
+                    seen_full.add(col_ref_upper)
+                    if not is_qualified:
+                        seen_unqualified.add(col_name)
                     ordering.append(o_sql)
                     params.extend(o_params)
                 result.append('ORDER BY %s' % ', '.join(ordering))

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -22,6 +22,15 @@ if django.VERSION >= (3, 1):
         compile_json_path = None
 if django.VERSION >= (4, 2):
     from django.core.exceptions import EmptyResultSet, FullResultSet
+# ColPairs was introduced in Django 5.2 for composite primary key support.
+# When an OrderBy wraps a ColPairs, Django's OrderBy.as_sql() joins all
+# columns into a single comma-separated SQL string. We expand these at
+# the expression level in get_order_by() so each ORDER BY item is always
+# a single column expression.
+try:
+    from django.db.models.expressions import ColPairs
+except ImportError:
+    ColPairs = None
 
 def _as_sql_agv(self, compiler, connection):
     return self.as_sql(compiler, connection, template='%(function)s(CONVERT(float, %(field)s))')
@@ -223,6 +232,32 @@ compiler.cursor_iter = _cursor_iter
 
 class SQLCompiler(compiler.SQLCompiler):
 
+    def get_order_by(self):
+        """
+        Expand ColPairs-based OrderBy expressions into individual per-column
+        OrderBy entries before SQL compilation.
+
+        Django 5.2+ composite PKs produce OrderBy(ColPairs(...)) which
+        compiles to a single comma-separated SQL string. SQL Server doesn't
+        allow duplicate columns in ORDER BY (error 169), and expanding at
+        the expression level lets us deduplicate individual columns cleanly
+        without parsing SQL strings.
+        """
+        result = super().get_order_by()
+        if ColPairs is None:
+            return result
+        expanded = []
+        for resolved, (sql, params, is_ref) in result:
+            if isinstance(getattr(resolved, 'expression', None), ColPairs):
+                for col in resolved.expression.get_cols():
+                    order = resolved.copy()
+                    order.set_source_expressions([col])
+                    col_sql, col_params = self.compile(order)
+                    expanded.append((order, (col_sql, col_params, is_ref)))
+            else:
+                expanded.append((resolved, (sql, params, is_ref)))
+        return expanded
+
     def as_sql(self, with_limits=True, with_col_aliases=False):
         """
         Create the SQL for this query. Return the SQL string and list of
@@ -326,25 +361,24 @@ class SQLCompiler(compiler.SQLCompiler):
                                     odir = 'DESC' if expr.descending else 'ASC'
                                     o_sql = '%s %s' % (o_sql, odir)
                                 # SQL Server doesn't allow duplicate columns in ORDER BY.
+                                # ColPairs are already expanded in get_order_by(), so each
+                                # o_sql is a single column/expression.
                                 # Handle the case where [col] and [table].[col] refer to
-                                # the same column (common with composite PK ordering).
-                                # Also handle composite PK which may emit multiple comma-separated
-                                # columns in a single o_sql (e.g., "[t].[a] DESC, [t].[b] DESC").
-                                parts = [p.strip() for p in o_sql.split(',')]
-                                for part in parts:
-                                    col_ref = part.rsplit(' ', 1)[0] if part.endswith((' ASC', ' DESC')) else part
-                                    col_ref_upper = col_ref.upper()
-                                    is_qualified = '.' in col_ref
-                                    col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
-                                    # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
-                                    if col_ref_upper in seen_full:
-                                        continue
-                                    if is_qualified and col_name in seen_unqualified:
-                                        continue
-                                    seen_full.add(col_ref_upper)
-                                    if not is_qualified:
-                                        seen_unqualified.add(col_name)
-                                    ordering.append(part)
+                                # the same column.
+                                col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.rstrip().endswith(('ASC', 'DESC')) else o_sql
+                                col_ref_upper = col_ref.upper()
+                                # Only treat as a qualified column ref if it looks like
+                                # [table].[col], not a function call containing dots.
+                                is_qualified = '.' in col_ref and '(' not in col_ref
+                                col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
+                                if col_ref_upper in seen_full:
+                                    continue
+                                if is_qualified and col_name in seen_unqualified:
+                                    continue
+                                seen_full.add(col_ref_upper)
+                                if not is_qualified:
+                                    seen_unqualified.add(col_name)
+                                ordering.append(o_sql)
                                 params.extend(o_params)
                             offsetting_order_by = ', '.join(ordering)
                             order_by = []
@@ -424,29 +458,23 @@ class SQLCompiler(compiler.SQLCompiler):
                             # replace it with NEWID()
                             o_sql = o_sql.replace('RAND()', 'NEWID()')
                     # SQL Server doesn't allow the same column to appear twice
-                    # in ORDER BY. Handle the case where [col] and [table].[col]
-                    # refer to the same column (common with composite PK ordering).
-                    # Also handle composite PK which may emit multiple comma-separated
-                    # columns in a single o_sql (e.g., "[t].[a] DESC, [t].[b] DESC").
-                    parts = [p.strip() for p in o_sql.split(',')]
-                    deduped_parts = []
-                    for part in parts:
-                        col_ref = part.rsplit(' ', 1)[0] if part.endswith((' ASC', ' DESC')) else part
-                        col_ref_upper = col_ref.upper()
-                        is_qualified = '.' in col_ref
-                        col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
-                        # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
-                        if col_ref_upper in seen_full:
-                            continue
-                        if is_qualified and col_name in seen_unqualified:
-                            continue
-                        seen_full.add(col_ref_upper)
-                        if not is_qualified:
-                            seen_unqualified.add(col_name)
-                        deduped_parts.append(part)
-                    if deduped_parts:
-                        ordering.append(', '.join(deduped_parts))
-                        params.extend(o_params)
+                    # in ORDER BY. ColPairs are already expanded in
+                    # get_order_by(), so each o_sql is a single expression.
+                    # Handle the case where [col] and [table].[col] refer to
+                    # the same column.
+                    col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.rstrip().endswith(('ASC', 'DESC')) else o_sql
+                    col_ref_upper = col_ref.upper()
+                    is_qualified = '.' in col_ref and '(' not in col_ref
+                    col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
+                    if col_ref_upper in seen_full:
+                        continue
+                    if is_qualified and col_name in seen_unqualified:
+                        continue
+                    seen_full.add(col_ref_upper)
+                    if not is_qualified:
+                        seen_unqualified.add(col_name)
+                    ordering.append(o_sql)
+                    params.extend(o_params)
                 result.append('ORDER BY %s' % ', '.join(ordering))
 
                 # For subqueres with an ORDER BY clause, SQL Server also

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -318,19 +318,23 @@ class SQLCompiler(compiler.SQLCompiler):
                                 # SQL Server doesn't allow duplicate columns in ORDER BY.
                                 # Handle the case where [col] and [table].[col] refer to
                                 # the same column (common with composite PK ordering).
-                                col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.endswith((' ASC', ' DESC')) else o_sql
-                                col_ref_upper = col_ref.upper()
-                                is_qualified = '.' in col_ref
-                                col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
-                                # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
-                                if col_ref_upper in seen_full:
-                                    continue
-                                if is_qualified and col_name in seen_unqualified:
-                                    continue
-                                seen_full.add(col_ref_upper)
-                                if not is_qualified:
-                                    seen_unqualified.add(col_name)
-                                ordering.append(o_sql)
+                                # Also handle composite PK which may emit multiple comma-separated
+                                # columns in a single o_sql (e.g., "[t].[a] DESC, [t].[b] DESC").
+                                parts = [p.strip() for p in o_sql.split(',')]
+                                for part in parts:
+                                    col_ref = part.rsplit(' ', 1)[0] if part.endswith((' ASC', ' DESC')) else part
+                                    col_ref_upper = col_ref.upper()
+                                    is_qualified = '.' in col_ref
+                                    col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
+                                    # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
+                                    if col_ref_upper in seen_full:
+                                        continue
+                                    if is_qualified and col_name in seen_unqualified:
+                                        continue
+                                    seen_full.add(col_ref_upper)
+                                    if not is_qualified:
+                                        seen_unqualified.add(col_name)
+                                    ordering.append(part)
                                 params.extend(o_params)
                             offsetting_order_by = ', '.join(ordering)
                             order_by = []
@@ -412,20 +416,27 @@ class SQLCompiler(compiler.SQLCompiler):
                     # SQL Server doesn't allow the same column to appear twice
                     # in ORDER BY. Handle the case where [col] and [table].[col]
                     # refer to the same column (common with composite PK ordering).
-                    col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.endswith((' ASC', ' DESC')) else o_sql
-                    col_ref_upper = col_ref.upper()
-                    is_qualified = '.' in col_ref
-                    col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
-                    # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
-                    if col_ref_upper in seen_full:
-                        continue
-                    if is_qualified and col_name in seen_unqualified:
-                        continue
-                    seen_full.add(col_ref_upper)
-                    if not is_qualified:
-                        seen_unqualified.add(col_name)
-                    ordering.append(o_sql)
-                    params.extend(o_params)
+                    # Also handle composite PK which may emit multiple comma-separated
+                    # columns in a single o_sql (e.g., "[t].[a] DESC, [t].[b] DESC").
+                    parts = [p.strip() for p in o_sql.split(',')]
+                    deduped_parts = []
+                    for part in parts:
+                        col_ref = part.rsplit(' ', 1)[0] if part.endswith((' ASC', ' DESC')) else part
+                        col_ref_upper = col_ref.upper()
+                        is_qualified = '.' in col_ref
+                        col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
+                        # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
+                        if col_ref_upper in seen_full:
+                            continue
+                        if is_qualified and col_name in seen_unqualified:
+                            continue
+                        seen_full.add(col_ref_upper)
+                        if not is_qualified:
+                            seen_unqualified.add(col_name)
+                        deduped_parts.append(part)
+                    if deduped_parts:
+                        ordering.append(', '.join(deduped_parts))
+                        params.extend(o_params)
                 result.append('ORDER BY %s' % ', '.join(ordering))
 
                 # For subqueres with an ORDER BY clause, SQL Server also

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -303,6 +303,7 @@ class SQLCompiler(compiler.SQLCompiler):
                     if do_offset_emulation:
                         if order_by:
                             ordering = []
+                            seen_columns = set()
                             for expr, (o_sql, o_params, _) in order_by:
                                 # value_expression in OVER clause cannot refer to
                                 # expressions or aliases in the select list. See:
@@ -313,6 +314,12 @@ class SQLCompiler(compiler.SQLCompiler):
                                     o_sql, _ = src.as_sql(self, self.connection)
                                     odir = 'DESC' if expr.descending else 'ASC'
                                     o_sql = '%s %s' % (o_sql, odir)
+                                # SQL Server doesn't allow duplicate columns in ORDER BY
+                                col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.endswith((' ASC', ' DESC')) else o_sql
+                                col_ref_upper = col_ref.upper()
+                                if col_ref_upper in seen_columns:
+                                    continue
+                                seen_columns.add(col_ref_upper)
                                 ordering.append(o_sql)
                                 params.extend(o_params)
                             offsetting_order_by = ', '.join(ordering)
@@ -383,6 +390,7 @@ class SQLCompiler(compiler.SQLCompiler):
 
             if order_by:
                 ordering = []
+                seen_columns = set()
                 for expr, (o_sql, o_params, _) in order_by:
                     if expr:
                         src = next(iter(expr.get_source_expressions()))
@@ -390,6 +398,14 @@ class SQLCompiler(compiler.SQLCompiler):
                             # ORDER BY RAND() doesn't return rows in random order
                             # replace it with NEWID()
                             o_sql = o_sql.replace('RAND()', 'NEWID()')
+                    # SQL Server doesn't allow the same column to appear twice
+                    # in ORDER BY. Extract column reference (without ASC/DESC)
+                    # and skip duplicates.
+                    col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.endswith((' ASC', ' DESC')) else o_sql
+                    col_ref_upper = col_ref.upper()
+                    if col_ref_upper in seen_columns:
+                        continue
+                    seen_columns.add(col_ref_upper)
                     ordering.append(o_sql)
                     params.extend(o_params)
                 result.append('ORDER BY %s' % ', '.join(ordering))

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -68,8 +68,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # CompositePrimaryKey support is only available in Django 5.2 and later
     supports_composite_primary_keys = django_version >= (5, 2)
     if django_version >= (5, 2) and isinstance(CompositePrimaryKey, type):
-       # Set fallback tupple lookup support
-       supports_tuple_lookups = False
+        # SQL Server doesn't support native tuple lookups.
+        supports_tuple_lookups = False
+        if django_version >= (5, 2, 4):
+            supports_tuple_comparison_against_subquery = False
     @cached_property
     def has_zoneinfo_database(self):
         with self.connection.cursor() as cursor:

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -20,6 +20,7 @@ from django.db.models.sql.query import Query
 if VERSION >= (5, 2):
     from django.db.models import Value
     from django.db.models.functions import JSONArray
+    from django.db.models.fields.composite import CompositePrimaryKey
 
 if VERSION >= (3, 1):
     from django.db.models.fields.json import (
@@ -468,7 +469,12 @@ def bulk_update_with_default(self, objs, fields, batch_size=None, default=None):
     fields = [self.model._meta.get_field(name) for name in fields]
     if any(not f.concrete or f.many_to_many for f in fields):
         raise ValueError('bulk_update() can only be used with concrete fields.')
-    if any(f.primary_key for f in fields):
+    # Check for primary key fields, including composite PK fields in Django 5.2+
+    pk_field_names = set()
+    if VERSION >= (5, 2) and isinstance(self.model._meta.pk, CompositePrimaryKey):
+        # For composite PKs, get all field names that are part of the PK
+        pk_field_names = set(self.model._meta.pk.field_names)
+    if any(f.primary_key or f.name in pk_field_names for f in fields):
         raise ValueError('bulk_update() cannot be used with primary key fields.')
     if not objs:
         return 0

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -2,20 +2,25 @@
 # Licensed under the BSD license.
 
 import json
+import itertools
 
 from django import VERSION
 from django.core import validators
 from django.db import NotSupportedError, connections, transaction
-from django.db.models import BooleanField, CheckConstraint, Value
-from django.db.models.expressions import Case, Exists, OrderBy, When, Window
+from django.db.models import BooleanField, CheckConstraint, Q, Value
+from django.db.models.expressions import Case, Exists, OrderBy, Subquery, When, Window
 from django.db.models.fields import BinaryField, Field
 from django.db.models.functions import Cast, NthValue, MD5, SHA1, SHA224, SHA256, SHA384, SHA512
 from django.db.models.functions.datetime import Now
 from django.db.models.functions.math import ATan2, Ln, Log, Mod, Round, Degrees, Radians, Power
 from django.db.models.functions.text import Replace
-from django.db.models.lookups import In, Lookup
+from django.db.models.lookups import Exact, In, Lookup
 from django.db.models.query import QuerySet
 from django.db.models.sql.query import Query
+if VERSION >= (5, 2):
+    from django.db.models.expressions import ColPairs
+else:
+    ColPairs = None
 # import value and JSONArray for Django 5.2+
 if VERSION >= (5, 2):
     from django.db.models import Value
@@ -229,6 +234,95 @@ def mssql_split_parameter_list_as_sql(self, compiler, connection):
     in_clause = lhs + ' IN ' + '(SELECT params from #Temp_params)'
 
     return in_clause, ()
+
+
+def _tuple_lookup_rhs_query(rhs):
+    if isinstance(rhs, Query):
+        return rhs
+    if isinstance(rhs, Subquery):
+        return rhs.query
+    return None
+
+
+def _tuple_lookup_exists_sql(lhs, rhs_query, compiler, connection):
+    rhs_exprs = itertools.chain.from_iterable(
+        (
+            select_expr
+            if ColPairs is not None and isinstance((select_expr := select[0]), ColPairs)
+            else [select_expr]
+        )
+        for select in rhs_query.get_compiler(connection=connection).get_select()[0]
+    )
+    query = rhs_query.clone()
+    query.add_q(Q(*[Exact(col, val) for col, val in zip(lhs, rhs_exprs)]))
+    return compiler.compile(Exists(query))
+
+
+if VERSION >= (5, 2, 4):
+    from django.db.models.fields.tuple_lookups import (
+        TupleExact,
+        TupleGreaterThan,
+        TupleGreaterThanOrEqual,
+        TupleIn,
+        TupleLessThan,
+        TupleLessThanOrEqual,
+    )
+
+    tuple_exact_get_fallback_sql = TupleExact.get_fallback_sql
+    tuple_in_get_fallback_sql = TupleIn.get_fallback_sql
+    tuple_gt_get_fallback_sql = TupleGreaterThan.get_fallback_sql
+    tuple_gte_get_fallback_sql = TupleGreaterThanOrEqual.get_fallback_sql
+    tuple_lt_get_fallback_sql = TupleLessThan.get_fallback_sql
+    tuple_lte_get_fallback_sql = TupleLessThanOrEqual.get_fallback_sql
+
+    def _sqlserver_tuple_comparison_get_fallback_sql(self, compiler, connection, original):
+        if connection.vendor == 'microsoft' and _tuple_lookup_rhs_query(self.rhs) is not None:
+            lookup = self.lookup_name
+            raise NotSupportedError(
+                f'"{lookup}" cannot be used to target composite fields through subqueries on this backend'
+            )
+        return original(self, compiler, connection)
+
+    def sqlserver_tuple_exact_get_fallback_sql(self, compiler, connection):
+        if connection.vendor == 'microsoft':
+            rhs_query = _tuple_lookup_rhs_query(self.rhs)
+            if rhs_query is not None:
+                return _tuple_lookup_exists_sql(self.lhs, rhs_query, compiler, connection)
+        return tuple_exact_get_fallback_sql(self, compiler, connection)
+
+    def sqlserver_tuple_in_get_fallback_sql(self, compiler, connection):
+        if connection.vendor == 'microsoft':
+            rhs_query = _tuple_lookup_rhs_query(self.rhs)
+            if rhs_query is not None:
+                return _tuple_lookup_exists_sql(self.lhs, rhs_query, compiler, connection)
+        return tuple_in_get_fallback_sql(self, compiler, connection)
+
+    def sqlserver_tuple_gt_get_fallback_sql(self, compiler, connection):
+        return _sqlserver_tuple_comparison_get_fallback_sql(
+            self, compiler, connection, tuple_gt_get_fallback_sql
+        )
+
+    def sqlserver_tuple_gte_get_fallback_sql(self, compiler, connection):
+        return _sqlserver_tuple_comparison_get_fallback_sql(
+            self, compiler, connection, tuple_gte_get_fallback_sql
+        )
+
+    def sqlserver_tuple_lt_get_fallback_sql(self, compiler, connection):
+        return _sqlserver_tuple_comparison_get_fallback_sql(
+            self, compiler, connection, tuple_lt_get_fallback_sql
+        )
+
+    def sqlserver_tuple_lte_get_fallback_sql(self, compiler, connection):
+        return _sqlserver_tuple_comparison_get_fallback_sql(
+            self, compiler, connection, tuple_lte_get_fallback_sql
+        )
+
+    TupleExact.get_fallback_sql = sqlserver_tuple_exact_get_fallback_sql
+    TupleIn.get_fallback_sql = sqlserver_tuple_in_get_fallback_sql
+    TupleGreaterThan.get_fallback_sql = sqlserver_tuple_gt_get_fallback_sql
+    TupleGreaterThanOrEqual.get_fallback_sql = sqlserver_tuple_gte_get_fallback_sql
+    TupleLessThan.get_fallback_sql = sqlserver_tuple_lt_get_fallback_sql
+    TupleLessThanOrEqual.get_fallback_sql = sqlserver_tuple_lte_get_fallback_sql
 
 
 def unquote_json_rhs(rhs_params):

--- a/test.sh
+++ b/test.sh
@@ -12,6 +12,12 @@ git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 git checkout $DJANGO_VERSION
 pip install -r tests/requirements/py3.txt
 
+# composite_pk tests were introduced in Django 5.2
+COMPOSITE_PK_TESTS=""
+if python -c "import django; exit(0 if django.VERSION >= (5, 2) else 1)"; then
+    COMPOSITE_PK_TESTS="composite_pk"
+fi
+
 coverage run tests/runtests.py --settings=testapp.settings --noinput \
     aggregation \
     aggregation_regress \
@@ -19,7 +25,7 @@ coverage run tests/runtests.py --settings=testapp.settings --noinput \
     backends \
     basic \
     bulk_create \
-    composite_pk \
+    $COMPOSITE_PK_TESTS \
     constraints \
     custom_columns \
     custom_lookups \

--- a/test.sh
+++ b/test.sh
@@ -19,6 +19,7 @@ coverage run tests/runtests.py --settings=testapp.settings --noinput \
     backends \
     basic \
     bulk_create \
+    composite_pk \
     constraints \
     custom_columns \
     custom_lookups \

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -420,45 +420,17 @@ if VERSION >= (6, 0):
         'model_fields.test_jsonfield.TestQuerying.test_usage_in_subquery',
     ])
 
-# Django 5.2 specific exclusions - tuple lookups not supported in SQL Server
+# Django 5.2 specific exclusions
 # These are good candidates for community contributions - see GitHub issues
 if VERSION >= (5, 2):
     EXCLUDED_TESTS.extend([
-        # Composite PK tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
-        # This uses pk__in with composite PK which generates unsupported tuple lookup SQL
-        'composite_pk.test_filter.CompositePKFilterTests.test_explicit_subquery',
-        # SQL Server doesn't support tuple/row comparisons (WHERE (a, b) = (x, y))
-        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_exact',
-        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_comparison',
         # SQL Server parameter splitting uses temp tables, resulting in different query count
         'composite_pk.tests.CompositePKTests.test_in_bulk_batching',
-        
-        # Tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
-        # TODO: Implement tuple lookup handling for SQL Server compatibility
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_exact',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gt',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gte',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_in',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lt',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lte',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_tuple_in_subquery',
-        'foreign_object.test_agnostic_order_trimjoin.TestLookupQuery.test_deep_mixed_backward',
         
         # inspectdb tests that expect specific table structures in inspectdb_special/pascal schemas
         'inspectdb.tests.InspectDBTestCase.test_custom_normalize_table_name',
         'inspectdb.tests.InspectDBTestCase.test_special_column_name_introspection', 
         'inspectdb.tests.InspectDBTestCase.test_table_name_introspection',
-        
-        # Multi-column foreign key tests with tuple lookups - also affected by SQL Server limitations
-        # TODO: Fix tuple lookup generation for multi-column FKs 
-        'foreign_object.tests.MultiColumnFKTests.test_double_nested_query',
-        'foreign_object.tests.MultiColumnFKTests.test_forward_in_lookup_filters_correctly',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_forward',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_hidden_forward',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_reverse',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_forward_works',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_reverse_works',
-        'foreign_object.tests.MultiColumnFKTests.test_reverse_query_returns_correct_result',
         
         # JSONField special character handling - SQL Server specific syntax issues
         # TODO: Fix JSONField key escaping for special characters
@@ -487,6 +459,34 @@ if VERSION >= (5, 2):
         # TODO: Fix JSONField update with CASE WHEN handling
         'expressions.tests.BasicExpressionsTests.test_update_jsonfield_case_when_key_is_null',
         
+    ])
+
+if VERSION >= (5, 2) and VERSION < (5, 2, 4):
+    EXCLUDED_TESTS.extend([
+        # Composite PK tuple subquery fallback fix landed in Django 5.2.4.
+        'composite_pk.test_filter.CompositePKFilterTests.test_explicit_subquery',
+        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_exact',
+        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_comparison',
+
+        # Tuple lookup tests kept excluded for Django <5.2.4.
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_exact',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gt',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gte',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_in',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lt',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lte',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_tuple_in_subquery',
+        'foreign_object.test_agnostic_order_trimjoin.TestLookupQuery.test_deep_mixed_backward',
+
+        # Multi-column foreign key tuple-lookup tests kept excluded for Django <5.2.4.
+        'foreign_object.tests.MultiColumnFKTests.test_double_nested_query',
+        'foreign_object.tests.MultiColumnFKTests.test_forward_in_lookup_filters_correctly',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_forward',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_hidden_forward',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_reverse',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_forward_works',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_reverse_works',
+        'foreign_object.tests.MultiColumnFKTests.test_reverse_query_returns_correct_result',
     ])
 
 REGEX_TESTS = [

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -319,6 +319,10 @@ if VERSION >= (5, 1):
 # These are good candidates for community contributions - see GitHub issues
 if VERSION >= (5, 2):
     EXCLUDED_TESTS.extend([
+        # Composite PK tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
+        # This uses pk__in with composite PK which generates unsupported tuple lookup SQL
+        'composite_pk.test_filter.CompositePKFilterTests.test_explicit_subquery',
+        
         # Tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
         # TODO: Implement tuple lookup handling for SQL Server compatibility
         'foreign_object.test_tuple_lookups.TupleLookupsTests.test_exact',

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -427,6 +427,11 @@ if VERSION >= (5, 2):
         # Composite PK tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
         # This uses pk__in with composite PK which generates unsupported tuple lookup SQL
         'composite_pk.test_filter.CompositePKFilterTests.test_explicit_subquery',
+        # SQL Server doesn't support tuple/row comparisons (WHERE (a, b) = (x, y))
+        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_exact',
+        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_comparison',
+        # SQL Server parameter splitting uses temp tables, resulting in different query count
+        'composite_pk.tests.CompositePKTests.test_in_bulk_batching',
         
         # Tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
         # TODO: Implement tuple lookup handling for SQL Server compatibility

--- a/testapp/tests/test_composite_pk_and_ordering.py
+++ b/testapp/tests/test_composite_pk_and_ordering.py
@@ -8,7 +8,7 @@ Tests for:
 """
 
 from django import VERSION
-from django.db import connection, models
+from django.db import NotSupportedError, connection, models
 from django.test import TestCase, TransactionTestCase
 
 from ..models import Author, Post
@@ -135,6 +135,7 @@ class BulkUpdateValidationTests(TestCase):
 # Django 5.2+ specific tests for composite PK
 if VERSION >= (5, 2):
     from django.db.models import CompositePrimaryKey
+    from django.db.models import OuterRef, Subquery
     from django.db.models.fields.composite import CompositePrimaryKey as CompositePrimaryKeyField
 
     class CompositePKValidationTests(TestCase):
@@ -282,3 +283,73 @@ if VERSION >= (5, 2):
                 self.TenantUser.objects.bulk_update(users, ['user_id'])
             
             self.assertIn('primary key', str(cm.exception).lower())
+
+    if VERSION >= (5, 2, 4):
+        class CompositePKTupleSubqueryLookupTests(TransactionTestCase):
+            @classmethod
+            def setUpClass(cls):
+                super().setUpClass()
+                with connection.cursor() as cursor:
+                    cursor.execute('''
+                        IF OBJECT_ID('testapp_tuplelookup_user', 'U') IS NOT NULL
+                            DROP TABLE testapp_tuplelookup_user
+                    ''')
+                    cursor.execute('''
+                        CREATE TABLE testapp_tuplelookup_user (
+                            tenant_id INT NOT NULL,
+                            user_id INT NOT NULL,
+                            name NVARCHAR(100) NOT NULL,
+                            PRIMARY KEY (tenant_id, user_id)
+                        )
+                    ''')
+
+            @classmethod
+            def tearDownClass(cls):
+                with connection.cursor() as cursor:
+                    cursor.execute('''
+                        IF OBJECT_ID('testapp_tuplelookup_user', 'U') IS NOT NULL
+                            DROP TABLE testapp_tuplelookup_user
+                    ''')
+                super().tearDownClass()
+
+            def setUp(self):
+                class TupleLookupUser(models.Model):
+                    pk = CompositePrimaryKey('tenant_id', 'user_id')
+                    tenant_id = models.IntegerField()
+                    user_id = models.IntegerField()
+                    name = models.CharField(max_length=100)
+
+                    class Meta:
+                        app_label = 'testapp'
+                        db_table = 'testapp_tuplelookup_user'
+                        managed = False
+
+                self.TupleLookupUser = TupleLookupUser
+
+                with connection.cursor() as cursor:
+                    cursor.execute('DELETE FROM testapp_tuplelookup_user')
+                    cursor.execute('''
+                        INSERT INTO testapp_tuplelookup_user (tenant_id, user_id, name)
+                        VALUES (1, 1, 'Alice'),
+                               (1, 2, 'Bob'),
+                               (2, 1, 'Charlie')
+                    ''')
+
+            def test_pk_in_subquery_uses_tuple_fallback(self):
+                subquery = Subquery(
+                    self.TupleLookupUser.objects.filter(tenant_id=1).values('pk')
+                )
+                queryset = self.TupleLookupUser.objects.filter(pk__in=subquery).order_by('tenant_id', 'user_id')
+                self.assertEqual(list(queryset.values_list('pk', flat=True)), [(1, 1), (1, 2)])
+
+            def test_pk_exact_subquery_uses_tuple_fallback(self):
+                queryset_rhs = self.TupleLookupUser.objects.filter(pk=OuterRef('pk')).values('pk')[:1]
+                self.assertEqual(self.TupleLookupUser.objects.filter(pk=queryset_rhs).count(), 3)
+
+            def test_pk_comparison_subquery_not_supported(self):
+                queryset_rhs = self.TupleLookupUser.objects.filter(pk=OuterRef('pk')).values('pk')[:1]
+                with self.assertRaisesMessage(
+                    NotSupportedError,
+                    '"gt" cannot be used to target composite fields through subqueries on this backend',
+                ):
+                    self.TupleLookupUser.objects.filter(pk__gt=queryset_rhs).count()

--- a/testapp/tests/test_composite_pk_and_ordering.py
+++ b/testapp/tests/test_composite_pk_and_ordering.py
@@ -1,0 +1,284 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the BSD license.
+
+"""
+Tests for:
+1. ORDER BY deduplication in compiler.py - SQL Server doesn't allow duplicate columns
+2. Composite PK bulk_update validation in functions.py
+"""
+
+from django import VERSION
+from django.db import connection, models
+from django.test import TestCase, TransactionTestCase
+
+from ..models import Author, Post
+
+
+class OrderByDeduplicationTests(TestCase):
+    """
+    Test that the ORDER BY deduplication logic works correctly.
+    SQL Server error: "A column has been specified more than once in the order by list"
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.author1 = Author.objects.create(name='Alice')
+        cls.author2 = Author.objects.create(name='Bob')
+        cls.author3 = Author.objects.create(name='Charlie')
+
+    def test_simple_order_by(self):
+        """Basic ORDER BY should work."""
+        authors = list(Author.objects.order_by('name'))
+        self.assertEqual([a.name for a in authors], ['Alice', 'Bob', 'Charlie'])
+
+    def test_order_by_desc(self):
+        """ORDER BY DESC should work."""
+        authors = list(Author.objects.order_by('-name'))
+        self.assertEqual([a.name for a in authors], ['Charlie', 'Bob', 'Alice'])
+
+    def test_order_by_pk(self):
+        """ORDER BY pk should work."""
+        authors = list(Author.objects.order_by('pk'))
+        self.assertEqual(len(authors), 3)
+
+    def test_order_by_pk_desc(self):
+        """ORDER BY -pk should work."""
+        authors = list(Author.objects.order_by('-pk'))
+        self.assertEqual(len(authors), 3)
+
+    def test_order_by_with_values(self):
+        """ORDER BY with values() should work."""
+        names = list(Author.objects.order_by('name').values_list('name', flat=True))
+        self.assertEqual(names, ['Alice', 'Bob', 'Charlie'])
+
+    def test_order_by_multiple_fields(self):
+        """ORDER BY with multiple different fields should work."""
+        authors = list(Author.objects.order_by('name', 'pk'))
+        self.assertEqual(len(authors), 3)
+
+    def test_raw_sql_with_single_column_order_by(self):
+        """Raw SQL with single column ORDER BY should work."""
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"SELECT name FROM {Author._meta.db_table} ORDER BY name ASC"
+            )
+            results = cursor.fetchall()
+            self.assertEqual(len(results), 3)
+
+
+class OrderByDeduplicationRawSQLTests(TransactionTestCase):
+    """
+    Test raw SQL cases that would fail without deduplication.
+    Using TransactionTestCase to ensure isolation.
+    """
+
+    def test_duplicate_column_in_order_by_fails_in_raw_sql(self):
+        """
+        This test documents that SQL Server rejects duplicate columns in ORDER BY.
+        Raw SQL: ORDER BY name ASC, name DESC - should fail.
+        """
+        Author.objects.create(name='Test')
+        
+        with self.assertRaises(Exception):
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"SELECT * FROM {Author._meta.db_table} ORDER BY name ASC, name DESC"
+                )
+
+
+class BulkUpdateValidationTests(TestCase):
+    """
+    Test that bulk_update properly validates fields.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.author1 = Author.objects.create(name='Alice')
+        cls.author2 = Author.objects.create(name='Bob')
+
+    def test_bulk_update_regular_field(self):
+        """bulk_update with regular fields should work."""
+        self.author1.name = 'Alice Updated'
+        self.author2.name = 'Bob Updated'
+        
+        Author.objects.bulk_update([self.author1, self.author2], ['name'])
+        
+        self.author1.refresh_from_db()
+        self.author2.refresh_from_db()
+        self.assertEqual(self.author1.name, 'Alice Updated')
+        self.assertEqual(self.author2.name, 'Bob Updated')
+
+    def test_bulk_update_pk_field_raises_error(self):
+        """bulk_update with PK field should raise ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            Author.objects.bulk_update([self.author1], ['id'])
+        
+        self.assertIn('primary key', str(cm.exception).lower())
+
+    def test_bulk_update_empty_fields_raises_error(self):
+        """bulk_update with empty fields should raise ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            Author.objects.bulk_update([self.author1], [])
+        
+        self.assertIn('field names must be given', str(cm.exception).lower())
+
+    def test_bulk_update_with_none_pk_raises_error(self):
+        """bulk_update with unsaved objects should raise ValueError."""
+        unsaved_author = Author(name='Unsaved')
+        
+        with self.assertRaises(ValueError) as cm:
+            Author.objects.bulk_update([unsaved_author], ['name'])
+        
+        self.assertIn('primary key set', str(cm.exception).lower())
+
+
+# Django 5.2+ specific tests for composite PK
+if VERSION >= (5, 2):
+    from django.db.models import CompositePrimaryKey
+    from django.db.models.fields.composite import CompositePrimaryKey as CompositePrimaryKeyField
+
+    class CompositePKValidationTests(TestCase):
+        """
+        Test composite PK validation logic for bulk_update.
+        These tests require Django 5.2+.
+        """
+
+        def test_composite_pk_field_names_detection(self):
+            """Verify we can correctly detect fields that are part of a composite PK."""
+            cpk = CompositePrimaryKey('tenant_id', 'user_id')
+            
+            pk_field_names = set()
+            if isinstance(cpk, CompositePrimaryKeyField):
+                pk_field_names = set(cpk.field_names)
+            
+            self.assertEqual(pk_field_names, {'tenant_id', 'user_id'})
+
+        def test_composite_pk_validation_logic(self):
+            """Test the validation logic used in bulk_update."""
+            class MockField:
+                def __init__(self, name, primary_key=False):
+                    self.name = name
+                    self.primary_key = primary_key
+
+            pk_field_names = {'tenant_id', 'user_id'}
+            
+            # Regular field - should be allowed
+            regular_field = MockField('name', primary_key=False)
+            is_pk_field = regular_field.primary_key or regular_field.name in pk_field_names
+            self.assertFalse(is_pk_field)
+            
+            # Field that's part of composite PK - should NOT be allowed
+            cpk_field = MockField('tenant_id', primary_key=False)
+            is_pk_field = cpk_field.primary_key or cpk_field.name in pk_field_names
+            self.assertTrue(is_pk_field)
+            
+            # Traditional single PK field - should NOT be allowed
+            traditional_pk = MockField('id', primary_key=True)
+            is_pk_field = traditional_pk.primary_key or traditional_pk.name in pk_field_names
+            self.assertTrue(is_pk_field)
+
+        def test_non_composite_pk_has_empty_field_names(self):
+            """For regular models, pk_field_names should be empty."""
+            pk_field_names = set()
+            
+            if isinstance(Author._meta.pk, CompositePrimaryKeyField):
+                pk_field_names = set(Author._meta.pk.field_names)
+            
+            self.assertEqual(pk_field_names, set())
+
+    class CompositePKModelTests(TransactionTestCase):
+        """
+        Test with actual composite PK model in the database.
+        """
+
+        @classmethod
+        def setUpClass(cls):
+            super().setUpClass()
+            # Create the test table
+            with connection.cursor() as cursor:
+                cursor.execute('''
+                    IF OBJECT_ID('testapp_tenantuser', 'U') IS NOT NULL
+                        DROP TABLE testapp_tenantuser
+                ''')
+                cursor.execute('''
+                    CREATE TABLE testapp_tenantuser (
+                        tenant_id INT NOT NULL,
+                        user_id INT NOT NULL,
+                        name NVARCHAR(100) NOT NULL,
+                        email NVARCHAR(100) NOT NULL,
+                        PRIMARY KEY (tenant_id, user_id)
+                    )
+                ''')
+
+        @classmethod
+        def tearDownClass(cls):
+            with connection.cursor() as cursor:
+                cursor.execute('''
+                    IF OBJECT_ID('testapp_tenantuser', 'U') IS NOT NULL
+                        DROP TABLE testapp_tenantuser
+                ''')
+            super().tearDownClass()
+
+        def setUp(self):
+            # Define model dynamically
+            class TenantUser(models.Model):
+                pk = CompositePrimaryKey('tenant_id', 'user_id')
+                tenant_id = models.IntegerField()
+                user_id = models.IntegerField()
+                name = models.CharField(max_length=100)
+                email = models.CharField(max_length=100)
+
+                class Meta:
+                    app_label = 'testapp'
+                    db_table = 'testapp_tenantuser'
+                    managed = False
+
+            self.TenantUser = TenantUser
+            
+            # Insert test data
+            with connection.cursor() as cursor:
+                cursor.execute('DELETE FROM testapp_tenantuser')
+                cursor.execute('''
+                    INSERT INTO testapp_tenantuser (tenant_id, user_id, name, email)
+                    VALUES (1, 1, 'Alice', 'alice@example.com'),
+                           (1, 2, 'Bob', 'bob@example.com'),
+                           (2, 1, 'Charlie', 'charlie@example.com')
+                ''')
+
+        def test_model_has_composite_pk(self):
+            """Verify the model has a composite PK."""
+            self.assertIsInstance(self.TenantUser._meta.pk, CompositePrimaryKeyField)
+            self.assertEqual(self.TenantUser._meta.pk.field_names, ('tenant_id', 'user_id'))
+
+        def test_bulk_update_regular_field_on_composite_pk_model(self):
+            """bulk_update with regular field should work on composite PK model."""
+            users = list(self.TenantUser.objects.all())
+            self.assertEqual(len(users), 3)
+            
+            for u in users:
+                u.email = u.email.replace('@example.com', '@test.com')
+            
+            self.TenantUser.objects.bulk_update(users, ['email'])
+            
+            # Verify the update
+            updated_users = list(self.TenantUser.objects.all())
+            for u in updated_users:
+                self.assertIn('@test.com', u.email)
+
+        def test_bulk_update_composite_pk_field_tenant_id_raises_error(self):
+            """bulk_update with composite PK field tenant_id should raise ValueError."""
+            users = list(self.TenantUser.objects.all())
+            
+            with self.assertRaises(ValueError) as cm:
+                self.TenantUser.objects.bulk_update(users, ['tenant_id'])
+            
+            self.assertIn('primary key', str(cm.exception).lower())
+
+        def test_bulk_update_composite_pk_field_user_id_raises_error(self):
+            """bulk_update with composite PK field user_id should raise ValueError."""
+            users = list(self.TenantUser.objects.all())
+            
+            with self.assertRaises(ValueError) as cm:
+                self.TenantUser.objects.bulk_update(users, ['user_id'])
+            
+            self.assertIn('primary key', str(cm.exception).lower())


### PR DESCRIPTION
This pull request introduces comprehensive improvements for supporting Django 5.2+ composite primary keys and tuple lookups in the SQL Server backend. The main focus is on correctly handling composite PKs, deduplicating ORDER BY columns, and providing compatibility and fallback logic for tuple lookups, especially in subqueries. It also updates test exclusions and documentation to reflect these new behaviors and limitations.

**Composite Primary Key & Tuple Lookup Support**

* Added expansion logic for `ColPairs` in `SQLCompiler.get_order_by()` to ensure each ORDER BY item is a single column, preventing SQL Server errors from duplicate columns and enabling deduplication at the expression level. [[1]](diffhunk://#diff-c58a8a75a69872ba4b7365cb2d4c7cc319190fbfad942a2fa982177342e71d4dR25-R33) [[2]](diffhunk://#diff-c58a8a75a69872ba4b7365cb2d4c7cc319190fbfad942a2fa982177342e71d4dR235-R260)
* Implemented fallback and compatibility logic for tuple lookups in `mssql/functions.py`, including custom handling for tuple comparisons against subqueries and patching Django's tuple lookup classes for SQL Server.
* Improved primary key detection in `bulk_update_with_default` to handle composite PKs, preventing accidental updates to PK fields.
* Updated `mssql/features.py` to set `supports_tuple_comparison_against_subquery` to `False` for Django 5.2.4+ and clarified SQL Server's limitations for tuple lookups.

**ORDER BY Deduplication**

* Enhanced deduplication logic in `as_sql()` for ORDER BY clauses, handling both qualified and unqualified column references, and ensuring that duplicate columns (including `[col]` and `[table].[col]`) are excluded. [[1]](diffhunk://#diff-c58a8a75a69872ba4b7365cb2d4c7cc319190fbfad942a2fa982177342e71d4dR351-R352) [[2]](diffhunk://#diff-c58a8a75a69872ba4b7365cb2d4c7cc319190fbfad942a2fa982177342e71d4dR363-R380) [[3]](diffhunk://#diff-c58a8a75a69872ba4b7365cb2d4c7cc319190fbfad942a2fa982177342e71d4dR451-R475)

**Testing & Exclusions**

* Updated test exclusions in `testapp/settings.py` to reflect new tuple lookup and composite PK limitations, with more granular exclusions based on Django version (especially <5.2.4). [[1]](diffhunk://#diff-68575e543cadfd63feb4572a74caf8aee4a1ab8c5dd0a5dbdc09ab1bc85b8e09L423-L453) [[2]](diffhunk://#diff-68575e543cadfd63feb4572a74caf8aee4a1ab8c5dd0a5dbdc09ab1bc85b8e09R464-R491)
* Modified `test.sh` to conditionally include composite PK tests only for Django 5.2+, improving CI reliability and coverage.

**Documentation & Workflow**

* Added detailed development workflow rules and guidelines in `.github/copilot-instructions.md`, including git hygiene, fix quality, and test discipline, to help contributors avoid common pitfalls and maintain code quality.