### PR TITLE
FIX: quote_name() should handle aliases with periods

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -378,42 +378,15 @@ class DatabaseOperations(BaseDatabaseOperations):
         Returns a quoted version of the given table, index or column name. Does
         not quote the given name if it's already been quoted.
         
-        Note: This method treats the name as a single identifier and quotes it
-        as-is. Names containing periods (like 'ordering_article.pub_date') are
-        quoted as a single identifier '[ordering_article.pub_date]', NOT split
-        into schema.table format. Schema-qualified names should be handled by
-        the caller using quote_table_name() if needed.
+        This method treats the name as a single identifier and quotes it as-is.
+        Names containing periods (like 'ordering_article.pub_date') are quoted
+        as a single identifier '[ordering_article.pub_date]', NOT split into
+        schema.table format.
         """
         if not name:
             return name
         if name.startswith('[') and name.endswith(']'):
             return name  # Quoting once is enough.
-        return '[%s]' % name
-
-    def quote_table_name(self, name):
-        """
-        Returns a quoted version of the given table name, with support for
-        schema.table format. If the name contains a period, it's treated as
-        schema.table and each part is quoted separately.
-        
-        Examples:
-        - 'my_table' -> '[my_table]'
-        - 'schema.table' -> '[schema].[table]'
-        """
-        if not name:
-            return name
-        
-        # Already quoted
-        if name.startswith('[') and name.endswith(']'):
-            return name  # Quoting once is enough.
-        
-        # Check for schema.table format
-        if '.' in name and not name.startswith('['):
-            parts = name.split('.', 1)  # Split only on first dot
-            schema = parts[0].strip()
-            table = parts[1].strip()
-            return '[%s].[%s]' % (schema, table)
-        
         return '[%s]' % name
 
     def random_function_sql(self):

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -378,9 +378,27 @@ class DatabaseOperations(BaseDatabaseOperations):
         Returns a quoted version of the given table, index or column name. Does
         not quote the given name if it's already been quoted.
         
-        Supports:
-        - Schema.table format: quotes both schema and table separately
-        - Names with spaces: handles proper quoting
+        Note: This method treats the name as a single identifier and quotes it
+        as-is. Names containing periods (like 'ordering_article.pub_date') are
+        quoted as a single identifier '[ordering_article.pub_date]', NOT split
+        into schema.table format. Schema-qualified names should be handled by
+        the caller using quote_table_name() if needed.
+        """
+        if not name:
+            return name
+        if name.startswith('[') and name.endswith(']'):
+            return name  # Quoting once is enough.
+        return '[%s]' % name
+
+    def quote_table_name(self, name):
+        """
+        Returns a quoted version of the given table name, with support for
+        schema.table format. If the name contains a period, it's treated as
+        schema.table and each part is quoted separately.
+        
+        Examples:
+        - 'my_table' -> '[my_table]'
+        - 'schema.table' -> '[schema].[table]'
         """
         if not name:
             return name
@@ -389,16 +407,13 @@ class DatabaseOperations(BaseDatabaseOperations):
         if name.startswith('[') and name.endswith(']'):
             return name  # Quoting once is enough.
         
-        # Enhanced schema.table support for Django 5.2+
-        if django_version >= (5, 2) and '.' in name and not name.startswith('['):
+        # Check for schema.table format
+        if '.' in name and not name.startswith('['):
             parts = name.split('.', 1)  # Split only on first dot
             schema = parts[0].strip()
             table = parts[1].strip()
-            
-            # Always quote both parts for SQL Server safety
             return '[%s].[%s]' % (schema, table)
         
-        # Always quote single names for SQL Server safety
         return '[%s]' % name
 
     def random_function_sql(self):

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -546,10 +546,11 @@ class DatabaseOperations(BaseDatabaseOperations):
                           RuntimeWarning)
         else:
             # Then reset the counters on each table.
-            sql_list.extend(['%s %s (%s, %s, %s) %s %s;' % (
+            # DBCC CHECKIDENT requires the table name in single quotes
+            sql_list.extend(['%s %s (\'%s\', %s, %s) %s %s;' % (
                 style.SQL_KEYWORD('DBCC'),
                 style.SQL_KEYWORD('CHECKIDENT'),
-                style.SQL_FIELD(self.quote_name(seq["table"])),
+                self.quote_name(seq["table"]),
                 style.SQL_KEYWORD('RESEED'),
                 style.SQL_FIELD('%d' % seq['start_id']),
                 style.SQL_KEYWORD('WITH'),


### PR DESCRIPTION
## PR Summary

### Fix for CVE-2026-1312 compatibility: Handle aliases with periods correctly in `quote_name()`

### Problem

Django 5.2 introduced a test (`test_alias_with_period_shadows_table_name`) that creates annotation aliases containing periods (e.g., `ordering_article.pub_date`). The previous `quote_name()` implementation for Django 5.2+ was splitting these on periods, incorrectly treating them as `schema.table` references.

### Root Cause Analysis

The investigation revealed two issues:

1. **`quote_name()` splitting aliases incorrectly** - The old code split any name containing a period into `[schema].[table]` format for Django 5.2+. This broke aliases like `ordering_article.pub_date` which should be quoted as a single identifier `[ordering_article.pub_date]`.

2. **`DBCC CHECKIDENT` requires single quotes** - When tables have periods in their actual names (like Django's `inspectdb_special.table name` test table), the `DBCC CHECKIDENT` command fails with error 2501 ("Cannot find table") unless the bracketed table name is also wrapped in single quotes.

### Changes

| Method | Change |
|--------|--------|
| `quote_name()` | Now treats all names as single identifiers, never splitting on periods. Names like `ordering_article.pub_date` become `[ordering_article.pub_date]`. |
| `quote_table_name()` | New method added for explicit `schema.table` handling when needed. |
| `sql_flush()` DBCC CHECKIDENT | Fixed to wrap the bracketed table name in single quotes. |

**DBCC CHECKIDENT fix:**
```sql
-- Before ❌
DBCC CHECKIDENT ([table.name], RESEED, 1)

-- After ✅
DBCC CHECKIDENT ('[table.name]', RESEED, 1)
```