### PR TITLE
Fix: Restore Meta.indexes when altering fields (#486, #491)

### DIFF
--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -406,6 +406,43 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                      old_db_params, new_db_params, strict=False):
         """Actually perform a "physical" (non-ManyToMany) field update."""
 
+        # ============================================================================
+        # SQL Server Index/Constraint Management During Column Alterations
+        # ============================================================================
+        #
+        # OVERVIEW:
+        # SQL Server requires explicit DROP and RESTORE of indexes/constraints when
+        # altering column types or nullability. This method handles alterations in
+        # four phases:
+        #
+        # 1. Constraint and special case handling
+        # 2. Column alter preparation
+        # 3. Column alteration
+        # 4. Column alteration cleanup
+        #
+        #
+        # KNOWN BUGS/LIMITATIONS:
+        #   1. Rename + alter in same migration: When a field is renamed (via RenameField)
+        #      AND has a type or nullability change (via AlterField) in the same migration,
+        #      indexes from Meta.indexes are not restored. The _delete_indexes() method
+        #      fails with FieldDoesNotExist because it looks up the index field by the
+        #      old field name, but RenameField has already updated the model state.
+        #      Tests (marked @expectedFailure):
+        #        - test_index_from_meta_indexes_retained_after_rename_and_type_change
+        #        - test_index_from_meta_indexes_retained_after_rename_and_nullability_change
+        #
+        #   2. unique_together + unique=True: When a field has BOTH unique=True AND
+        #      participates in unique_together, only the single-field unique constraint
+        #      is restored after field alteration. The unique_together constraint is NOT
+        #      restored because the restoration code is in an 'else' block that only
+        #      executes when the field does NOT have unique=True.
+        #      Test (marked @expectedFailure):
+        #        - test_unique_together_retained_when_field_also_has_unique_true
+
+        # ============================================================================
+        # 1. Constraint and special case handling
+        # ============================================================================
+
         # the backend doesn't support altering a column to/from AutoField as
         # SQL Server cannot alter columns to add and remove IDENTITY properties
         old_is_auto = False
@@ -569,11 +606,23 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 if isinstance(sql, DjStatement):
                     sql.rename_column_references(model._meta.db_table, old_field.column, new_field.column)
 
+        # ===============================================================================
+        # 2. Column alter preparation
+        # ===============================================================================
+
         # Next, start accumulating actions to do
         actions = []
         null_actions = []
         post_actions = []
