### PR TITLE
FIX: Expand ColPairs in get_order_by() to prevent ORDER BY corruption with JSONArray

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,3 +146,18 @@ echo "yes" | python tests/runtests.py --settings=testapp.settings <module>
 3. Add appropriate test exclusions with comments explaining why
 4. Keep compiler.py and schema.py changes focused - they are complex and sensitive
 5. When adding SQL Server function overrides, use the `as_microsoft` pattern in `functions.py`
+
+## Development Workflow Rules
+
+### Git Hygiene
+- **Only commit files you intentionally changed.** Untracked files (e.g. `result.xml`, build artifacts) may exist in the workspace but not be in `.gitignore` — do not stage or commit them. Review `git diff` and `git status` before committing.
+- Do not modify `testapp/settings.py` database connection settings (ODBC driver version, passwords) as part of a PR — those are local dev environment changes.
+
+### Fix Quality
+- **Find the root cause, not a workaround.** Don't parse or manipulate compiled SQL strings when Django provides a structured expression API to solve the problem at the right level. Work at the expression/node level (e.g. override `get_order_by()`, use `as_microsoft` pattern) rather than post-hoc string surgery on generated SQL.
+- Follow existing codebase patterns: the `as_microsoft` monkey-patching pattern in `functions.py`, the `_as_microsoft()` dispatch in `compiler.py`, and compiler method overrides are the standard extension points.
+
+### Test Discipline
+- **All tests must be green before submitting.** If a test fails due to a SQL Server limitation (not a bug you introduced), add it to `EXCLUDED_TESTS` in `testapp/settings.py` with a comment explaining why.
+- If a failure is outside the scope of your PR, ask whether to fix it or exclude it — don't leave it failing silently.
+- Always run the specific Django test modules affected by your change (e.g. `ordering`, `db_functions`, `composite_pk`) in addition to the unit tests (`python manage.py test testapp.tests`).

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -22,6 +22,15 @@ if django.VERSION >= (3, 1):
         compile_json_path = None
 if django.VERSION >= (4, 2):
     from django.core.exceptions import EmptyResultSet, FullResultSet
+# ColPairs was introduced in Django 5.2 for composite primary key support.
+# When an OrderBy wraps a ColPairs, Django's OrderBy.as_sql() joins all
+# columns into a single comma-separated SQL string. We expand these at
+# the expression level in get_order_by() so each ORDER BY item is always
+# a single column expression.
+try:
+    from django.db.models.expressions import ColPairs
+except ImportError:
+    ColPairs = None
 
 def _as_sql_agv(self, compiler, connection):
     return self.as_sql(compiler, connection, template='%(function)s(CONVERT(float, %(field)s))')
@@ -223,6 +232,32 @@ compiler.cursor_iter = _cursor_iter
 
 class SQLCompiler(compiler.SQLCompiler):
 
