### PR TITLE
FIX: Updates TimeZone support for DATETIMEOFFSET type, fixes incorrect Now() in USE_TZ=True cases.

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -99,9 +99,13 @@ def encode_value(v):
 def handle_datetimeoffset(dto_value):
     # Decode bytes returned from SQL Server
     # source: https://github.com/mkleehammer/pyodbc/wiki/Using-an-Output-Converter-function
-    tup = struct.unpack("<6hI2h", dto_value)  # e.g., (2017, 3, 16, 10, 35, 18, 500000000)
-    return datetime.datetime(tup[0], tup[1], tup[2], tup[3], tup[4], tup[5], tup[6] // 1000,
-                             datetime.timezone(datetime.timedelta(hours=tup[7], minutes=tup[8])))
+    # Format: 6 shorts (year, month, day, hour, minute, second),
+    #         1 unsigned int (nanoseconds), 2 shorts (tz_offset_hour, tz_offset_minute)
+    tup = struct.unpack("<6hI2h", dto_value)
+    return datetime.datetime(
+        tup[0], tup[1], tup[2], tup[3], tup[4], tup[5], tup[6] // 1000,
+        datetime.timezone(datetime.timedelta(hours=tup[7], minutes=tup[8])),
+    )
 
 
 class DatabaseWrapper(BaseDatabaseWrapper):

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -88,7 +88,8 @@ def handle_datetimeoffset(dto_value):
     # Decode bytes returned from SQL Server
     # source: https://github.com/mkleehammer/pyodbc/wiki/Using-an-Output-Converter-function
     tup = struct.unpack("<6hI2h", dto_value)  # e.g., (2017, 3, 16, 10, 35, 18, 500000000)
