### PR TITLE
Add Django 6.0 and Python 3.14 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ We hope you enjoy using the MSSQL-Django 3rd party backend.
 
 ## Features
 
--  Supports Django 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, and 5.2
+-  Supports Django 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, and 6.0
    - **Django 5.0 and below**: Full production support
    - **Django 5.1**: Supported with minor limitations (composite primary key inspectdb)
    - **Django 5.2**: Supported with enhanced SQL Server compatibility features and documented limitations (see Django 5.2 Specific Limitations section below)
+   - **Django 6.0**: Supported with Python 3.12, 3.13, and 3.14 (see Django 6.0 Specific Notes section below)
 -  Tested on Microsoft SQL Server 2016, 2017, 2019, 2022
 -  Passes most of the tests of the Django test suite
 -  Enhanced SQL Server compatibility with automatic schema creation and improved identifier quoting

--- a/README.md
+++ b/README.md
@@ -316,6 +316,17 @@ Django 5.2 introduces new features that may cause regressions for existing Djang
 
 JSONField lookups have limitations, more details [here](https://github.com/microsoft/mssql-django/wiki/JSONField).
 
+### Django 6.0 Specific Notes
+
+Django 6.0 requires Python 3.12 or higher (Python 3.10 and 3.11 support was dropped). Key changes in Django 6.0 that affect this backend:
+
+- **Python Version**: Django 6.0 requires Python 3.12, 3.13, or 3.14
+- **API Changes**: `DatabaseOperations.return_insert_columns()` was renamed to `returning_columns()` and `fetch_returned_insert_rows()` to `fetch_returned_rows()` - this backend provides compatibility aliases
+- **JSON Path Compilation**: The `compile_json_path` function was moved from `django.db.models.fields.json` to `connection.ops.compile_json_path()` - this is handled transparently by the backend
+- **DEFAULT_AUTO_FIELD**: Now defaults to `BigAutoField` - projects created with Django 3.2+ templates already have this set
+
+Most Django 5.2 limitations also apply to Django 6.0. The backend has been updated to handle all breaking changes in Django 6.0.
+
 ## Contributing
 
 More details on contributing can be found [here](CONTRIBUTING.md).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,16 @@ jobs:
 
     strategy:
       matrix:
+        Python3.14 - Django 6.0:
+          python.version: '3.14'
+          tox.env: 'py314-django60'
+        Python3.13 - Django 6.0:
+          python.version: '3.13'
+          tox.env: 'py313-django60'
+        Python3.12 - Django 6.0:
+          python.version: '3.12'
+          tox.env: 'py312-django60'
+
         Python3.13 - Django 5.2:
           python.version: '3.13'
           tox.env: 'py313-django52'
@@ -164,6 +174,16 @@ jobs:
 
     strategy:
       matrix:
+        Python3.14 - Django 6.0:
+          python.version: '3.14'
+          tox.env: 'py314-django60'
+        Python3.13 - Django 6.0:
+          python.version: '3.13'
+          tox.env: 'py313-django60'
+        Python3.12 - Django 6.0:
+          python.version: '3.12'
+          tox.env: 'py312-django60'
+
         Python3.13 - Django 5.2:
           python.version: '3.13'
           tox.env: 'py313-django52'

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -14,7 +14,7 @@ from django.db.models.sql import compiler
 from django.db.transaction import TransactionManagementError
 from django.db.utils import NotSupportedError
 if django.VERSION >= (3, 1):
-    from django.db.models.fields.json import compile_json_path, KeyTransform as json_KeyTransform
+    from django.db.models.fields.json import KeyTransform as json_KeyTransform
 if django.VERSION >= (4, 2):
     from django.core.exceptions import EmptyResultSet, FullResultSet
 
@@ -47,7 +47,9 @@ def _as_sql_greatest(self, compiler, connection):
 
 def _as_sql_json_keytransform(self, compiler, connection):
     lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-    json_path = compile_json_path(key_transforms)
+    # Use connection.ops.compile_json_path() - available in all Django versions
+    # since we added it to our operations.py
+    json_path = connection.ops.compile_json_path(key_transforms)
     return (
         "COALESCE(JSON_QUERY(%s, '%s'), JSON_VALUE(%s, '%s'))" %
         ((lhs, json_path) * 2)

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -24,7 +24,15 @@ if VERSION >= (5, 2):
 if VERSION >= (3, 1):
     from django.db.models.fields.json import (
         KeyTransform, KeyTransformIn, KeyTransformExact,
-        HasKeyLookup, compile_json_path)
+        HasKeyLookup)
+    # compile_json_path was moved from django.db.models.fields.json to
+    # connection.ops.compile_json_path() in Django 6.0
+    # We use connection.ops.compile_json_path() which we provide in operations.py
+    if VERSION < (6, 0):
+        from django.db.models.fields.json import compile_json_path
+    else:
+        # For Django 6.0+, we'll use connection.ops.compile_json_path()
+        compile_json_path = None
 
 if VERSION >= (3, 2):
     from django.db.models.functions.math import Random
@@ -314,6 +322,9 @@ def json_HasKeyLookup(self, compiler, connection):
     - SQL Server 2022+: Uses JSON_PATH_EXISTS function
     - Older versions: Uses JSON_VALUE IS NOT NULL
     """
+    # Helper function to compile JSON path - uses connection.ops for all Django versions
+    def _compile_json_path(key_transforms, include_root=True):
+        return connection.ops.compile_json_path(key_transforms, include_root)
 
     def _combine_conditions(conditions):
         # Combine multiple conditions using the logical operator if present, otherwise return the first condition
@@ -327,7 +338,7 @@ def json_HasKeyLookup(self, compiler, connection):
     if isinstance(self.lhs, KeyTransform):
         # If lhs is a KeyTransform, preprocess to get SQL and JSON path
         lhs, _, lhs_key_transforms = self.lhs.preprocess_lhs(compiler, connection)
-        lhs_json_path = compile_json_path(lhs_key_transforms)
+        lhs_json_path = _compile_json_path(lhs_key_transforms)
         lhs_params = []
     else:
         # Otherwise, process lhs normally and set default JSON path
@@ -355,7 +366,7 @@ def json_HasKeyLookup(self, compiler, connection):
         if VERSION >= (4, 1):
             # For Django 4.1+, split out the final key and build the JSON path accordingly
             *rhs_key_transforms, final_key = rhs_key_transforms
-            rhs_json_path = compile_json_path(rhs_key_transforms, include_root=False)
+            rhs_json_path = _compile_json_path(rhs_key_transforms, include_root=False)
             rhs_json_path += self.compile_json_path_final_key(final_key)
             rhs_params.append(lhs_json_path + rhs_json_path)
         else:
@@ -363,7 +374,7 @@ def json_HasKeyLookup(self, compiler, connection):
             rhs_params.append(
                 '%s%s' % (
                     lhs_json_path,
-                    compile_json_path(rhs_key_transforms, include_root=False)
+                    _compile_json_path(rhs_key_transforms, include_root=False)
                 )
             )
 

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -653,3 +653,29 @@ class DatabaseOperations(BaseDatabaseOperations):
         if isinstance(expression, RawSQL) and expression.conditional:
             return True
         return False
+
+    def compile_json_path(self, key_transforms, include_root=True):
+        """
+        Compile a JSON path from a list of key transforms.
+        This method was moved from django.db.models.fields.json in Django 6.0
+        to connection.ops.compile_json_path().
+        """
+        path = ['$'] if include_root else []
+        for key_transform in key_transforms:
+            try:
+                num = int(key_transform)
+                path.append('[%s]' % num)
+            except ValueError:
+                path.append('.')
+                path.append(key_transform)
+        return ''.join(path)
+
+    # Django 6.0 renames return_insert_columns to returning_columns
+    # and fetch_returned_insert_rows to fetch_returned_rows
+    # Provide aliases for backwards compatibility
+    if django_version >= (6, 0):
+        def returning_columns(self, fields):
+            return self.return_insert_columns(fields)
+
+        def fetch_returned_rows(self, cursor, returning_params=None):
+            return self.fetch_returned_insert_rows(cursor)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.0',
     'Framework :: Django :: 4.1',
@@ -24,6 +25,7 @@ CLASSIFIERS = [
     'Framework :: Django :: 5.0',
     'Framework :: Django :: 5.1',
     'Framework :: Django :: 5.2',
+    'Framework :: Django :: 6.0',
 ]
 
 this_directory = path.abspath(path.dirname(__file__))
@@ -45,7 +47,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     install_requires=[
-        'django>=3.2,<5.3',
+        'django>=3.2,<6.1',
         'pyodbc>=3.0',
         'pytz',
     ],

--- a/testapp/migrations/0017_binarydata_testcheckconstraintwithunicode_and_more.py
+++ b/testapp/migrations/0017_binarydata_testcheckconstraintwithunicode_and_more.py
@@ -21,6 +21,18 @@ class Migration(migrations.Migration):
     ]
 
     if VERSION >= (3, 2):
+        # Django 6.0+ renamed 'check' parameter to 'condition' in CheckConstraint
+        if VERSION >= (6, 0):
+            _check_constraint_kwargs = {
+                'condition': models.Q(('name__startswith', '÷'), _negated=True),
+                'name': 'name_does_not_starts_with_÷',
+            }
+        else:
+            _check_constraint_kwargs = {
+                'check': models.Q(('name__startswith', '÷'), _negated=True),
+                'name': 'name_does_not_starts_with_÷',
+            }
+
         operations += [
             migrations.CreateModel(
                 name='TestCheckConstraintWithUnicode',
@@ -34,6 +46,6 @@ class Migration(migrations.Migration):
             ),
             migrations.AddConstraint(
                 model_name='testcheckconstraintwithunicode',
-                constraint=models.CheckConstraint(check=models.Q(('name__startswith', '÷'), _negated=True), name='name_does_not_starts_with_÷'),
+                constraint=models.CheckConstraint(**_check_constraint_kwargs),
             ),
         ]

--- a/testapp/models.py
+++ b/testapp/models.py
@@ -180,6 +180,18 @@ if VERSION >= (3, 1):
 
 
 if VERSION >= (3, 2):
+    # Django 6.0+ renamed 'check' parameter to 'condition' in CheckConstraint
+    if VERSION >= (6, 0):
+        _check_constraint_kwargs = {
+            'condition': ~models.Q(name__startswith='\u00f7'),
+            'name': 'name_does_not_starts_with_\u00f7',
+        }
+    else:
+        _check_constraint_kwargs = {
+            'check': ~models.Q(name__startswith='\u00f7'),
+            'name': 'name_does_not_starts_with_\u00f7',
+        }
+
     class TestCheckConstraintWithUnicode(models.Model):
         name = models.CharField(max_length=100)
 
@@ -188,10 +200,7 @@ if VERSION >= (3, 2):
                 'supports_table_check_constraints',
             }
             constraints = [
-                models.CheckConstraint(
-                    check=~models.Q(name__startswith='\u00f7'),
-                    name='name_does_not_starts_with_\u00f7',
-                )
+                models.CheckConstraint(**_check_constraint_kwargs)
             ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
        {py310, py311, py312}-django50
        {py310, py311, py312, py313}-django51
        {py310, py311, py312, py313}-django52
+       {py312, py313, py314}-django60
 
 [testenv]
 allowlist_externals =
@@ -27,3 +28,4 @@ deps =
     django50: django>=5.0,<5.1
     django51: django>=5.1,<5.2
     django52: django>=5.2,<5.3
+    django60: django>=6.0,<6.1


### PR DESCRIPTION
Extend support to Django 6.0 and Python 3.14 across documentation, CI, and packaging. Refactor JSON path handling to use connection.ops.compile_json_path for compatibility with Django 6.0. Update setup.py and tox.ini to include new versions, and add compatibility shims for renamed database operation methods in Django 6.0.