-        # Type or comment change?
+
+        # Column alter preparation: type change path
+        # Triggers when: Column type changes (or db_comment changes in Django 4.2+)
+        # Drops: Unique constraints + all indexes containing this field
+        #
+        # SQL Server requires indexes/constraints to be dropped before ALTER COLUMN
+        # can change the column's data type. This path drops both unique constraints
+        # and all indexes that include the altered field.
+
         if old_type != new_type or (django_version >= (4, 2) and
                 self.connection.features.supports_comments
                 and old_field.db_comment != new_field.db_comment
@@ -626,7 +675,14 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             needs_database_default = needs_database_default and new_field.db_default is NOT_PROVIDED
         if needs_database_default:
             actions.append(self._alter_column_default_sql(model, old_field, new_field))
-        # Nullability change?
+
+        # Column alter preparation: nullability change path
+        # Triggers when: Column nullability changes (NULL ↔ NOT NULL)
+        # Drops: Unique constraints + all indexes containing this field
+        #
+        # SQL Server requires indexes/constraints to be dropped before ALTER COLUMN
+        # can change the column's NULL/NOT NULL constraint.
+
         if old_field.null != new_field.null:
             fragment = self._alter_column_null_sql(model, old_field, new_field)
             if fragment:
@@ -634,21 +690,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 # Drop unique constraint, SQL Server requires explicit deletion
                 self._delete_unique_constraints(model, old_field, new_field, strict)
                 # Drop indexes, SQL Server requires explicit deletion
-                indexes_dropped = self._delete_indexes(model, old_field, new_field)
-                auto_index_names = []
-                for index_from_meta in model._meta.indexes:
-                    auto_index_names.append(self._create_index_name(model._meta.db_table, index_from_meta.fields))
+                self._delete_indexes(model, old_field, new_field)
 
-                if (
-                    new_field.get_internal_type() not in ("JSONField", "TextField") and
-                    (old_field.db_index or not new_field.db_index) and
-                    new_field.db_index or
-                    ((indexes_dropped and sorted(indexes_dropped) == sorted([index.name for index in model._meta.indexes])) or
-                     (indexes_dropped and sorted(indexes_dropped) == sorted(auto_index_names)))
-                ):
-                    create_index_sql_statement = self._create_index_sql(model, [new_field])
-                    if create_index_sql_statement.__str__() not in [sql.__str__() for sql in self.deferred_sql]:
-                        post_actions.append((create_index_sql_statement, ()))
+        # ================================================================================
+        # 3. Column alteration
+        # ================================================================================
+
         # Only if we have a default and there is a change from NULL to NOT NULL
         four_way_default_alteration = (
             (new_field.has_default() or (django_version >= (5,0) and new_field.db_default is not NOT_PROVIDED)) and
@@ -731,14 +778,28 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if (not old_field.db_index or old_field.unique) and new_field.db_index and not new_field.unique:
             self.execute(self._create_index_sql(model, [new_field]))
 
+        # ================================================================================
+        # 4. Column alteration cleanup
+        # ================================================================================
+        # WHEN THIS RUNS:
+        #   - Only if type changed OR nullability changed
+        #   - Only if column was NOT renamed (rename is handled separately)
+        # Test:
+        #   - test_index_from_meta_indexes_retained_after_rename_and_type_change (@expectedFailure)
+        #   - test_index_from_meta_indexes_retained_after_rename_and_nullability_change (@expectedFailure)
+        #
+
         # Restore indexes & unique constraints deleted above, SQL Server requires explicit restoration
         if (old_type != new_type or (old_field.null != new_field.null)) and (
             old_field.column == new_field.column  # column rename is handled separately above
         ):
-            # Restore unique constraints
-            # Note: if nullable they are implemented via an explicit filtered UNIQUE INDEX (not CONSTRAINT)
-            # in order to get ANSI-compliant NULL behaviour (i.e. NULL != NULL, multiple are allowed)
-            # Note: Don't restore primary keys, we need to re-create those seperately
+            # --------------------------------------------------------------------------------
+            # restore single-field unique constraints
+            # --------------------------------------------------------------------------------
+            # If the field had unique=True and still does, recreate the constraint.
+            # Note: Nullable unique constraints use filtered indexes (ANSI NULL behavior).
+            # Note: Primary keys are restored separately below.
+            # --------------------------------------------------------------------------------
             if old_field.unique and new_field.unique and not new_field.primary_key:
                 if new_field.null:
                     self.execute(
@@ -753,6 +814,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                         self.execute(self._create_unique_sql(model, columns=[old_field.column]))
                 self._delete_deferred_unique_indexes_for_field(old_field)
             else:
+                # --------------------------------------------------------------------------------
+                # Restore unique_together constraints
+                # --------------------------------------------------------------------------------
+                # If the field is NOT unique itself but IS part of unique_together,
+                # restore those multi-field unique constraints as filtered indexes.
+                # The filter ensures ANSI NULL behavior (multiple NULLs allowed).
+                # Test: test_unique_together_retained_when_field_also_has_unique_true
+                # https://github.com/microsoft/mssql-django/issues/494
+                # --------------------------------------------------------------------------------
                 if django_version >= (4, 0):
                     for field_names in model._meta.unique_together:
                         columns = [model._meta.get_field(field).column for field in field_names]
@@ -766,7 +836,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                         if old_field.column in columns:
                             condition = ' AND '.join(["[%s] IS NOT NULL" % col for col in columns])
                             self.execute(self._create_unique_sql(model, columns, condition=condition))
-            # Restore primary keys
+
+            # --------------------------------------------------------------------------------
+            # Primary keys
+            # --------------------------------------------------------------------------------
+            # If the field was and still is a primary key, recreate the PK constraint.
+            # --------------------------------------------------------------------------------
             if old_field.primary_key and new_field.primary_key:
                 self.execute(
                     self.sql_create_pk % {
@@ -777,8 +852,14 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                         "columns": self.quote_name(new_field.column),
                     }
                 )
-            # Restore unqiue_together
-            # If we have ALTERed an AutoField or BigAutoField we need to recreate all unique_together clauses
+
+            # --------------------------------------------------------------------------------
+            # AutoField/BigAutoField special handling - unique_together
+            # --------------------------------------------------------------------------------
+            # When altering an AutoField or BigAutoField, restore ALL unique_together
+            # constraints across the entire model (not just those containing this field).
+            # This is necessary due to SQL Server's IDENTITY column restrictions.
+            # --------------------------------------------------------------------------------
             for t in (AutoField, BigAutoField):
                 if isinstance(old_field, t) or isinstance(new_field, t):
                     for field_names in model._meta.unique_together:
@@ -797,36 +878,103 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                             )
                     break
 
-            # Restore indexes
-            # If we have ALTERed an AutoField or BigAutoField we need to recreate all indexes
-            for t in (AutoField, BigAutoField):
-                if isinstance(old_field, t) or isinstance(new_field, t):
-                    for field in model._meta.fields:
-                        if field.db_index:
-                            self.execute(
-                                self._create_index_sql(model, [field])
-                            )
-                    break
+            # --------------------------------------------------------------------------------
+            # db_index, index_together, and Meta.indexes
+            # --------------------------------------------------------------------------------
+            # Build lists of indexes to restore, then restore them with deduplication.
+            #
+            # Two lists are built:
+            #   - index_columns: Field lists for db_index and index_together
+            #   - indexes_to_restore: Index objects from Meta.indexes (preserves names)
+            #
+            #   - Deduplication: Check against deferred_sql and post_actions to prevent
+            #     double creation when both DROP paths triggered
+            #
+            # AutoField/BigAutoField changes are special: SQL Server requires dropping ALL
+            # indexes on the table to change an IDENTITY column, so we must restore ALL
+            # indexes (not just those involving the altered field).
+            # --------------------------------------------------------------------------------
             index_columns = []
-            if old_field.db_index and new_field.db_index:
+            indexes_to_restore = []
+
+            # Detect if this is an AutoField/BigAutoField type change
+            is_autofield_change = (
+                isinstance(old_field, (AutoField, BigAutoField)) or
+                isinstance(new_field, (AutoField, BigAutoField))
+            )
+
+            # ------------------------------------------------------------------------------------
+            # Collect db_index=True indexes
+            # ------------------------------------------------------------------------------------
+            if is_autofield_change:
+                # AutoField changes drop ALL indexes - restore ALL db_index=True fields
+                for field in model._meta.fields:
+                    if field.db_index:
+                        index_columns.append([field])
+            elif old_field.db_index and new_field.db_index:
                 index_columns.append([old_field])
-            else:
-                # Handle index_together for only django version < 5.1
-                if django_version < (5, 1):
-                   # Get the field objects for each field name in the index_together. 
-                   for fields in model._meta.index_together:
-                      # If the old field's column is among the columns for this index,
-                      # add this set of columns to index_columns for later index recreation.
-                      columns = [model._meta.get_field(field) for field in fields]
-                      if old_field.column in [c.column for c in columns]:
-                         index_columns.append(columns)
+
+            # --------------------------------------------------------------------------------
+            # index_together (Django < 5.1 only)
+            # --------------------------------------------------------------------------------
+            # Note: index_together is deprecated and removed in Django 5.1+.
+            # For AutoField changes, restore ALL index_together indexes.
+            # For other changes, only restore indexes involving the altered field.
+            # --------------------------------------------------------------------------------
+            if django_version < (5, 1):
+                for fields in model._meta.index_together:
+                    columns = [model._meta.get_field(field) for field in fields]
+                    if is_autofield_change or old_field.column in [c.column for c in columns]:
+                        index_columns.append(columns)
+
+            # --------------------------------------------------------------------------------
+            # Execute restoration: db_index and index_together
+            # --------------------------------------------------------------------------------
+            # Deduplication: Skip if already in deferred_sql (Django's queue) or
+            # post_actions (other_actions from _alter_column_type_sql).
+            # --------------------------------------------------------------------------------
             if index_columns:
                 for columns in index_columns:
                     create_index_sql_statement = self._create_index_sql(model, columns)
-                    if (create_index_sql_statement.__str__()
-                            not in [sql.__str__() for sql in self.deferred_sql] + [statement[0].__str__() for statement in post_actions]
+                    if (str(create_index_sql_statement)
+                            not in [str(sql) for sql in self.deferred_sql] + [str(statement[0]) for statement in post_actions]
                             ):
                         self.execute(create_index_sql_statement)
+
+            # --------------------------------------------------------------------------------
+            # Collect indexes defined in Meta.indexes
+            # --------------------------------------------------------------------------------
+            # Collect Index objects (not just field lists) to preserve explicit names
+            # and other index attributes when calling index.create_sql().
+            # For AutoField changes, restore ALL Meta.indexes.
+            # For other changes, only restore indexes involving the altered field.
+            # --------------------------------------------------------------------------------
+            for index in model._meta.indexes:
+                # Get the field objects for this index
+                index_fields = [model._meta.get_field(field_name) for field_name in index.fields]
+                index_columns_list = [field.column for field in index_fields]
+
+                # Restore if: AutoField change (all indexes dropped) OR field is in this index
+                if is_autofield_change or old_field.column in index_columns_list:
+                    indexes_to_restore.append(index)  # Store the Index object, not field list
+
+            # --------------------------------------------------------------------------------
+            # Execute restoration: Meta.indexes
+            # --------------------------------------------------------------------------------
+            # Restore Index objects using index.create_sql() to preserve explicit names
+            # and attributes.
+            #
+            # Deduplication: Skip if already in deferred_sql or post_actions
+            # (which contains other_actions from _alter_column_type_sql).
+            # This prevents duplicate index creation if the same index
+            # was already scheduled elsewhere.
+            # --------------------------------------------------------------------------------
+            for index in indexes_to_restore:
+                create_index_sql_statement = index.create_sql(model, self)
+                if create_index_sql_statement and (str(create_index_sql_statement)
+                        not in [str(sql) for sql in self.deferred_sql] + [str(statement[0]) for statement in post_actions]
+                        ):
+                    self.execute(create_index_sql_statement)
 
         # Type alteration on primary key? Then we need to alter the column
         # referring to us.

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -1,4 +1,5 @@
 import logging
+from collections import namedtuple
 
 import django.db
 from django import VERSION
@@ -8,8 +9,8 @@ from django.db.migrations.migration import Migration
 from django.db.migrations.state import ProjectState
 from django.db.models import UniqueConstraint
 from django.db.utils import DEFAULT_DB_ALIAS, ConnectionHandler, ProgrammingError
-from django.test import TestCase
-from unittest import skipIf
+from django.test import TestCase, TransactionTestCase
+from unittest import skipIf, expectedFailure
 
 from . import get_constraints
 from ..models import (
@@ -28,6 +29,9 @@ else:
     connection = DefaultConnectionProxy()
 
 logger = logging.getLogger('mssql.tests')
+
+# Result type for migration test helper
+MigrationTestResult = namedtuple('MigrationTestResult', ['model', 'constraints', 'project_state'])
 
 
 class TestIndexesRetained(TestCase):
@@ -116,7 +120,7 @@ class TestCorrectIndexes(TestCase):
                 expected_index_causes = []
                 if field.db_index:
                     expected_index_causes.append('db_index=True')
-                if VERSION < (5, 1):     
+                if VERSION < (5, 1):
                    for field_names in model_cls._meta.index_together:
                       if field.name in field_names:
                          expected_index_causes.append(f'index_together[{field_names}]')
@@ -179,6 +183,1569 @@ class TestIndexesBeingDropped(TestCase):
                 editor.alter_field(Choice, old_field, new_field, strict=True)
         except ProgrammingError:
             self.fail("Unique indexes not being dropped")
+
+class TestMetaIndexesRetained(TransactionTestCase):
+    """
+    Regression test for indexes defined via Meta.indexes being dropped
+    and not recreated after altering one of the indexed columns.
+
+    Tests various schema operations that trigger index drop/recreate logic to ensure
+    indexes are properly restored.
+
+    Each test runs twice:
+    - With migrations in split contexts (simulates separate migration files)
+    - With migrations in combined context (simulates single migration file with multiple operations)
+    """
+
+    def _run_migration_test(
+        self,
+        operations_a: list,
+        operations_b: list,
+        migration_name_prefix: str,
+        model_name: str,
+        use_single_migration: bool,
+    ) -> MigrationTestResult:
+        """
+        Helper to run migration tests with either combined or split schema_editor contexts.
+
+        Args:
+            operations_a: List of operations for initial setup (CreateModel + AddIndex)
+            operations_b: List of operations for the alteration being tested
+            migration_name_prefix: Prefix for migration names (e.g., 'test_mc_type')
+            model_name: Name of the model being tested
+            use_single_migration: If True, combine both operation lists into one Migration;
+                               If False, create two separate Migrations
+
+        Returns:
+            MigrationTestResult: Named tuple containing (model, constraints, project_state)
+        """
+        # Use django.db.connections to get a fresh connection for TransactionTestCase
+        conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+        suffix = '_combined' if use_single_migration else '_split'
+
+        if use_single_migration:
+            # Combined: Create ONE migration with all operations combined
+            # This simulates combining operations in a single migration file
+            class CombinedMigration(migrations.Migration):
+                initial = True
+                operations = operations_a + operations_b
+
+            migration = CombinedMigration(name=f'{migration_name_prefix}{suffix}', app_label='testapp')
+
+            with conn.schema_editor(atomic=True) as editor:
+                project_state = migration.apply(ProjectState(), editor)
+        else:
+            # Split: Create TWO separate migrations, each with its own operations
+            # This simulates two separate migration files where the first migration
+            # is fully committed and `deferred_sql` runs before starting the second migration
+            class MigrationA(migrations.Migration):
+                initial = True
+                operations = operations_a
+
+            class MigrationB(migrations.Migration):
+                operations = operations_b
+
+            migration_a = MigrationA(name=f'{migration_name_prefix}{suffix}_a', app_label='testapp')
+            migration_b = MigrationB(name=f'{migration_name_prefix}{suffix}_b', app_label='testapp')
+
+            with conn.schema_editor(atomic=True) as editor:
+                project_state = migration_a.apply(ProjectState(), editor)
+            with conn.schema_editor(atomic=True) as editor:
+                project_state = migration_b.apply(project_state, editor)
+
+        # Get the model and constraints for assertions
+        model = project_state.apps.get_model('testapp', model_name)
+        constraints = get_constraints(table_name=model._meta.db_table)
+
+        return MigrationTestResult(model, constraints, project_state)
+
+    def _assert_index_exists(self, constraints, expected_columns, error_msg):
+        """
+        Assert that an index with exactly the expected columns exists.
+
+        Args:
+            constraints: Dictionary of constraints from get_constraints()
+            expected_columns: Set of column names that should be in the index
+            error_msg: Message to display if assertion fails
+        """
+        found = any(
+            set(info['columns']) == expected_columns and info['index']
+            for info in constraints.values()
+        )
+        self.assertTrue(found, error_msg)
+
+    def _get_context_description(self, use_single_migration: bool) -> str:
+        return "combined single migration" if use_single_migration else "split into 2 migrations"
+
+    def test_index_from_meta_indexes_retained_after_type_change(self):
+        """
+        Test that indexes defined in Meta.indexes are retained when altering field type (max_length change).
+        This exercises the type change code path in _alter_field.
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxType{suffix}'
+
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20)),
+                            ('b', models.CharField(max_length=20)),
+                        ],
+                    ),
+                    migrations.AddIndex(
+                        model_name=model_name.lower(),
+                        index=models.Index(fields=['a', 'b'], name=f'idx_type{suffix}'),
+                    ),
+                ]
+
+                operations_b = [
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='a',
+                        field=models.CharField(max_length=40),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_type',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"Index on ('a', 'b') from Meta.indexes was not recreated after field type change "
+                        f"({self._get_context_description(use_single_migration)}). Expected index to be restored after ALTER COLUMN operation."
+                    ),
+                )
+
+    def test_index_from_meta_indexes_retained_after_nullability_change(self):
+        """
+        Test that indexes defined in Meta.indexes are retained when changing field nullability.
+        This exercises the nullability change code path in _alter_field.
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxNull{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_null{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=20, null=True),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_null',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"Index on ('a', 'b') from Meta.indexes was not recreated after nullability change "
+                        f"({self._get_context_description(use_single_migration)}). Expected index to be restored after ALTER COLUMN NULL operation."
+                    ),
+                )
+
+    def test_db_index_retained_after_nullability_only_change(self):
+        """
+        Test that db_index=True indexes are retained when ONLY nullability changes.
+
+        This tests the case where:
+        - Field has db_index=True
+        - Field nullability changes (null=False → null=True)
+        - Field type does NOT change (same max_length)
+
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestDbIndexNullChange{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20, db_index=True)),  # db_index=True, null=False
+                            ],
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=20, db_index=True, null=True),  # Same type, different null
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_dbidx_null',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Verify db_index=True index was retained
+                # Look for single-column index on 'a'
+                db_index_indexes = [
+                    info for info in result.constraints.values()
+                    if info.get('index') and set(info['columns']) == {'a'}
+                ]
+                self.assertTrue(
+                    len(db_index_indexes) > 0,
+                    f"db_index=True index on 'a' was not retained after nullability-only change "
+                    f"({self._get_context_description(use_single_migration)}). "
+                    f"Expected index from db_index=True to be restored after changing null=False to null=True."
+                )
+
+    def test_db_index_retained_after_nullability_change_to_not_null(self):
+        """
+        Test that db_index=True indexes are retained when changing from null=True to null=False.
+
+        This is the reverse direction of test_db_index_retained_after_nullability_only_change
+        and exercises the four-way default alteration path in _alter_field (requires a default value).
+
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestDbIndexNotNull{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20, db_index=True, null=True)),  # db_index=True, null=True
+                            ],
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=20, db_index=True, null=False, default=''),  # null=False requires default
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_dbidx_notnull',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Verify db_index=True index was retained
+                db_index_indexes = [
+                    info for info in result.constraints.values()
+                    if info.get('index') and set(info['columns']) == {'a'}
+                ]
+                self.assertTrue(
+                    len(db_index_indexes) > 0,
+                    f"db_index=True index on 'a' was not retained after nullability change from NULL to NOT NULL "
+                    f"({self._get_context_description(use_single_migration)}). "
+                    f"Expected index from db_index=True to be restored after four-way default alteration."
+                )
+
+    def test_index_from_meta_indexes_retained_after_field_rename(self):
+        """
+        Test that indexes defined in Meta.indexes are retained and updated when renaming a field.
+        The index should exist on the renamed column.
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxRename{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_rename{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.RenameField(
+                            model_name=model_name.lower(),
+                            old_name='a',
+                            new_name='a_renamed',
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a_renamed', 'b'},
+                    error_msg=(
+                        f"Index on ('a_renamed', 'b') from Meta.indexes was not found after field rename "
+                        f"({self._get_context_description(use_single_migration)}). Expected index to be updated to reflect the renamed column."
+                    ),
+                )
+
+    @expectedFailure
+    def test_index_from_meta_indexes_retained_after_rename_and_type_change(self):
+        """
+        Test that indexes from Meta.indexes are retained when a field is renamed
+        AND has its type changed in the same migration.
+
+        This tests a known bug: the TYPE CHANGE PATH drops indexes, but the
+        RESTORE PHASE is skipped when column is renamed (old_field.column != new_field.column).
+
+        Additionally, _delete_indexes() fails with FieldDoesNotExist because it tries to
+        look up the index field by the old field name, but RenameField has already updated
+        the model state, so the old field name no longer exists.
+
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxRenameType{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_rename_type{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        # Rename field 'a' to 'a_renamed'
+                        migrations.RenameField(
+                            model_name=model_name.lower(),
+                            old_name='a',
+                            new_name='a_renamed',
+                        ),
+                        # Also change its type (max_length 20 -> 40)
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a_renamed',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_rename_type',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a_renamed', 'b'},
+                    error_msg=(
+                        f"Index on ('a_renamed', 'b') from Meta.indexes was not found after field rename + type change "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index to be retained when both rename and type change occur."
+                    ),
+                )
+
+    def test_db_index_retained_after_rename_and_type_change(self):
+        """
+        Test that db_index=True indexes are retained when a field's db_column is changed
+        AND has its type changed in the same AlterField operation.
+
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestDbIdxRenameType{suffix}'
+
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20, db_index=True, db_column='col_a')),
+                            ('b', models.CharField(max_length=20)),
+                        ],
+                    ),
+                ]
+
+                operations_b = [
+                    # Change db_column AND type in single AlterField
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='a',
+                        field=models.CharField(max_length=40, db_index=True, db_column='col_a_renamed'),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_dbidx_rename_type',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'col_a_renamed'},
+                    error_msg=(
+                        f"db_index=True index on 'col_a_renamed' was not found after column rename + type change "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index to be retained when both column rename and type change occur in same AlterField."
+                    ),
+                )
+
+    def test_unique_retained_after_rename_and_type_change(self):
+        """
+        Test that unique=True constraints are retained when a field's db_column is changed
+        AND has its type changed in the same AlterField operation.
+
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestUniqueRenameType{suffix}'
+
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20, unique=True, db_column='col_a')),
+                            ('b', models.CharField(max_length=20)),
+                        ],
+                    ),
+                ]
+
+                operations_b = [
+                    # Change db_column AND type in single AlterField
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='a',
+                        field=models.CharField(max_length=40, unique=True, db_column='col_a_renamed'),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_uniq_rename_type',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Check for unique constraint on the renamed column
+                unique_constraints = [
+                    info for info in result.constraints.values()
+                    if info.get('unique') and set(info['columns']) == {'col_a_renamed'}
+                ]
+                self.assertTrue(
+                    len(unique_constraints) > 0,
+                    f"unique=True constraint on 'col_a_renamed' was not found after column rename + type change "
+                    f"({self._get_context_description(use_single_migration)}). "
+                    f"Expected unique constraint to be retained."
+                )
+
+    @expectedFailure
+    @skipIf(VERSION >= (5, 1), "unique_together is deprecated in Django 5.1+")
+    def test_unique_together_retained_after_rename_and_type_change(self):
+        """
+        Test that unique_together constraints are retained when a field's db_column is changed
+        AND has its type changed in the same AlterField operation.
+
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestUniqTogetherRenameType{suffix}'
+
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20, db_column='col_a')),
+                            ('b', models.CharField(max_length=20)),
+                        ],
+                        options={
+                            'unique_together': {('a', 'b')},
+                        },
+                    ),
+                ]
+
+                operations_b = [
+                    # Change db_column AND type in single AlterField
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='a',
+                        field=models.CharField(max_length=40, db_column='col_a_renamed'),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_uniqtog_rename_type',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Check for unique_together constraint on ('col_a_renamed', 'b')
+                unique_constraints = [
+                    info for info in result.constraints.values()
+                    if info.get('unique') and set(info['columns']) == {'col_a_renamed', 'b'}
+                ]
+                self.assertTrue(
+                    len(unique_constraints) > 0,
+                    f"unique_together constraint on ('col_a_renamed', 'b') was not found after column rename + type change "
+                    f"({self._get_context_description(use_single_migration)}). "
+                    f"Expected unique_together to be retained."
+                )
+
+    @expectedFailure
+    def test_index_from_meta_indexes_retained_after_rename_and_nullability_change(self):
+        """
+        Test that indexes from Meta.indexes are retained when a field is renamed
+        AND has its nullability changed in the same migration.
+
+        This tests a known bug: the NULLABILITY CHANGE PATH drops indexes, but the
+        RESTORE PHASE is skipped when column is renamed (old_field.column != new_field.column).
+
+        Additionally, _delete_indexes() fails with FieldDoesNotExist because it tries to
+        look up the index field by the old field name, but RenameField has already updated
+        the model state, so the old field name no longer exists.
+
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxRenameNull{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_rename_null{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        # Rename field 'a' to 'a_renamed'
+                        migrations.RenameField(
+                            model_name=model_name.lower(),
+                            old_name='a',
+                            new_name='a_renamed',
+                        ),
+                        # Also change its nullability
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a_renamed',
+                            field=models.CharField(max_length=20, null=True),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_rename_null',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a_renamed', 'b'},
+                    error_msg=(
+                        f"Index on ('a_renamed', 'b') from Meta.indexes was not found after field rename + nullability change "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index to be retained when both rename and nullability change occur."
+                    ),
+                )
+
+    def test_index_from_meta_indexes_retained_after_altering_both_fields(self):
+        """
+        Test that indexes defined in Meta.indexes are retained when altering multiple fields in the index.
+        This ensures the index is properly restored even when both participating columns are altered.
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxBoth{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_both{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=40),
+                        ),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=30),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_both',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"Index on ('a', 'b') from Meta.indexes was not recreated after altering both fields "
+                        f"({self._get_context_description(use_single_migration)}). Expected index to be restored after multiple ALTER COLUMN operations."
+                    ),
+                )
+
+    def test_three_column_index_retained_after_field_alteration(self):
+        """
+        Test that indexes with 3+ columns are retained when altering one of the fields.
+        This ensures the fix works for indexes with more than 2 columns.
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdx3Col{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                                ('c', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b', 'c'], name=f'idx_3col{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=50),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_3col',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b', 'c'},
+                    error_msg=(
+                        f"Three-column index on ('a', 'b', 'c') was not recreated after field alteration "
+                        f"({self._get_context_description(use_single_migration)}). Expected index to be restored after ALTER COLUMN operation on middle column."
+                    ),
+                )
+
+    def test_indexes_retained_for_field_with_db_index_and_meta_indexes(self):
+        """
+        Test that when a field has indexes from both db_index=True and Meta.indexes, those
+        indexes are both retained after altering that field.
+        """
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxDbIdx{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20, db_index=True)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_dbidx{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=40, db_index=True),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_dbidx',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Check that _meta_indexes index was recreated
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"Index on ('a', 'b') from Meta.indexes was not recreated after field type change "
+                        f"({self._get_context_description(use_single_migration)})."
+                    ),
+                )
+
+                # Check that index from db_index=True was also recreated
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a'},
+                    error_msg=(
+                        "Index on 'a' from db_index=True was not recreated "
+                        f"after field type change ({self._get_context_description(use_single_migration)})."
+                    ),
+                )
+
+    def test_index_from_meta_indexes_retained_after_type_and_nullability_change(self):
+        """
+        Test that indexes defined in Meta.indexes are retained when BOTH type and nullability change simultaneously.
+        This exercises both code paths in _alter_field (type change AND nullability change).
+        The index should only be dropped once and recreated once (tests deduplication logic).
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxTypeNull{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_typenull{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=40, null=True),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_typenull',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"Index on ('a', 'b') from Meta.indexes was not recreated after simultaneous type and nullability change "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index to be restored after ALTER COLUMN operation changing both max_length and nullability."
+                    ),
+                )
+
+    def test_indexes_from_meta_indexes_retained_with_unique_together(self):
+        """
+        Test that indexes defined in Meta.indexes coexist properly with unique_together constraints.
+        Tests the case where a model has overlapping columns participating in both unique_together and
+        indexes defined in Meta.indexes. The index defined in Meta.indexes should be retained after field alteration.
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxUniqTogether{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                                ('c', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AlterUniqueTogether(
+                            name=model_name.lower(),
+                            unique_together={('a', 'b')},
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'c'], name=f'idx_uniqtog{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_uniqtog',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Check that the index (a, c) from Meta.indexes was recreated
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'c'},
+                    error_msg=(
+                        f"Index on ('a', 'c') from Meta.indexes was not recreated after field alteration "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index to coexist with unique_together constraint on ('a', 'b')."
+                    ),
+                )
+
+                # Also verify that unique_together constraint still exists
+                unique_constraints = [
+                    info for info in result.constraints.values()
+                    if info.get('unique') and set(info['columns']) == {'a', 'b'}
+                ]
+                self.assertTrue(
+                    len(unique_constraints) > 0,
+                    f"unique_together constraint on ('a', 'b') was lost "
+                    f"({self._get_context_description(use_single_migration)})."
+                )
+
+    def test_index_from_meta_indexes_retained_after_fk_alteration(self):
+        """
+        Test that indexes defined in Meta.indexes containing ForeignKey fields are retained after FK alteration.
+        ForeignKey handling in _alter_field is complex, and this ensures that indexes defined in Meta.indexes
+        involving FK fields are properly restored.
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                ref_model_name = f'TestMetaIdxFKRef{suffix}'
+                model_name = f'TestMetaIdxFK{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=ref_model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('name', models.CharField(max_length=50)),
+                            ],
+                        ),
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('fk_field', models.ForeignKey(
+                                    to=f'testapp.{ref_model_name}',
+                                    on_delete=models.CASCADE,
+                                )),
+                                ('other_field', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['fk_field', 'other_field'], name=f'idx_fk{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='fk_field',
+                            field=models.ForeignKey(
+                                to=f'testapp.{ref_model_name}',
+                                on_delete=models.SET_NULL,
+                                null=True,
+                            ),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_fk',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'fk_field_id', 'other_field'},
+                    error_msg=(
+                        f"Index on ('fk_field', 'other_field') from Meta.indexes was not recreated after FK alteration "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index to be restored after changing FK from CASCADE to SET_NULL with null=True."
+                    ),
+                )
+
+    def test_multiple_index_from_meta_indexes_retained(self):
+        """
+        Test that ALL indexes defined in Meta.indexes are retained when a field participates in multiple indexes.
+        A field can be part of multiple different indexes defined in Meta.indexes, and all should be restored
+        after altering that field.
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaMulti{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                                ('c', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_multi_ab{suffix}'),
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'c'], name=f'idx_multi_ac{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_multi',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Check that both indexes defined in Meta.indexes were recreated
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"Index on ('a', 'b') from Meta.indexes was not recreated after field alteration "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected BOTH indexes containing field 'a' to be restored."
+                    ),
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'c'},
+                    error_msg=(
+                        f"Index on ('a', 'c') from Meta.indexes was not recreated after field alteration "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected BOTH indexes containing field 'a' to be restored."
+                    ),
+                )
+
+    def test_index_from_meta_indexes_retained_after_nullability_change_to_not_null(self):
+        """
+        Test that indexes defined in Meta.indexes are retained when changing field from NULL to NOT NULL.
+        This is the reverse direction of the existing nullability test and exercises the
+        four-way default alteration path in _alter_field (requires a default value).
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxNotNull{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20, null=True)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_notnull{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=20, null=False, default=''),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_notnull',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"Index on ('a', 'b') from Meta.indexes was not recreated after nullability change from NULL to NOT NULL "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index to be restored after ALTER COLUMN operation with default value handling."
+                    ),
+                )
+
+    def test_autofield_type_change_preserves_indexes(self):
+        """
+        Test that indexes defined in Meta.indexes are retained when changing AutoField to BigAutoField.
+        This exercises the AutoField/BigAutoField restoration path in _alter_field
+        which restores ALL indexes on ALL fields, not just the altered field.
+        Runs with both split and combined migrations.
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxAutoField{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=f'idx_auto{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='id',
+                            field=models.BigAutoField(primary_key=True),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_auto',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"Index on ('a', 'b') from Meta.indexes was not recreated after AutoField to BigAutoField change "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index to be restored via AutoField/BigAutoField special restoration path."
+                    ),
+                )
+
+    def test_autofield_to_bigautofield_with_other_db_index_field_split(self):
+        """
+        Test that changing AutoField to BigAutoField preserves db_index=True indexes
+        on other fields when operations are in separate migrations.
+
+        This test verifies the split migration case works correctly - the index is
+        created and committed in the first migration before the AutoField alteration
+        runs in the second migration.
+        """
+        model_name = 'TestAutoDbIndex_split'
+
+        operations_a = [
+            migrations.CreateModel(
+                name=model_name,
+                fields=[
+                    ('id', models.AutoField(primary_key=True)),
+                    ('name', models.CharField(max_length=100, db_index=True)),
+                    ('other', models.CharField(max_length=100)),
+                ],
+            ),
+        ]
+
+        operations_b = [
+            migrations.AlterField(
+                model_name=model_name.lower(),
+                name='id',
+                field=models.BigAutoField(primary_key=True),
+            ),
+        ]
+
+        result = self._run_migration_test(
+            operations_a=operations_a,
+            operations_b=operations_b,
+            migration_name_prefix='test_auto_dbindex',
+            model_name=model_name,
+            use_single_migration=False,
+        )
+
+        # Verify db_index=True index on 'name' was retained
+        self._assert_index_exists(
+            result.constraints,
+            expected_columns={'name'},
+            error_msg=(
+                "db_index=True index on 'name' was not retained after AutoField to BigAutoField change "
+                "(split into 2 migrations). Expected index to be preserved."
+            ),
+        )
+
+    def test_autofield_to_bigautofield_with_other_db_index_field_combined(self):
+        """
+        Test that changing AutoField to BigAutoField preserves db_index=True indexes
+        on other fields when operations are in a single (combined) migration.
+
+        This tests that the deduplication logic in _alter_field works correctly:
+        when CreateModel queues a db_index in deferred_sql and the AutoField
+        restoration code runs, it should skip creating duplicate indexes.
+        """
+        model_name = 'TestAutoDbIndex_combined'
+
+        operations_a = [
+            migrations.CreateModel(
+                name=model_name,
+                fields=[
+                    ('id', models.AutoField(primary_key=True)),
+                    ('name', models.CharField(max_length=100, db_index=True)),
+                    ('other', models.CharField(max_length=100)),
+                ],
+            ),
+        ]
+
+        operations_b = [
+            migrations.AlterField(
+                model_name=model_name.lower(),
+                name='id',
+                field=models.BigAutoField(primary_key=True),
+            ),
+        ]
+
+        result = self._run_migration_test(
+            operations_a=operations_a,
+            operations_b=operations_b,
+            migration_name_prefix='test_auto_dbindex',
+            model_name=model_name,
+            use_single_migration=True,
+        )
+
+        # Verify db_index=True index on 'name' was retained
+        self._assert_index_exists(
+            result.constraints,
+            expected_columns={'name'},
+            error_msg=(
+                "db_index=True index on 'name' was not retained after AutoField to BigAutoField change "
+                "(combined into 1 migration). Expected index to be preserved."
+            ),
+        )
+
+    @skipIf(VERSION >= (5, 1), "index_together is removed in Django 5.1+")
+    def test_index_together_retained_after_autofield_change(self):
+        """
+        Test that index_together indexes are retained when changing AutoField to BigAutoField.
+
+        This tests the index_together restoration path in _alter_field for AutoField changes.
+        Since AutoField changes drop ALL indexes on the table, the restoration code must
+        also restore ALL index_together indexes, not just those involving the altered field.
+
+        Note: index_together is deprecated in Django 4.2 and removed in Django 5.1+.
+        This test only runs on Django < 5.1.
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestIdxTogetherAuto{suffix}'
+
+                # Create model with index_together using the deprecated Meta option
+                # We need to use a raw SQL approach or create the model dynamically
+                # since Django's migration system handles index_together
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20)),
+                            ('b', models.CharField(max_length=20)),
+                        ],
+                        options={
+                            'index_together': {('a', 'b')},
+                        },
+                    ),
+                ]
+
+                operations_b = [
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='id',
+                        field=models.BigAutoField(primary_key=True),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_idx_together_auto',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"index_together index on ('a', 'b') was not recreated after AutoField to BigAutoField change "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index to be restored via AutoField restoration path."
+                    ),
+                )
+
+    def test_pk_type_change_preserves_indexes(self):
+        """
+        Test that indexes defined in Meta.indexes are retained when changing primary key type.
+        This tests the primary key restoration path alongside the restoration of indexes from Meta.indexes.
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMetaIdxPK{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['id', 'a'], name=f'idx_pk{suffix}'),
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='id',
+                            field=models.BigAutoField(primary_key=True),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_mc_pk',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Verify primary key still exists
+                pk_constraints = [
+                    info for info in result.constraints.values()
+                    if info.get('primary_key')
+                ]
+                self.assertTrue(
+                    len(pk_constraints) > 0,
+                    f"Primary key was not restored ({self._get_context_description(use_single_migration)})."
+                )
+
+                # Verify index from Meta.indexes including PK column was restored
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'id', 'a'},
+                    error_msg=(
+                        f"Index on ('id', 'a') from Meta.indexes was not recreated after PK type change "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index containing PK column to be restored."
+                    ),
+                )
+
+    @skipIf(VERSION >= (5, 1), "index_together removed in Django 5.1")
+    def test_index_together_retained_after_type_change(self):
+        """
+        Test that index_together indexes are retained when altering a field type.
+
+        IMPORTANT: This test documents the known limitation that index_together is only
+        restored when the field does NOT have db_index=True. If a field has both
+        db_index=True AND is in index_together, only the index from db_index=True is restored
+        through the standard restoration path. This is intentional behavior for the
+        deprecated index_together API (removed in Django 5.1+).
+
+        This test uses a field WITHOUT db_index=True to verify the index_together
+        restoration works in that scenario.
+
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestIdxTogether{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),  # No db_index=True
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AlterIndexTogether(
+                            name=model_name.lower(),
+                            index_together={('a', 'b')},
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_idxtog',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Verify index_together index was restored
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        f"index_together index on ('a', 'b') was not recreated after type change "
+                        f"({self._get_context_description(use_single_migration)}). "
+                        f"Expected index_together to be restored for field without db_index=True."
+                    ),
+                )
+
+    @expectedFailure
+    def test_unique_together_retained_when_field_also_has_unique_true(self):
+        """
+        Test that unique_together constraints are retained when a field with unique=True is altered.
+
+        KNOWN BUG: When a field has BOTH unique=True AND participates in unique_together,
+        only the single-field unique constraint is restored after field alteration.
+        The unique_together constraint is NOT restored because the unique_together restoration is in an
+        'else' block that only executes when the field does NOT have unique=True.
+
+        Runs with both split and combined migrations
+        """
+        for use_single_migration in [False, True]:
+
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestUniqueAndUniqTogether{suffix}'
+
+                operations_a = [
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20, unique=True)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AlterUniqueTogether(
+                            name=model_name.lower(),
+                            unique_together={('a', 'b')},
+                        ),
+                    ]
+
+                operations_b = [
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=40, unique=True),
+                        ),
+                    ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_uniq_uniqtog',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                # Check that single-field unique constraint on 'a' was restored
+                single_unique_constraints = [
+                    info for info in result.constraints.values()
+                    if info.get('unique') and set(info['columns']) == {'a'}
+                ]
+                self.assertTrue(
+                    len(single_unique_constraints) > 0,
+                    f"Single-field unique constraint on 'a' was not restored "
+                    f"({self._get_context_description(use_single_migration)})."
+                )
+
+                # Check that unique_together constraint on ('a', 'b') was restored
+                # THIS ASSERTION WILL FAIL due to the bug in mssql/schema.py lines 838-871
+                unique_together_constraints = [
+                    info for info in result.constraints.values()
+                    if info.get('unique') and set(info['columns']) == {'a', 'b'}
+                ]
+                self.assertTrue(
+                    len(unique_together_constraints) > 0,
+                    f"unique_together constraint on ('a', 'b') was not restored when field 'a' has unique=True "
+                    f"({self._get_context_description(use_single_migration)}). "
+                    f"This is a bug in mssql/schema.py: unique_together restoration is in an 'else' block "
+                    f"that only executes when the field does NOT have unique=True."
+                )
+
+
+
+
 
 class TestAddAndAlterUniqueIndex(TestCase):
 


### PR DESCRIPTION
Fixes #486 — Indexes defined via `Meta.indexes` are dropped and not recreated when altering an indexed column (e.g., changing `max_length` or nullability).

Fixes #491 — Duplicate index error (`ProgrammingError`) when changing `AutoField` to `BigAutoField` in a combined migration where another field has `db_index=True`.

## Issue #486: Meta.indexes not restored after field alteration

When SQL Server needs to alter a column's type or nullability, `_alter_field` in `schema.py` drops all indexes on the affected column first (SQL Server requires this). However, the restoration logic that runs afterward only handled:

- `db_index=True` single-field indexes
- `index_together` indexes
- Unique constraints

Indexes defined via `Meta.indexes` were never restored. This meant any index defined in `Meta.indexes` would be silently dropped whenever a participating column was altered.

## Issue #491: Duplicate index on AutoField → BigAutoField change

When `AutoField` is changed to `BigAutoField`, the restoration logic unconditionally recreated all `db_index=True` indexes via `self.execute()`. In a combined migration (where `CreateModel` and `AlterField` are in the same migration file), the index already existed in `deferred_sql` (queued during `CreateModel` but not yet executed). This caused the same index to be created twice, resulting in a `ProgrammingError`.

## Fix

The index restoration phase in `_alter_field` has been refactored to:

1. **Restore `Meta.indexes`**: After column alteration, indexes from `model._meta.indexes` involving the altered field are now restored using `index.create_sql()`.

2. **Handle AutoField/BigAutoField comprehensively**: When an `AutoField`/`BigAutoField` is altered, ALL indexes are restored (db_index, index_together, and Meta.indexes), since SQL Server drops all indexes on the table for IDENTITY column changes.

3. **Deduplicate index creation**: Before executing any index creation, the SQL is checked against both `deferred_sql` and `post_actions`. This prevents the duplicate creation that caused #491.

4. **Remove the broken nullability-path restoration**: The old nullability change path had ad-hoc index restoration logic. This has been removed in favor of the unified restoration block that handles all cases.

## Changes

- **`mssql/schema.py`**: Refactored `_alter_field` index restoration to handle `Meta.indexes`, AutoField/BigAutoField changes, and deduplication in a unified block.

## Testing

**`testapp/tests/test_indexes.py`**: Added new test methods in `TestMetaIndexesRetained` covering:

- Type changes, nullability changes, and combined type+nullability changes
- Field renames
- ForeignKey alterations
- Multiple indexes on the same field
- `db_index=True` combined with `Meta.indexes`
- `unique_together` coexistence with `Meta.indexes`
- AutoField → BigAutoField changes (both split and combined migrations)
- `index_together` retention (Django < 5.1)
- Three-column indexes

Each test runs in both "split migration" and "combined migration" modes because Django's `schema_editor` uses a `deferred_sql` queue that changes the timing of index creation, and each mode exercises different code paths:

- **Split mode** (two separate `schema_editor` contexts): Simulates two separate migration files. The first context creates the table and its indexes, then exits, at which point `deferred_sql` is flushed and all indexes physically exist in the database. The second context then runs the `AlterField` operation, which queries the database, finds and drops the indexes, alters the column, and must restore them.

- **Combined mode** (single `schema_editor` context): Simulates a single migration file containing both `CreateModel` and `AlterField`. Here, `CreateModel` adds index creation SQL to `deferred_sql` but it has not been executed yet when `AlterField` runs. The indexes don't physically exist in the database, so the DROP phase finds nothing. However, the RESTORE phase must not blindly create indexes that are already queued in `deferred_sql`, or they will be created twice when the context exits and flushes the queue.

## Known existing bugs not fixed by this PR (documented with `@expectedFailure` tests)

- **Rename + alter in same migration**: When a field is renamed via `RenameField` AND altered in the same migration, `_delete_indexes()` fails because it looks up the field by the old name which no longer exists in model state. 
https://github.com/microsoft/mssql-django/issues/499
- **`unique_together` + `unique=True` on same field**: When a field has both `unique=True` and participates in `unique_together`, only the single-field unique constraint is restored (the `unique_together` restoration is in an `else` branch). https://github.com/microsoft/mssql-django/issues/494