### PR TITLE
FIX: Exclude testapp from package distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     'Release Notes': 'https://github.com/microsoft/mssql-django/releases',
     },
     license='BSD',
-    packages=find_packages(),
+    packages=find_packages(exclude=['testapp', 'testapp.*']),
     install_requires=[
         'django>=3.2,<6.1',
         'pyodbc>=3.0',

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,7 @@ if python -c "import django; exit(0 if django.VERSION >= (5, 2) else 1)"; then
     COMPOSITE_PK_TESTS="composite_pk"
 fi
 
-coverage run tests/runtests.py --settings=testapp.settings --noinput \
+PYTHONPATH=.. coverage run tests/runtests.py --settings=testapp.settings --noinput \
     aggregation \
     aggregation_regress \
     annotations \


### PR DESCRIPTION
Fixes #502 

find_packages() is called without exclusions in setup.py, causing testapp to be
installed as a top-level package alongside mssql into site-packages. This creates namespace collisions for downstream projects that define their own testapp.

Add exclude=['testapp', 'testapp.*'] to find_packages() to prevent this.