### PR TITLE
FEAT: Enable Django 5.2.4 tuple lookup fallbacks and tighten version-gated exclusions

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -68,8 +68,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # CompositePrimaryKey support is only available in Django 5.2 and later
     supports_composite_primary_keys = django_version >= (5, 2)
     if django_version >= (5, 2) and isinstance(CompositePrimaryKey, type):
-       # Set fallback tupple lookup support
-       supports_tuple_lookups = False
+        # SQL Server doesn't support native tuple lookups.
+        supports_tuple_lookups = False
+        if django_version >= (5, 2, 4):
+            supports_tuple_comparison_against_subquery = False
     @cached_property
     def has_zoneinfo_database(self):
         with self.connection.cursor() as cursor:

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -2,18 +2,19 @@
 # Licensed under the BSD license.
 
 import json
+import itertools
 
 from django import VERSION
 from django.core import validators
 from django.db import NotSupportedError, connections, transaction
-from django.db.models import BooleanField, CheckConstraint, Value
-from django.db.models.expressions import Case, Exists, OrderBy, When, Window
+from django.db.models import BooleanField, CheckConstraint, Q, Value
+from django.db.models.expressions import Case, ColPairs, Exists, OrderBy, Subquery, When, Window
 from django.db.models.fields import BinaryField, Field
 from django.db.models.functions import Cast, NthValue, MD5, SHA1, SHA224, SHA256, SHA384, SHA512
 from django.db.models.functions.datetime import Now
 from django.db.models.functions.math import ATan2, Ln, Log, Mod, Round, Degrees, Radians, Power
 from django.db.models.functions.text import Replace
-from django.db.models.lookups import In, Lookup
+from django.db.models.lookups import Exact, In, Lookup
 from django.db.models.query import QuerySet
 from django.db.models.sql.query import Query
 # import value and JSONArray for Django 5.2+
@@ -229,6 +230,52 @@ def mssql_split_parameter_list_as_sql(self, compiler, connection):
     in_clause = lhs + ' IN ' + '(SELECT params from #Temp_params)'
 
     return in_clause, ()
+
+
+def _tuple_lookup_rhs_query(rhs):
+    if isinstance(rhs, Query):
+        return rhs
+    if isinstance(rhs, Subquery):
+        return rhs.query
+    return None
+
+
+def _tuple_lookup_exists_sql(lhs, rhs_query, compiler, connection):
+    rhs_exprs = itertools.chain.from_iterable(
+        (
+            select_expr
+            if isinstance((select_expr := select[0]), ColPairs)
+            else [select_expr]
+        )
+        for select in rhs_query.get_compiler(connection=connection).get_select()[0]
+    )
+    query = rhs_query.clone()
+    query.add_q(Q(*[Exact(col, val) for col, val in zip(lhs, rhs_exprs)]))
+    return compiler.compile(Exists(query))
+
+
+if VERSION >= (5, 2, 4):
+    from django.db.models.fields.tuple_lookups import TupleExact, TupleIn
+
+    tuple_exact_get_fallback_sql = TupleExact.get_fallback_sql
+    tuple_in_get_fallback_sql = TupleIn.get_fallback_sql
+
+    def sqlserver_tuple_exact_get_fallback_sql(self, compiler, connection):
+        if connection.vendor == 'microsoft':
+            rhs_query = _tuple_lookup_rhs_query(self.rhs)
+            if rhs_query is not None:
+                return _tuple_lookup_exists_sql(self.lhs, rhs_query, compiler, connection)
+        return tuple_exact_get_fallback_sql(self, compiler, connection)
+
+    def sqlserver_tuple_in_get_fallback_sql(self, compiler, connection):
+        if connection.vendor == 'microsoft':
+            rhs_query = _tuple_lookup_rhs_query(self.rhs)
+            if rhs_query is not None:
+                return _tuple_lookup_exists_sql(self.lhs, rhs_query, compiler, connection)
+        return tuple_in_get_fallback_sql(self, compiler, connection)
+
+    TupleExact.get_fallback_sql = sqlserver_tuple_exact_get_fallback_sql
+    TupleIn.get_fallback_sql = sqlserver_tuple_in_get_fallback_sql
 
 
 def unquote_json_rhs(rhs_params):

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -259,10 +259,29 @@ def _tuple_lookup_exists_sql(lhs, rhs_query, compiler, connection):
 
 
 if VERSION >= (5, 2, 4):