-    return datetime.datetime(tup[0], tup[1], tup[2], tup[3], tup[4], tup[5], tup[6] // 1000)
+    return datetime.datetime(tup[0], tup[1], tup[2], tup[3], tup[4], tup[5], tup[6] // 1000,
+                             datetime.timezone(datetime.timedelta(hours=tup[7], minutes=tup[8])))
 
 
 class DatabaseWrapper(BaseDatabaseWrapper):

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -153,9 +153,11 @@ def sqlserver_exists(self, compiler, connection, template=None, **extra_context)
     return sql, params
 
 def sqlserver_now(self, compiler, connection, **extra_context):
-        return self.as_sql(
-            compiler, connection, template="SYSDATETIME()", **extra_context
-        )
+    if settings.USE_TZ:
+        return self.as_sql(compiler, connection, template="SYSDATETIMEOFFSET()", **extra_context)
+    else:
+        # continue using SYSDATETIME to get the DB local time when django is not TZ aware
+        return self.as_sql(compiler, connection, template="SYSDATETIME()", **extra_context)
 
 def sqlserver_lookup(self, compiler, connection):
     # MSSQL doesn't allow EXISTS() to be compared to another expression

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -5,6 +5,7 @@ import json
 import itertools
 
 from django import VERSION
+from django.conf import settings
 from django.core import validators
 from django.db import NotSupportedError, connections, transaction
 from django.db.models import BooleanField, CheckConstraint, Q, Value
@@ -171,9 +172,7 @@ def sqlserver_exists(self, compiler, connection, template=None, **extra_context)
 def sqlserver_now(self, compiler, connection, **extra_context):
     if settings.USE_TZ:
         return self.as_sql(compiler, connection, template="SYSDATETIMEOFFSET()", **extra_context)
-    else:
-        # continue using SYSDATETIME to get the DB local time when django is not TZ aware
-        return self.as_sql(compiler, connection, template="SYSDATETIME()", **extra_context)
+    return self.as_sql(compiler, connection, template="SYSDATETIME()", **extra_context)
 
 def sqlserver_lookup(self, compiler, connection):
     # MSSQL doesn't allow EXISTS() to be compared to another expression

--- a/testapp/tests/test_base.py
+++ b/testapp/tests/test_base.py
@@ -174,6 +174,25 @@ class TestHandleDatetimeoffset(SimpleTestCase):
         self.assertIsNotNone(result.tzinfo)
         self.assertEqual(result.utcoffset(), datetime.timedelta(hours=-5))
 
+    def test_datetime_negative_half_hour_offset(self):
+        """Test conversion with a negative half-hour offset (-09:30 Marquesas)."""
+        dto_bytes = struct.pack("<6hI2h", 2024, 7, 1, 12, 0, 0, 0, -9, -30)
+        result = handle_datetimeoffset(dto_bytes)
+
+        self.assertEqual(result.hour, 12)
+        self.assertIsNotNone(result.tzinfo)
+        expected = datetime.timedelta(hours=-9, minutes=-30)
+        self.assertEqual(result.utcoffset(), expected)
+
+    def test_datetime_positive_three_quarter_offset(self):
+        """Test conversion with +05:45 (Nepal) offset."""
+        dto_bytes = struct.pack("<6hI2h", 2024, 3, 15, 10, 30, 0, 0, 5, 45)
+        result = handle_datetimeoffset(dto_bytes)
+
+        self.assertEqual(result.hour, 10)
+        self.assertIsNotNone(result.tzinfo)
+        self.assertEqual(result.utcoffset(), datetime.timedelta(hours=5, minutes=45))
+
     def test_datetime_edge_case_midnight_utc(self):
         """Test with edge case: midnight on Jan 1, 2000 at UTC."""
         dto_bytes = struct.pack("<6hI2h", 2000, 1, 1, 0, 0, 0, 0, 0, 0)

--- a/testapp/tests/test_base.py
+++ b/testapp/tests/test_base.py
@@ -138,10 +138,8 @@ class TestPrepareTokenForOdbc(SimpleTestCase):
 class TestHandleDatetimeoffset(SimpleTestCase):
     """Tests for the handle_datetimeoffset function."""
 
-    def test_datetime_conversion(self):
-        """Test conversion of binary datetime offset to Python datetime."""
-        # Pack a known datetime: 2023-06-15 14:30:45.123456
-        # Format: year, month, day, hour, minute, second, nanoseconds (as microseconds * 1000), tz_hour, tz_min
+    def test_datetime_conversion_utc(self):
+        """Test conversion of binary datetime offset with UTC (zero offset)."""
         dto_bytes = struct.pack("<6hI2h", 2023, 6, 15, 14, 30, 45, 123456000, 0, 0)
         result = handle_datetimeoffset(dto_bytes)
 
@@ -153,10 +151,31 @@ class TestHandleDatetimeoffset(SimpleTestCase):
         self.assertEqual(result.minute, 30)
         self.assertEqual(result.second, 45)
         self.assertEqual(result.microsecond, 123456)
+        self.assertIsNotNone(result.tzinfo)
+        self.assertEqual(result.utcoffset(), datetime.timedelta(0))
 
-    def test_datetime_edge_case(self):
-        """Test with edge case values."""
-        # Midnight on Jan 1, 2000
+    def test_datetime_positive_offset(self):
+        """Test conversion with a positive timezone offset (+05:30 IST)."""
+        dto_bytes = struct.pack("<6hI2h", 2024, 1, 10, 9, 0, 0, 0, 5, 30)
+        result = handle_datetimeoffset(dto_bytes)
+
+        self.assertEqual(result.year, 2024)
+        self.assertEqual(result.hour, 9)
+        self.assertIsNotNone(result.tzinfo)
+        self.assertEqual(result.utcoffset(), datetime.timedelta(hours=5, minutes=30))
+
+    def test_datetime_negative_offset(self):
+        """Test conversion with a negative timezone offset (-05:00 EST)."""
+        dto_bytes = struct.pack("<6hI2h", 2024, 12, 25, 18, 0, 0, 0, -5, 0)
+        result = handle_datetimeoffset(dto_bytes)
+
+        self.assertEqual(result.year, 2024)
+        self.assertEqual(result.hour, 18)
+        self.assertIsNotNone(result.tzinfo)
+        self.assertEqual(result.utcoffset(), datetime.timedelta(hours=-5))
+
+    def test_datetime_edge_case_midnight_utc(self):
+        """Test with edge case: midnight on Jan 1, 2000 at UTC."""
         dto_bytes = struct.pack("<6hI2h", 2000, 1, 1, 0, 0, 0, 0, 0, 0)
         result = handle_datetimeoffset(dto_bytes)
 
@@ -167,6 +186,7 @@ class TestHandleDatetimeoffset(SimpleTestCase):
         self.assertEqual(result.minute, 0)
         self.assertEqual(result.second, 0)
         self.assertEqual(result.microsecond, 0)
+        self.assertEqual(result.utcoffset(), datetime.timedelta(0))
 
 
 class TestDatabaseWrapperIsDriverNotFoundError(SimpleTestCase):

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -5,6 +5,7 @@ from django import VERSION
 from django.db import connections, connection, models
 from django.db.models.functions import Now
 from django.test import TransactionTestCase, TestCase, skipUnlessDBFeature
+from django.test.utils import override_settings
 from django.utils import timezone
 
 from ..models import Author, BinaryData
@@ -178,3 +179,24 @@ class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
             self.assertNotIn("SCOPE_IDENTITY", ctx[0]["sql"])
         finally:
             connection.features_class.can_return_rows_from_bulk_insert = old_return_rows_flag
+
+
+class NowSQLTemplateTests(TestCase):
+    """Regression tests for #371 / PR #484: Now() should emit
+    SYSDATETIMEOFFSET() when USE_TZ=True, SYSDATETIME() otherwise."""
+
+    @override_settings(USE_TZ=True)
+    def test_now_uses_sysdatetimeoffset_when_use_tz(self):
+        qs = Author.objects.annotate(ts=Now()).filter(first_name="x")
+        compiler = qs.query.get_compiler(using="default")
+        sql_compiled, _ = compiler.as_sql()
+        self.assertIn("SYSDATETIMEOFFSET()", sql_compiled)
+        self.assertNotIn("SYSDATETIME()", sql_compiled)
+
+    @override_settings(USE_TZ=False)
+    def test_now_uses_sysdatetime_when_no_tz(self):
+        qs = Author.objects.annotate(ts=Now()).filter(first_name="x")
+        compiler = qs.query.get_compiler(using="default")
+        sql_compiled, _ = compiler.as_sql()
+        self.assertIn("SYSDATETIME()", sql_compiled)
+        self.assertNotIn("SYSDATETIMEOFFSET()", sql_compiled)

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -202,7 +202,7 @@ class NowSQLTemplateTests(TestCase):
 
     @override_settings(USE_TZ=True)
     def test_now_uses_sysdatetimeoffset_when_use_tz(self):
-        qs = Author.objects.annotate(ts=Now()).filter(first_name="x")
+        qs = Author.objects.annotate(ts=Now()).filter(name="x")
         compiler = qs.query.get_compiler(using="default")
         sql_compiled, _ = compiler.as_sql()
         self.assertIn("SYSDATETIMEOFFSET()", sql_compiled)
@@ -210,7 +210,7 @@ class NowSQLTemplateTests(TestCase):
 
     @override_settings(USE_TZ=False)
     def test_now_uses_sysdatetime_when_no_tz(self):
-        qs = Author.objects.annotate(ts=Now()).filter(first_name="x")
+        qs = Author.objects.annotate(ts=Now()).filter(name="x")
         compiler = qs.query.get_compiler(using="default")
         sql_compiled, _ = compiler.as_sql()
         self.assertIn("SYSDATETIME()", sql_compiled)


### PR DESCRIPTION
1. _handle_datetimeoffset_ Fixes the datetime parsing of column type DATETIMEOFFSET. This updates Pull #140 that forgot to parse the timezone offset part of the type. This is a straightforward bugfix. (see #136 )

2. _sqlserver_now_ Fixes Now(), to use timezone-aware SYSDATETIMEOFFSET(), to ensure a timezone aware (USE_TZ) django get a correct value for Now() when the database OS is not configured as UTC timezone.

This also fixes #371 .