### PR TITLE
Update JSON path compilation for Django 6.0

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -14,7 +14,9 @@ from django.db.models.sql import compiler
 from django.db.transaction import TransactionManagementError
 from django.db.utils import NotSupportedError
 if django.VERSION >= (3, 1):
-    from django.db.models.fields.json import compile_json_path, KeyTransform as json_KeyTransform
+    from django.db.models.fields.json import KeyTransform as json_KeyTransform
+if django.VERSION >= (3, 1) and django.VERSION < (6, 0):
+    from django.db.models.fields.json import compile_json_path
 if django.VERSION >= (4, 2):
     from django.core.exceptions import EmptyResultSet, FullResultSet
 
@@ -47,7 +49,7 @@ def _as_sql_greatest(self, compiler, connection):
 
 def _as_sql_json_keytransform(self, compiler, connection):
     lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-    json_path = compile_json_path(key_transforms)
+    json_path = connection.ops.compile_json_path(key_transforms)
     return (
         "COALESCE(JSON_QUERY(%s, '%s'), JSON_VALUE(%s, '%s'))" %
         ((lhs, json_path) * 2)


### PR DESCRIPTION
compile_json_path is no longer defined in django.db.models.fields.json in Django 6.0