-    from django.db.models.fields.tuple_lookups import TupleExact, TupleIn
+    from django.db.models.fields.tuple_lookups import (
+        TupleExact,
+        TupleGreaterThan,
+        TupleGreaterThanOrEqual,
+        TupleIn,
+        TupleLessThan,
+        TupleLessThanOrEqual,
+    )
 
     tuple_exact_get_fallback_sql = TupleExact.get_fallback_sql
     tuple_in_get_fallback_sql = TupleIn.get_fallback_sql
+    tuple_gt_get_fallback_sql = TupleGreaterThan.get_fallback_sql
+    tuple_gte_get_fallback_sql = TupleGreaterThanOrEqual.get_fallback_sql
+    tuple_lt_get_fallback_sql = TupleLessThan.get_fallback_sql
+    tuple_lte_get_fallback_sql = TupleLessThanOrEqual.get_fallback_sql
+
+    def _sqlserver_tuple_comparison_get_fallback_sql(self, compiler, connection, original):
+        if connection.vendor == 'microsoft' and _tuple_lookup_rhs_query(self.rhs) is not None:
+            lookup = self.lookup_name
+            raise NotSupportedError(
+                f'"{lookup}" cannot be used to target composite fields through subqueries on this backend'
+            )
+        return original(self, compiler, connection)
 
     def sqlserver_tuple_exact_get_fallback_sql(self, compiler, connection):
         if connection.vendor == 'microsoft':
@@ -278,8 +297,32 @@ if VERSION >= (5, 2, 4):
                 return _tuple_lookup_exists_sql(self.lhs, rhs_query, compiler, connection)
         return tuple_in_get_fallback_sql(self, compiler, connection)
 
+    def sqlserver_tuple_gt_get_fallback_sql(self, compiler, connection):
+        return _sqlserver_tuple_comparison_get_fallback_sql(
+            self, compiler, connection, tuple_gt_get_fallback_sql
+        )
+
+    def sqlserver_tuple_gte_get_fallback_sql(self, compiler, connection):
+        return _sqlserver_tuple_comparison_get_fallback_sql(
+            self, compiler, connection, tuple_gte_get_fallback_sql
+        )
+
+    def sqlserver_tuple_lt_get_fallback_sql(self, compiler, connection):
+        return _sqlserver_tuple_comparison_get_fallback_sql(
+            self, compiler, connection, tuple_lt_get_fallback_sql
+        )
+
+    def sqlserver_tuple_lte_get_fallback_sql(self, compiler, connection):
+        return _sqlserver_tuple_comparison_get_fallback_sql(
+            self, compiler, connection, tuple_lte_get_fallback_sql
+        )
+
     TupleExact.get_fallback_sql = sqlserver_tuple_exact_get_fallback_sql
     TupleIn.get_fallback_sql = sqlserver_tuple_in_get_fallback_sql
+    TupleGreaterThan.get_fallback_sql = sqlserver_tuple_gt_get_fallback_sql
+    TupleGreaterThanOrEqual.get_fallback_sql = sqlserver_tuple_gte_get_fallback_sql
+    TupleLessThan.get_fallback_sql = sqlserver_tuple_lt_get_fallback_sql
+    TupleLessThanOrEqual.get_fallback_sql = sqlserver_tuple_lte_get_fallback_sql
 
 
 def unquote_json_rhs(rhs_params):

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -8,7 +8,7 @@ from django import VERSION
 from django.core import validators
 from django.db import NotSupportedError, connections, transaction
 from django.db.models import BooleanField, CheckConstraint, Q, Value
-from django.db.models.expressions import Case, ColPairs, Exists, OrderBy, Subquery, When, Window
+from django.db.models.expressions import Case, Exists, OrderBy, Subquery, When, Window
 from django.db.models.fields import BinaryField, Field
 from django.db.models.functions import Cast, NthValue, MD5, SHA1, SHA224, SHA256, SHA384, SHA512
 from django.db.models.functions.datetime import Now
@@ -17,6 +17,10 @@ from django.db.models.functions.text import Replace
 from django.db.models.lookups import Exact, In, Lookup
 from django.db.models.query import QuerySet
 from django.db.models.sql.query import Query
+try:
+    from django.db.models.expressions import ColPairs
+except ImportError:
+    ColPairs = None
 # import value and JSONArray for Django 5.2+
 if VERSION >= (5, 2):
     from django.db.models import Value
