### PR TITLE
FEAT: Add SQL Server 2025 Support w/ CI (Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We hope you enjoy using the MSSQL-Django 3rd party backend.
    - **Django 5.0 and below**: Full production support
    - **Django 5.1**: Supported with minor limitations (composite primary key inspectdb)
    - **Django 5.2**: Supported with enhanced SQL Server compatibility features and documented limitations (see Django 5.2 Specific Limitations section below)
--  Tested on Microsoft SQL Server 2016, 2017, 2019, 2022
+-  Tested on Microsoft SQL Server 2016, 2017, 2019, 2022, 2025
 -  Passes most of the tests of the Django test suite
 -  Enhanced SQL Server compatibility with automatic schema creation and improved identifier quoting
 -  Compatible with

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -257,8 +257,8 @@ jobs:
 
       - script: |
           docker version
-          docker pull mcr.microsoft.com/mssql/server:2022-latest
-          docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=$(TestAppPassword)' -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
+          docker pull mcr.microsoft.com/mssql/server:2025-latest
+          docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=$(TestAppPassword)' -p 1433:1433 -d mcr.microsoft.com/mssql/server:2025-latest
           curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
           curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
           
@@ -267,7 +267,7 @@ jobs:
           
           # Extended wait for the container to be running and SQL Server service to be listening
           for i in {1..60}; do
-            if docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2022-latest) 2>&1 | grep -q "SQL Server is now ready for client connections"; then
+            if docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2025-latest) 2>&1 | grep -q "SQL Server is now ready for client connections"; then
               echo "SQL Server service is ready after $i attempts ($(($i * 3)) seconds)"
               break
             fi
@@ -283,7 +283,7 @@ jobs:
           echo "Testing SQL Server connectivity..."
           if ! timeout 30 bash -c 'until echo > /dev/tcp/localhost/1433; do sleep 1; done'; then
             echo "Cannot connect to SQL Server on port 1433"
-            docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2022-latest)
+            docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2025-latest)
             exit 1
           fi
           
@@ -347,7 +347,7 @@ jobs:
                 sqlcmd -S "tcp:127.0.0.1,1433" -U sa -P "$(TestAppPassword)" -Q "SELECT 1 AS test" -l 10
                 echo ""
                 echo "Container logs:"
-                docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2022-latest)
+                docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2025-latest)
                 exit 1
               else
                 echo "Authentication failed (attempt $i), waiting 10 seconds before retry..."

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -196,6 +196,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         14: 2017,
         15: 2019,
         16: 2022,
+        17: 2025,
     }
 
     # https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-csharp-retry-windows/

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -389,6 +389,20 @@ class DatabaseOperations(BaseDatabaseOperations):
         if name.startswith('[') and name.endswith(']'):
             return name  # Quoting once is enough.
         
+        # SQL Server 2025 fix: stricter about periods in identifiers
+        # Aliases like 'ordering_article.pub_date' must be quoted as a single
+        # identifier [ordering_article.pub_date], not split into [ordering_article].[pub_date]
+        # Only split for known SQL Server schemas (dbo, sys, guest, etc.)
+        sql_server_version = getattr(self.connection, 'sql_server_version', 2019)
+        if sql_server_version >= 2025 and '.' in name and not name.startswith('['):
+            parts = name.split('.', 1)
+            schema = parts[0].strip().lower()
+            known_schemas = {'dbo', 'sys', 'guest', 'information_schema'}
+            if schema in known_schemas or schema.startswith('db_'):
+                return '[%s].[%s]' % (parts[0].strip(), parts[1].strip())
+            # Not a known schema - quote as single identifier (e.g., alias with period)
+            return '[%s]' % name
+        
         # Enhanced schema.table support for Django 5.2+
         if django_version >= (5, 2) and '.' in name and not name.startswith('['):
             parts = name.split('.', 1)  # Split only on first dot

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -393,7 +393,15 @@ class DatabaseOperations(BaseDatabaseOperations):
         # Aliases like 'ordering_article.pub_date' must be quoted as a single
         # identifier [ordering_article.pub_date], not split into [ordering_article].[pub_date]
         # Only split for known SQL Server schemas (dbo, sys, guest, etc.)
-        sql_server_version = getattr(self.connection, 'sql_server_version', 2019)
+        # Note: We check __dict__ directly to avoid triggering the cached_property
+        # during database creation when the connection isn't available yet.
+        sql_server_version = self.connection.__dict__.get('sql_server_version', None)
+        if sql_server_version is None:
+            # Fallback: check the cached versions dictionary directly
+            # The _known_versions dict is stored as a default parameter in the function
+            from mssql.base import DatabaseWrapper
+            _known_versions = DatabaseWrapper.sql_server_version.func.__defaults__[0]
+            sql_server_version = _known_versions.get(self.connection.alias, 2019)
         if sql_server_version >= 2025 and '.' in name and not name.startswith('['):
             parts = name.split('.', 1)
             schema = parts[0].strip().lower()

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -389,28 +389,6 @@ class DatabaseOperations(BaseDatabaseOperations):
         if name.startswith('[') and name.endswith(']'):
             return name  # Quoting once is enough.
         
-        # SQL Server 2025 fix: stricter about periods in identifiers
-        # Aliases like 'ordering_article.pub_date' must be quoted as a single
-        # identifier [ordering_article.pub_date], not split into [ordering_article].[pub_date]
-        # Only split for known SQL Server schemas (dbo, sys, guest, etc.)
-        # Note: We check __dict__ directly to avoid triggering the cached_property
-        # during database creation when the connection isn't available yet.
-        sql_server_version = self.connection.__dict__.get('sql_server_version', None)
-        if sql_server_version is None:
-            # Fallback: check the cached versions dictionary directly
-            # The _known_versions dict is stored as a default parameter in the function
-            from mssql.base import DatabaseWrapper
-            _known_versions = DatabaseWrapper.sql_server_version.func.__defaults__[0]
-            sql_server_version = _known_versions.get(self.connection.alias, 2019)
-        if sql_server_version >= 2025 and '.' in name and not name.startswith('['):
-            parts = name.split('.', 1)
-            schema = parts[0].strip().lower()
-            known_schemas = {'dbo', 'sys', 'guest', 'information_schema'}
-            if schema in known_schemas or schema.startswith('db_'):
-                return '[%s].[%s]' % (parts[0].strip(), parts[1].strip())
-            # Not a known schema - quote as single identifier (e.g., alias with period)
-            return '[%s]' % name
-        
         # Enhanced schema.table support for Django 5.2+
         if django_version >= (5, 2) and '.' in name and not name.startswith('['):
             parts = name.split('.', 1)  # Split only on first dot


### PR DESCRIPTION
AB#41802
AB#41958

GH Issue - #480 

This pull request updates the codebase and CI pipeline to add support for Microsoft SQL Server 2025. The changes ensure compatibility and testing against the latest SQL Server version, both in documentation and automated test environments.

**SQL Server 2025 Support**

* Added SQL Server 2025 (`version 17`) to the supported versions mapping in `mssql/base.py` to enable backend compatibility.
* Updated the documentation in `README.md` to indicate testing on SQL Server 2025.

**Continuous Integration Pipeline Updates**

* Changed all references in `azure-pipelines.yml` to use the `mcr.microsoft.com/mssql/server:2025-latest` Docker image instead of `2022-latest`, ensuring CI tests run against SQL Server 2025. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L260-R261) [[2]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L270-R270) [[3]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L286-R286) [[4]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L350-R350)