+    def get_order_by(self):
+        """
+        Expand ColPairs-based OrderBy expressions into individual per-column
+        OrderBy entries before SQL compilation.
+
+        Django 5.2+ composite PKs produce OrderBy(ColPairs(...)) which
+        compiles to a single comma-separated SQL string. SQL Server doesn't
+        allow duplicate columns in ORDER BY (error 169), and expanding at
+        the expression level lets us deduplicate individual columns cleanly
+        without parsing SQL strings.
+        """
+        result = super().get_order_by()
+        if ColPairs is None:
+            return result
+        expanded = []
+        for resolved, (sql, params, is_ref) in result:
+            if isinstance(getattr(resolved, 'expression', None), ColPairs):
+                for col in resolved.expression.get_cols():
+                    order = resolved.copy()
+                    order.set_source_expressions([col])
+                    col_sql, col_params = self.compile(order)
+                    expanded.append((order, (col_sql, col_params, is_ref)))
+            else:
+                expanded.append((resolved, (sql, params, is_ref)))
+        return expanded
+
     def as_sql(self, with_limits=True, with_col_aliases=False):
         """
         Create the SQL for this query. Return the SQL string and list of
@@ -326,25 +361,24 @@ class SQLCompiler(compiler.SQLCompiler):
                                     odir = 'DESC' if expr.descending else 'ASC'
                                     o_sql = '%s %s' % (o_sql, odir)
                                 # SQL Server doesn't allow duplicate columns in ORDER BY.
+                                # ColPairs are already expanded in get_order_by(), so each
+                                # o_sql is a single column/expression.
                                 # Handle the case where [col] and [table].[col] refer to
-                                # the same column (common with composite PK ordering).
-                                # Also handle composite PK which may emit multiple comma-separated
-                                # columns in a single o_sql (e.g., "[t].[a] DESC, [t].[b] DESC").
-                                parts = [p.strip() for p in o_sql.split(',')]
-                                for part in parts:
-                                    col_ref = part.rsplit(' ', 1)[0] if part.endswith((' ASC', ' DESC')) else part
-                                    col_ref_upper = col_ref.upper()
-                                    is_qualified = '.' in col_ref
-                                    col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
-                                    # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
-                                    if col_ref_upper in seen_full:
-                                        continue
-                                    if is_qualified and col_name in seen_unqualified:
-                                        continue
-                                    seen_full.add(col_ref_upper)
-                                    if not is_qualified:
-                                        seen_unqualified.add(col_name)
-                                    ordering.append(part)
+                                # the same column.
+                                col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.rstrip().endswith(('ASC', 'DESC')) else o_sql
+                                col_ref_upper = col_ref.upper()
+                                # Only treat as a qualified column ref if it looks like
+                                # [table].[col], not a function call containing dots.
+                                is_qualified = '.' in col_ref and '(' not in col_ref
+                                col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
+                                if col_ref_upper in seen_full:
+                                    continue
+                                if is_qualified and col_name in seen_unqualified:
+                                    continue
+                                seen_full.add(col_ref_upper)
+                                if not is_qualified:
+                                    seen_unqualified.add(col_name)
+                                ordering.append(o_sql)
                                 params.extend(o_params)
                             offsetting_order_by = ', '.join(ordering)
                             order_by = []
@@ -424,29 +458,23 @@ class SQLCompiler(compiler.SQLCompiler):
                             # replace it with NEWID()
                             o_sql = o_sql.replace('RAND()', 'NEWID()')
                     # SQL Server doesn't allow the same column to appear twice
-                    # in ORDER BY. Handle the case where [col] and [table].[col]
-                    # refer to the same column (common with composite PK ordering).
-                    # Also handle composite PK which may emit multiple comma-separated
-                    # columns in a single o_sql (e.g., "[t].[a] DESC, [t].[b] DESC").
-                    parts = [p.strip() for p in o_sql.split(',')]
-                    deduped_parts = []
-                    for part in parts:
-                        col_ref = part.rsplit(' ', 1)[0] if part.endswith((' ASC', ' DESC')) else part
-                        col_ref_upper = col_ref.upper()
-                        is_qualified = '.' in col_ref
-                        col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
-                        # Skip if exact duplicate or if qualified ref matches earlier unqualified ref
-                        if col_ref_upper in seen_full:
-                            continue
-                        if is_qualified and col_name in seen_unqualified:
-                            continue
-                        seen_full.add(col_ref_upper)
-                        if not is_qualified:
-                            seen_unqualified.add(col_name)
-                        deduped_parts.append(part)
-                    if deduped_parts:
-                        ordering.append(', '.join(deduped_parts))
-                        params.extend(o_params)
+                    # in ORDER BY. ColPairs are already expanded in
+                    # get_order_by(), so each o_sql is a single expression.
+                    # Handle the case where [col] and [table].[col] refer to
+                    # the same column.
+                    col_ref = o_sql.rsplit(' ', 1)[0] if o_sql.rstrip().endswith(('ASC', 'DESC')) else o_sql
+                    col_ref_upper = col_ref.upper()
+                    is_qualified = '.' in col_ref and '(' not in col_ref
+                    col_name = col_ref.rsplit('.', 1)[-1].upper() if is_qualified else col_ref_upper
+                    if col_ref_upper in seen_full:
+                        continue
+                    if is_qualified and col_name in seen_unqualified:
+                        continue
+                    seen_full.add(col_ref_upper)
+                    if not is_qualified:
+                        seen_unqualified.add(col_name)
+                    ordering.append(o_sql)
+                    params.extend(o_params)
                 result.append('ORDER BY %s' % ', '.join(ordering))
 
                 # For subqueres with an ORDER BY clause, SQL Server also

--- a/test.sh
+++ b/test.sh
@@ -12,6 +12,12 @@ git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 git checkout $DJANGO_VERSION
 pip install -r tests/requirements/py3.txt
 
+# composite_pk tests were introduced in Django 5.2
+COMPOSITE_PK_TESTS=""
+if python -c "import django; exit(0 if django.VERSION >= (5, 2) else 1)"; then
+    COMPOSITE_PK_TESTS="composite_pk"
+fi
+
 coverage run tests/runtests.py --settings=testapp.settings --noinput \
     aggregation \
     aggregation_regress \
@@ -19,7 +25,7 @@ coverage run tests/runtests.py --settings=testapp.settings --noinput \
     backends \
     basic \
     bulk_create \
-    composite_pk \
+    $COMPOSITE_PK_TESTS \
     constraints \
     custom_columns \
     custom_lookups \

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -427,6 +427,11 @@ if VERSION >= (5, 2):
         # Composite PK tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
         # This uses pk__in with composite PK which generates unsupported tuple lookup SQL
         'composite_pk.test_filter.CompositePKFilterTests.test_explicit_subquery',
+        # SQL Server doesn't support tuple/row comparisons (WHERE (a, b) = (x, y))
+        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_exact',
+        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_comparison',
+        # SQL Server parameter splitting uses temp tables, resulting in different query count
+        'composite_pk.tests.CompositePKTests.test_in_bulk_batching',
         
         # Tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
         # TODO: Implement tuple lookup handling for SQL Server compatibility


### PR DESCRIPTION
- Override get_order_by() to expand OrderBy(ColPairs(...)) into individual
  OrderBy(Col(...)) entries before SQL compilation, preventing naive
  comma-splitting from corrupting complex expressions (JSONArray, KeyTransform)
- Simplify ORDER BY deduplication: each item is now guaranteed to be a single
  expression, eliminating the need for SQL string parsing
- Add composite_pk test exclusions for pre-existing SQL Server tuple comparison
  limitations (test_outer_ref_pk_filter_on_pk_exact, test_outer_ref_pk_filter_on_pk_comparison,
  test_in_bulk_batching)
- Update copilot instructions with development workflow rules

Fixes: test_order_by_key and test_order_by_nested_key in JSONArrayTests