@@ -244,7 +248,7 @@ def _tuple_lookup_exists_sql(lhs, rhs_query, compiler, connection):
     rhs_exprs = itertools.chain.from_iterable(
         (
             select_expr
-            if isinstance((select_expr := select[0]), ColPairs)
+            if ColPairs is not None and isinstance((select_expr := select[0]), ColPairs)
             else [select_expr]
         )
         for select in rhs_query.get_compiler(connection=connection).get_select()[0]

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -17,9 +17,9 @@ from django.db.models.functions.text import Replace
 from django.db.models.lookups import Exact, In, Lookup
 from django.db.models.query import QuerySet
 from django.db.models.sql.query import Query
-try:
+if VERSION >= (5, 2):
     from django.db.models.expressions import ColPairs
-except ImportError:
+else:
     ColPairs = None
 # import value and JSONArray for Django 5.2+
 if VERSION >= (5, 2):

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -420,23 +420,17 @@ if VERSION >= (6, 0):
         'model_fields.test_jsonfield.TestQuerying.test_usage_in_subquery',
     ])
 
-# Django 5.2 specific exclusions - tuple lookups not supported in SQL Server
+# Django 5.2 specific exclusions
 # These are good candidates for community contributions - see GitHub issues
 if VERSION >= (5, 2):
     EXCLUDED_TESTS.extend([
         # SQL Server parameter splitting uses temp tables, resulting in different query count
         'composite_pk.tests.CompositePKTests.test_in_bulk_batching',
         
-        # Tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
-        # TODO: Implement tuple lookup handling for SQL Server compatibility
-        
         # inspectdb tests that expect specific table structures in inspectdb_special/pascal schemas
         'inspectdb.tests.InspectDBTestCase.test_custom_normalize_table_name',
         'inspectdb.tests.InspectDBTestCase.test_special_column_name_introspection', 
         'inspectdb.tests.InspectDBTestCase.test_table_name_introspection',
-        
-        # Multi-column foreign key tests with tuple lookups - also affected by SQL Server limitations
-        # TODO: Fix tuple lookup generation for multi-column FKs 
         
         # JSONField special character handling - SQL Server specific syntax issues
         # TODO: Fix JSONField key escaping for special characters
@@ -473,6 +467,8 @@ if VERSION >= (5, 2) and VERSION < (5, 2, 4):
         'composite_pk.test_filter.CompositePKFilterTests.test_explicit_subquery',
         'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_exact',
         'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_comparison',
+
+        # Tuple lookup tests kept excluded for Django <5.2.4.
         'foreign_object.test_tuple_lookups.TupleLookupsTests.test_exact',
         'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gt',
         'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gte',
@@ -481,6 +477,8 @@ if VERSION >= (5, 2) and VERSION < (5, 2, 4):
         'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lte',
         'foreign_object.test_tuple_lookups.TupleLookupsTests.test_tuple_in_subquery',
         'foreign_object.test_agnostic_order_trimjoin.TestLookupQuery.test_deep_mixed_backward',
+
+        # Multi-column foreign key tuple-lookup tests kept excluded for Django <5.2.4.
         'foreign_object.tests.MultiColumnFKTests.test_double_nested_query',
         'foreign_object.tests.MultiColumnFKTests.test_forward_in_lookup_filters_correctly',
         'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_forward',

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -424,25 +424,11 @@ if VERSION >= (6, 0):
 # These are good candidates for community contributions - see GitHub issues
 if VERSION >= (5, 2):
     EXCLUDED_TESTS.extend([
-        # Composite PK tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
-        # This uses pk__in with composite PK which generates unsupported tuple lookup SQL
-        'composite_pk.test_filter.CompositePKFilterTests.test_explicit_subquery',
-        # SQL Server doesn't support tuple/row comparisons (WHERE (a, b) = (x, y))
-        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_exact',
-        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_comparison',
         # SQL Server parameter splitting uses temp tables, resulting in different query count
         'composite_pk.tests.CompositePKTests.test_in_bulk_batching',
         
         # Tuple lookup tests - SQL Server doesn't support (col1, col2) IN syntax
         # TODO: Implement tuple lookup handling for SQL Server compatibility
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_exact',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gt',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gte',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_in',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lt',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lte',
-        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_tuple_in_subquery',
-        'foreign_object.test_agnostic_order_trimjoin.TestLookupQuery.test_deep_mixed_backward',
         
         # inspectdb tests that expect specific table structures in inspectdb_special/pascal schemas
         'inspectdb.tests.InspectDBTestCase.test_custom_normalize_table_name',
@@ -451,14 +437,6 @@ if VERSION >= (5, 2):
         
         # Multi-column foreign key tests with tuple lookups - also affected by SQL Server limitations
         # TODO: Fix tuple lookup generation for multi-column FKs 
-        'foreign_object.tests.MultiColumnFKTests.test_double_nested_query',
-        'foreign_object.tests.MultiColumnFKTests.test_forward_in_lookup_filters_correctly',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_forward',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_hidden_forward',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_reverse',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_forward_works',
-        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_reverse_works',
-        'foreign_object.tests.MultiColumnFKTests.test_reverse_query_returns_correct_result',
         
         # JSONField special character handling - SQL Server specific syntax issues
         # TODO: Fix JSONField key escaping for special characters
@@ -487,6 +465,30 @@ if VERSION >= (5, 2):
         # TODO: Fix JSONField update with CASE WHEN handling
         'expressions.tests.BasicExpressionsTests.test_update_jsonfield_case_when_key_is_null',
         
+    ])
+
+if VERSION >= (5, 2) and VERSION < (5, 2, 4):
+    EXCLUDED_TESTS.extend([
+        # Composite PK tuple subquery fallback fix landed in Django 5.2.4.
+        'composite_pk.test_filter.CompositePKFilterTests.test_explicit_subquery',
+        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_exact',
+        'composite_pk.test_filter.CompositePKFilterTests.test_outer_ref_pk_filter_on_pk_comparison',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_exact',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gt',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_gte',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_in',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lt',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_lte',
+        'foreign_object.test_tuple_lookups.TupleLookupsTests.test_tuple_in_subquery',
+        'foreign_object.test_agnostic_order_trimjoin.TestLookupQuery.test_deep_mixed_backward',
+        'foreign_object.tests.MultiColumnFKTests.test_double_nested_query',
+        'foreign_object.tests.MultiColumnFKTests.test_forward_in_lookup_filters_correctly',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_forward',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_hidden_forward',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_foreignobject_reverse',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_forward_works',
+        'foreign_object.tests.MultiColumnFKTests.test_prefetch_related_m2m_reverse_works',
+        'foreign_object.tests.MultiColumnFKTests.test_reverse_query_returns_correct_result',
     ])
 
 REGEX_TESTS = [

--- a/testapp/tests/test_composite_pk_and_ordering.py
+++ b/testapp/tests/test_composite_pk_and_ordering.py
@@ -343,17 +343,13 @@ if VERSION >= (5, 2):
                 self.assertEqual(list(queryset.values_list('pk', flat=True)), [(1, 1), (1, 2)])
 
             def test_pk_exact_subquery_uses_tuple_fallback(self):
-                subquery = Subquery(
-                    self.TupleLookupUser.objects.filter(pk=OuterRef('pk')).values('pk')[:1]
-                )
-                self.assertEqual(self.TupleLookupUser.objects.filter(pk=subquery).count(), 3)
+                queryset_rhs = self.TupleLookupUser.objects.filter(pk=OuterRef('pk')).values('pk')[:1]
+                self.assertEqual(self.TupleLookupUser.objects.filter(pk=queryset_rhs).count(), 3)
 
             def test_pk_comparison_subquery_not_supported(self):
-                subquery = Subquery(
-                    self.TupleLookupUser.objects.filter(pk=OuterRef('pk')).values('pk')[:1]
-                )
+                queryset_rhs = self.TupleLookupUser.objects.filter(pk=OuterRef('pk')).values('pk')[:1]
                 with self.assertRaisesMessage(
                     NotSupportedError,
                     '"gt" cannot be used to target composite fields through subqueries on this backend',
                 ):
-                    self.TupleLookupUser.objects.filter(pk__gt=subquery).count()
+                    self.TupleLookupUser.objects.filter(pk__gt=queryset_rhs).count()

--- a/testapp/tests/test_composite_pk_and_ordering.py
+++ b/testapp/tests/test_composite_pk_and_ordering.py
@@ -8,7 +8,7 @@ Tests for:
 """
 
 from django import VERSION
-from django.db import connection, models
+from django.db import NotSupportedError, connection, models
 from django.test import TestCase, TransactionTestCase
 
 from ..models import Author, Post
@@ -135,6 +135,7 @@ class BulkUpdateValidationTests(TestCase):
 # Django 5.2+ specific tests for composite PK
 if VERSION >= (5, 2):
     from django.db.models import CompositePrimaryKey
+    from django.db.models import OuterRef, Subquery
     from django.db.models.fields.composite import CompositePrimaryKey as CompositePrimaryKeyField
 
     class CompositePKValidationTests(TestCase):
@@ -282,3 +283,77 @@ if VERSION >= (5, 2):
                 self.TenantUser.objects.bulk_update(users, ['user_id'])
             
             self.assertIn('primary key', str(cm.exception).lower())
+
+    if VERSION >= (5, 2, 4):
+        class CompositePKTupleSubqueryLookupTests(TransactionTestCase):
+            @classmethod
+            def setUpClass(cls):
+                super().setUpClass()
+                with connection.cursor() as cursor:
+                    cursor.execute('''
+                        IF OBJECT_ID('testapp_tuplelookup_user', 'U') IS NOT NULL
+                            DROP TABLE testapp_tuplelookup_user
+                    ''')
+                    cursor.execute('''
+                        CREATE TABLE testapp_tuplelookup_user (
+                            tenant_id INT NOT NULL,
+                            user_id INT NOT NULL,
+                            name NVARCHAR(100) NOT NULL,
+                            PRIMARY KEY (tenant_id, user_id)
+                        )
+                    ''')
+
+            @classmethod
+            def tearDownClass(cls):
+                with connection.cursor() as cursor:
+                    cursor.execute('''
+                        IF OBJECT_ID('testapp_tuplelookup_user', 'U') IS NOT NULL
+                            DROP TABLE testapp_tuplelookup_user
+                    ''')
+                super().tearDownClass()
+
+            def setUp(self):
+                class TupleLookupUser(models.Model):
+                    pk = CompositePrimaryKey('tenant_id', 'user_id')
+                    tenant_id = models.IntegerField()
+                    user_id = models.IntegerField()
+                    name = models.CharField(max_length=100)
+
+                    class Meta:
+                        app_label = 'testapp'
+                        db_table = 'testapp_tuplelookup_user'
+                        managed = False
+
+                self.TupleLookupUser = TupleLookupUser
+
+                with connection.cursor() as cursor:
+                    cursor.execute('DELETE FROM testapp_tuplelookup_user')
+                    cursor.execute('''
+                        INSERT INTO testapp_tuplelookup_user (tenant_id, user_id, name)
+                        VALUES (1, 1, 'Alice'),
+                               (1, 2, 'Bob'),
+                               (2, 1, 'Charlie')
+                    ''')
+
+            def test_pk_in_subquery_uses_tuple_fallback(self):
+                subquery = Subquery(
+                    self.TupleLookupUser.objects.filter(tenant_id=1).values('pk')
+                )
+                queryset = self.TupleLookupUser.objects.filter(pk__in=subquery).order_by('tenant_id', 'user_id')
+                self.assertEqual(list(queryset.values_list('pk', flat=True)), [(1, 1), (1, 2)])
+
+            def test_pk_exact_subquery_uses_tuple_fallback(self):
+                subquery = Subquery(
+                    self.TupleLookupUser.objects.filter(pk=OuterRef('pk')).values('pk')[:1]
+                )
+                self.assertEqual(self.TupleLookupUser.objects.filter(pk=subquery).count(), 3)
+
+            def test_pk_comparison_subquery_not_supported(self):
+                subquery = Subquery(
+                    self.TupleLookupUser.objects.filter(pk=OuterRef('pk')).values('pk')[:1]
+                )
+                with self.assertRaisesMessage(
+                    NotSupportedError,
+                    '"gt" cannot be used to target composite fields through subqueries on this backend',
+                ):
+                    self.TupleLookupUser.objects.filter(pk__gt=subquery).count()


### PR DESCRIPTION
- This PR adds SQL Server-safe tuple lookup fallback behavior for Django 5.2.4+, and narrows test exclusions so tuple-related tests stay excluded only for Django <5.2.4.
- Backend changes:
  - Updated tuple capability gating in features.py.
  - Added guarded tuple fallback handling for TupleExact/TupleIn with correlated EXISTS rewrite in functions.py.
- Test/policy changes:
  - Added composite PK tuple-subquery regression coverage in test_composite_pk_and_ordering.py.
  - Moved tuple and MultiColumnFK exclusions under the Django <5.2.4 block, with clarified comments in settings.py.
- Validation:
  - Unexcluded tuple-related foreign_object and MultiColumnFK cases for 5.2.4+ and verified passing locally.
  - Kept known failing non-tuple-converged case excluded (single-query validation-count expectation).
- Follow-up:
  - Any remaining tuple-related exclusions for <5.2.4 are intentional compatibility guards, not regressions.