### PR TITLE
FIX: Test Exclusions for 5.2 & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ We hope you enjoy using the MSSQL-Django 3rd party backend.
 
 ## Features
 
--  Supports Django 3.2, 4.0, 4.1, 4.2 and 5.0
+-  Supports Django 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, and 5.2
+   - **Django 5.0 and below**: Full production support
+   - **Django 5.1**: Supported with minor limitations (composite primary key inspectdb)
+   - **Django 5.2**: Supported with enhanced SQL Server compatibility features and documented limitations (see Django 5.2 Specific Limitations section below)
 -  Tested on Microsoft SQL Server 2016, 2017, 2019, 2022
 -  Passes most of the tests of the Django test suite
+-  Enhanced SQL Server compatibility with automatic schema creation and improved identifier quoting
 -  Compatible with
    [Micosoft ODBC Driver for SQL Server](https://docs.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server),
    [SQL Server Native Client](https://msdn.microsoft.com/en-us/library/ms131321(v=sql.120).aspx),
@@ -272,6 +276,42 @@ The following features are currently not fully supported:
 - Filtered index
 - Date extract function
 - Bulk insert into a table with a trigger and returning the rows inserted
+
+### Django 5.1 Specific Limitations
+
+Django 5.1 introduces composite primary key support which has limited compatibility with SQL Server:
+- **inspectdb command**: Cannot properly inspect tables with composite primary keys
+- **Backend debugging**: SQL execution wrapper debug functionality may not work correctly
+- **Schema operations**: Some field unique constraint removal operations may have issues
+- Most other Django 5.1 features work correctly with SQL Server
+
+### Django 5.2 Specific Limitations
+
+Django 5.2 introduces new features that may cause regressions for existing Django 5.0+ applications. This release includes enhanced SQL Server compatibility for Django 5.2, with automatic schema creation and improved identifier quoting. The following limitations remain:
+
+**Critical Limitations (May Affect Common Use Cases):**
+- **Tuple lookups**: Queries like `Model.objects.filter((col1, col2)__in=[(val1, val2)])` will fail with SQL syntax errors as SQL Server doesn't support `(col1, col2) IN (...)` syntax
+- **Multi-column foreign key relationships**: Complex queries involving foreign keys with multiple columns may fail in Django 5.2 due to tuple lookup generation
+- **JSONField with special characters**: JSONField lookups involving special characters (quotes, emojis, escape sequences) may generate invalid SQL
+- **JSONField bulk updates**: Bulk update operations on JSONField with null handling may fail
+
+**Moderate Impact:**
+- **Complex aggregations**: Some aggregation queries with filtered references and subqueries may not work correctly
+- **Prefetch operations**: `prefetch_related()` operations on multi-column foreign keys may fail
+
+**Low Impact (Edge Cases):**
+- **Migration operations**: Advanced migration operations involving composite primary keys and generated fields
+- **Backend debugging**: Certain backend debugging and introspection features
+- **JSONField CASE WHEN updates**: JSONField updates using CASE WHEN expressions with null handling
+
+**Specific Test Failures in Django 5.2:**
+- All `foreign_object.test_tuple_lookups.TupleLookupsTests.*` tests
+- All `foreign_object.tests.MultiColumnFKTests.*` tests involving complex queries
+- `model_fields.test_jsonfield.TestQuerying.test_lookups_special_chars*` tests
+- `queries.test_bulk_update.BulkUpdateTests.test_json_field_sql_null` test
+- Various migration and backend debugging tests
+
+**Workaround**: These limitations are documented in the test exclusions (`testapp/settings.py`) and are excellent candidates for community contributions. Applications using Django 5.0 and below are unaffected by these limitations.
 
 JSONField lookups have limitations, more details [here](https://github.com/microsoft/mssql-django/wiki/JSONField).
 

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -362,7 +362,7 @@ if VERSION >= (5, 2):
         
         # Backend and schema test failures
         # TODO: Fix SQL Server specific backend behavior 
-        'backends.base.test_base.ExecuteWrapperTests.test_wrapper_debug',
+        # 'backends.base.test_base.ExecuteWrapperTests.test_wrapper_debug',  # Removed duplicate; now only in Django 5.2+ block
         'indexes.tests.SchemaIndexesTests.test_alter_field_unique_false_removes_deferred_sql',
         
         # Aggregation with filtered references  

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -98,6 +98,9 @@ ENABLE_REGEX_TESTS = False
 USE_TZ = False
 
 TEST_RUNNER = "testapp.runners.ExcludedTestSuiteRunner"
+
+# Test exclusions for features not supported by SQL Server or requiring special handling
+# Community contributions welcome to implement these features incrementally
 EXCLUDED_TESTS = [
     'aggregation_regress.tests.AggregationTests.test_annotation_with_value',
     'aggregation.tests.AggregateTestCase.test_distinct_on_aggregate',
@@ -289,12 +292,88 @@ EXCLUDED_TESTS = [
     'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_with_select_related_and_order',
     'expressions_window.tests.WindowFunctionTests.test_limited_filter',
     'schema.tests.SchemaTests.test_remove_ignored_unique_constraint_not_create_fk_index',
-    
-    # Generated field 5.0.6 tests
-    'migrations.test_operations.OperationTests.test_invalid_generated_field_changes_on_rename_virtual',
-    'migrations.test_operations.OperationTests.test_invalid_generated_field_changes_on_rename_stored',
-    
+
 ]
+
+# Django 5.0 specific exclusions - these tests fail due to SQL Server limitations
+if VERSION >= (5, 0):
+    EXCLUDED_TESTS.extend([
+        # Generated field 5.0.6 tests
+        'migrations.test_operations.OperationTests.test_invalid_generated_field_changes_on_rename_virtual',
+        'migrations.test_operations.OperationTests.test_invalid_generated_field_changes_on_rename_stored',
+    ])
+
+# Django 5.1 specific exclusions - these tests fail due to SQL Server limitations
+if VERSION >= (5, 1):
+    EXCLUDED_TESTS.extend([
+        # Composite primary key tests - not supported in SQL Server
+        'inspectdb.tests.InspectDBTransactionalTests.test_composite_primary_key',
+        
+        # Backend and schema test failures that appear in Django 5.1
+        # TODO: Fix SQL Server specific backend behavior 
+        'backends.base.test_base.ExecuteWrapperTests.test_wrapper_debug',
+        'indexes.tests.SchemaIndexesTests.test_alter_field_unique_false_removes_deferred_sql',
+    ])
+
+# Django 5.2 specific exclusions - tuple lookups not supported in SQL Server
+# These are good candidates for community contributions - see GitHub issues
+if VERSION >= (5, 2):
+    EXCLUDED_TESTS.extend([
+        # Tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
+        # TODO: Implement tuple lookup handling for SQL Server compatibility
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_exact',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gt',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gte',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_in',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lt',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lte',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_tuple_in_subquery',
+        'foreign_object.test_agnostic_order_trimjoin.TestLookupQuery.test_deep_mixed_backward',
+        
+        # inspectdb tests that expect specific table structures in inspectdb_special/pascal schemas
+        'inspectdb.tests.InspectDBTestCase.test_custom_normalize_table_name',
+        'inspectdb.tests.InspectDBTestCase.test_special_column_name_introspection', 
+        'inspectdb.tests.InspectDBTestCase.test_table_name_introspection',
+        
+        # Multi-column foreign key tests with tuple lookups - also affected by SQL Server limitations
+        # TODO: Fix tuple lookup generation for multi-column FKs 
+        'foreign_object.tests.MultiColumnFKTests.test_double_nested_query',
+        'foreign_object.tests.MultiColumnFKTests.test_forward_in_lookup_filters_correctly',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_forward',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_hidden_forward',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_reverse',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_forward_works',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_reverse_works',
+        'foreign_object.tests.MultiColumnFKTests.test_reverse_query_returns_correct_result',
+        
+        # JSONField special character handling - SQL Server specific syntax issues
+        # TODO: Fix JSONField key escaping for special characters
+        'model_fields.test_jsonfield.TestQuerying.test_lookups_special_chars',
+        'model_fields.test_jsonfield.TestQuerying.test_lookups_special_chars_double_quotes',
+        
+        # JSONField bulk update with null handling
+        # TODO: Fix bulk update SQL generation for JSONField null values
+        'queries.test_bulk_update.BulkUpdateTests.test_json_field_sql_null',
+        
+        # Migration and composite primary key issues  
+        # TODO: Implement composite primary key support
+        'migrations.test_operations.OperationTests.test_composite_pk_operations',
+        'migrations.test_operations.OperationTests.test_generated_field_changes_output_field',
+        
+        # Backend and schema test failures
+        # TODO: Fix SQL Server specific backend behavior 
+        'backends.base.test_base.ExecuteWrapperTests.test_wrapper_debug',
+        'indexes.tests.SchemaIndexesTests.test_alter_field_unique_false_removes_deferred_sql',
+        
+        # Aggregation with filtered references  
+        # TODO: Fix complex aggregation queries with outer references
+        'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_aggregrate_ref_in_subquery_annotation',
+        
+        # JSONField test failures
+        # TODO: Fix JSONField update with CASE WHEN handling
+        'expressions.tests.BasicExpressionsTests.test_update_jsonfield_case_when_key_is_null',
+        
+    ])
 
 REGEX_TESTS = [
     'lookup.tests.LookupTests.test_regex',


### PR DESCRIPTION
This pull request expands support for newer Django versions (5.1 and 5.2) in the MSSQL-Django backend, documents version-specific limitations, and updates the test exclusion list to reflect new incompatibilities and areas for community contribution. The README is updated to clarify the level of support and known issues for each Django version, while `testapp/settings.py` now programmatically excludes failing tests based on Django version.

**Django version support and documentation:**

* README now lists support for Django 5.1 and 5.2, with clear breakdowns of limitations for each version, especially regarding composite primary keys and SQL Server compatibility features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R280-R315)

**Test suite management:**

* `testapp/settings.py` introduces version-aware exclusions for tests that fail due to SQL Server limitations in Django 5.0, 5.1, and 5.2. This includes tuple lookups, multi-column foreign keys, JSONField operations, and composite primary key features. [[1]](diffhunk://#diff-68575e543cadfd63feb4572a74caf8aee4a1ab8c5dd0a5dbdc09ab1bc85b8e09R101-R103) [[2]](diffhunk://#diff-68575e543cadfd63feb4572a74caf8aee4a1ab8c5dd0a5dbdc09ab1bc85b8e09R296-R376)

**Community contribution guidance:**

* The README and test exclusions highlight which limitations are good candidates for community contributions, making it easier for new contributors to identify areas needing work. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R280-R315) [[2]](diffhunk://#diff-68575e543cadfd63feb4572a74caf8aee4a1ab8c5dd0a5dbdc09ab1bc85b8e09R296-R376)