### PR TITLE
FIX: Django 6.0 JSON lookup path handling

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -61,9 +61,9 @@ def _as_sql_greatest(self, compiler, connection):
 
 def _as_sql_json_keytransform(self, compiler, connection):
     lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-    # For Django < 6.0, use Django's built-in compile_json_path
-    # For Django 6.0+, use connection.ops.compile_json_path()
-    if django.VERSION >= (6, 0):
+    # Always prefer backend compilation when available so SQL Server-specific
+    # escaping rules are applied consistently across Django versions.
+    if hasattr(connection.ops, 'compile_json_path'):
         json_path = connection.ops.compile_json_path(key_transforms)
     else:
         json_path = compile_json_path(key_transforms)

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -67,6 +67,7 @@ def _as_sql_json_keytransform(self, compiler, connection):
         json_path = connection.ops.compile_json_path(key_transforms)
     else:
         json_path = compile_json_path(key_transforms)
+    json_path = json_path.replace("'", "''")
     return (
         "COALESCE(JSON_QUERY(%s, '%s'), JSON_VALUE(%s, '%s'))" %
         ((lhs, json_path) * 2)

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -43,6 +43,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_ignore_conflicts = False
     supports_index_on_text_field = False
     supports_json_field_contains = False
+    supports_json_negative_indexing = False
     supports_order_by_nulls_modifier = False
     supports_over_clause = True
     supports_paramstyle_pyformat = False

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -422,7 +422,7 @@ def json_HasKeyLookup(self, compiler, connection):
         # For Django < 6.0, use Django's built-in compile_json_path
         # For Django 6.0+, use connection.ops.compile_json_path()
         # This is necessary because compile_json_path was moved in Django 6.0 from
-        # django.db.models.fields.json to connection.ops.compile_json_path()
+        # django.db.models.fields.json to connection.ops.compile_json_path().
         if VERSION >= (6, 0):
             return connection.ops.compile_json_path(key_transforms, include_root)
         else:
@@ -493,7 +493,6 @@ def json_HasKeyLookup(self, compiler, connection):
             cast_sql, cast_params = self.lhs.as_sql(compiler, connection)
 
             for path in rhs_params:
-                # Escape single quotes in the path for SQL
                 path_escaped = path.replace("'", "''")
                 # Build the JSON_PATH_EXISTS condition
                 conditions.append(f"JSON_PATH_EXISTS({cast_sql}, '{path_escaped}') > 0")
@@ -502,7 +501,6 @@ def json_HasKeyLookup(self, compiler, connection):
             return _combine_conditions(conditions), params
         else:
             for path in rhs_params:
-                # Escape single quotes in the path for SQL
                 path_escaped = path.replace("'", "''")
                 # Build the JSON_PATH_EXISTS condition using lhs
                 conditions.append("JSON_PATH_EXISTS(%s, '%s') > 0" % (lhs, path_escaped))
@@ -521,7 +519,6 @@ def json_HasKeyLookup(self, compiler, connection):
         else:
             conditions = []
             for path in rhs_params:
-                # Escape single quotes in the path for SQL
                 path_escaped = path.replace("'", "''")
                 # Build the JSON_VALUE IS NOT NULL condition
                 conditions.append("JSON_VALUE(%s, '%s') IS NOT NULL" % (lhs, path_escaped))

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -661,13 +661,23 @@ class DatabaseOperations(BaseDatabaseOperations):
         This method was moved from django.db.models.fields.json in Django 6.0
         to connection.ops.compile_json_path().
 
-                Contract:
-                - This helper returns a raw JSON path.
-                - Callers that embed it inside SQL string literals must apply SQL quote
-                    escaping exactly once at the SQL generation layer.
+        Contract:
+        - This helper returns a raw JSON path string
+            (for example: $.a[0]."complex key").
+        - Callers that embed it inside SQL string literals must apply SQL
+            string-literal escaping exactly once at SQL generation time.
+        - Non-simple key text in the returned path is already JSON-escaped and
+            must not be JSON-escaped again.
 
-        For SQL Server, we use bracket notation with escaped keys for any
-        non-simple key names to properly handle special characters.
+        SQL Server JSON path shape:
+        - Include root '$' when include_root is True.
+        - Emit array indices as bracket notation: [0], [1], ...
+        - Emit simple object keys (^[a-zA-Z_][a-zA-Z0-9_]*$) as dot notation:
+            .key_name
+        - Emit all other object keys as quoted dot notation with JSON-escaped
+            key text: ."complex key", ."key.with\"quotes\""
+
+        This function does not perform SQL identifier quoting.
         """
         import json
         import re

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -7,6 +7,7 @@ import warnings
 import sys
 
 from django.conf import settings
+from django.db import NotSupportedError
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.models.expressions import Exists, ExpressionWrapper, RawSQL
 from django.db.models.sql.where import WhereNode
@@ -651,7 +652,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         Matches Django's default behavior: use the provided encoder (or None).
         """
         import json
-        
+
         return json.dumps(value, cls=encoder)
 
     def compile_json_path(self, key_transforms, include_root=True):
@@ -669,19 +670,24 @@ class DatabaseOperations(BaseDatabaseOperations):
         for key_transform in key_transforms:
             try:
                 num = int(key_transform)
+                if (
+                    num < 0
+                    and not self.connection.features.supports_json_negative_indexing
+                ):
+                    raise NotSupportedError(
+                        "Using negative JSON array indices is not supported on this "
+                        "database backend. (SQL Server)"
+                    )
                 path.append('[%s]' % num)
             except ValueError:
-                # Use bracket notation for keys with special characters
-                # json.dumps properly escapes quotes and other special chars
-                escaped_key = json.dumps(key_transform)
                 # Check if key is simple (alphanumeric/underscore only)
                 if re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', key_transform):
                     path.append('.')
                     path.append(key_transform)
                 else:
-                    # Use bracket notation: $["key with \"quotes\""]
-                    path.append('[%s]' % escaped_key)
-        return ''.join(path)
+                    escaped_key = json.dumps(key_transform, ensure_ascii=True)[1:-1]
+                    path.append('."%s"' % escaped_key)
+        return ''.join(path).replace("'", "''")
 
     # Django 6.0 renames return_insert_columns to returning_columns
     # and fetch_returned_insert_rows to fetch_returned_rows

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -660,7 +660,12 @@ class DatabaseOperations(BaseDatabaseOperations):
         Compile a JSON path from a list of key transforms.
         This method was moved from django.db.models.fields.json in Django 6.0
         to connection.ops.compile_json_path().
-        
+
+                Contract:
+                - This helper returns a raw JSON path.
+                - Callers that embed it inside SQL string literals must apply SQL quote
+                    escaping exactly once at the SQL generation layer.
+
         For SQL Server, we use bracket notation with escaped keys for any
         non-simple key names to properly handle special characters.
         """
@@ -687,7 +692,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                 else:
                     escaped_key = json.dumps(key_transform, ensure_ascii=True)[1:-1]
                     path.append('."%s"' % escaped_key)
-        return ''.join(path).replace("'", "''")
+        return ''.join(path)
 
     # Django 6.0 renames return_insert_columns to returning_columns
     # and fetch_returned_insert_rows to fetch_returned_rows

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -340,46 +340,8 @@ if VERSION >= (6, 0):
         'expressions.tests.FTimeDeltaTests.test_datetime_subtraction',
         'expressions.tests.FTimeDeltaTests.test_time_subtraction',
         
-        # JSONField - UUID serialization and negative array index handling needed
-        'model_fields.test_jsonfield.TestQuerying.test_deep_negative_lookup_array',
-        'model_fields.test_jsonfield.TestQuerying.test_deep_negative_lookup_mixed',
-        'model_fields.test_jsonfield.TestQuerying.test_deep_values',
-        'model_fields.test_jsonfield.TestQuerying.test_exact',
-        'model_fields.test_jsonfield.TestQuerying.test_exact_complex',
-        'model_fields.test_jsonfield.TestQuerying.test_expression_wrapper_key_transform',
-        'model_fields.test_jsonfield.TestQuerying.test_has_any_keys',
-        'model_fields.test_jsonfield.TestQuerying.test_has_key',
-        'model_fields.test_jsonfield.TestQuerying.test_has_keys',
-        'model_fields.test_jsonfield.TestQuerying.test_icontains',
-        'model_fields.test_jsonfield.TestQuerying.test_isnull',
-        'model_fields.test_jsonfield.TestQuerying.test_join_key_transform_annotation_expression',
-        'model_fields.test_jsonfield.TestQuerying.test_key_contains',
-        'model_fields.test_jsonfield.TestQuerying.test_key_endswith',
-        'model_fields.test_jsonfield.TestQuerying.test_key_icontains',
-        'model_fields.test_jsonfield.TestQuerying.test_key_iendswith',
-        'model_fields.test_jsonfield.TestQuerying.test_key_iexact',
-        'model_fields.test_jsonfield.TestQuerying.test_key_in',
-        'model_fields.test_jsonfield.TestQuerying.test_key_istartswith',
-        'model_fields.test_jsonfield.TestQuerying.test_key_startswith',
-        'model_fields.test_jsonfield.TestQuerying.test_key_transform',
-        'model_fields.test_jsonfield.TestQuerying.test_key_transform_annotation_expression',
-        'model_fields.test_jsonfield.TestQuerying.test_key_transform_expression',
-        'model_fields.test_jsonfield.TestQuerying.test_key_transform_raw_expression',
-        'model_fields.test_jsonfield.TestQuerying.test_key_values',
-        'model_fields.test_jsonfield.TestQuerying.test_lookup_exclude',
-        'model_fields.test_jsonfield.TestQuerying.test_lookup_exclude_nonexistent_key',
-        'model_fields.test_jsonfield.TestQuerying.test_nested_key_transform_annotation_expression',
-        'model_fields.test_jsonfield.TestQuerying.test_nested_key_transform_expression',
-        'model_fields.test_jsonfield.TestQuerying.test_nested_key_transform_on_subquery',
-        'model_fields.test_jsonfield.TestQuerying.test_nested_key_transform_raw_expression',
-        'model_fields.test_jsonfield.TestQuerying.test_none_key_exclude',
-        'model_fields.test_jsonfield.TestQuerying.test_obj_subquery_lookup',
-        'model_fields.test_jsonfield.TestQuerying.test_order_grouping_custom_decoder',
+        # JSONField ordering-by-transform still needs dedicated ORDER BY handling.
         'model_fields.test_jsonfield.TestQuerying.test_ordering_by_transform',
-        'model_fields.test_jsonfield.TestQuerying.test_shallow_list_lookup',
-        'model_fields.test_jsonfield.TestQuerying.test_shallow_list_negative_lookup',
-        'model_fields.test_jsonfield.TestQuerying.test_shallow_lookup_obj_target',
-        'model_fields.test_jsonfield.TestQuerying.test_shallow_obj_lookup',
         
         # SQL Server limitations (permanent exclusions)
         # STRING_AGG with DISTINCT - SQL Server syntax differs
@@ -387,7 +349,7 @@ if VERSION >= (6, 0):
         # REGEXP_LIKE function not available in SQL Server
         'expressions.tests.BasicExpressionsTests.test_lookups_subquery',
         
-        # JSON path escaping test - bracket notation difference
+        # JSON path escaping test keeps backend-specific escaping requirements.
         'model_fields.test_jsonfield.TestQuerying.test_key_sql_injection_escape',
         # Migration tests with schema differences
         'migrations.test_commands.MakeMigrationsTests.test_makemigrations_check_no_changes',
@@ -431,11 +393,6 @@ if VERSION >= (5, 2):
         'inspectdb.tests.InspectDBTestCase.test_custom_normalize_table_name',
         'inspectdb.tests.InspectDBTestCase.test_special_column_name_introspection', 
         'inspectdb.tests.InspectDBTestCase.test_table_name_introspection',
-        
-        # JSONField special character handling - SQL Server specific syntax issues
-        # TODO: Fix JSONField key escaping for special characters
-        'model_fields.test_jsonfield.TestQuerying.test_lookups_special_chars',
-        'model_fields.test_jsonfield.TestQuerying.test_lookups_special_chars_double_quotes',
         
         # JSONField bulk update with null handling
         # TODO: Fix bulk update SQL generation for JSONField null values

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -4,6 +4,7 @@
 from unittest import skipUnless
 
 from django import VERSION
+from django.db import NotSupportedError, connections
 from django.test import TestCase
 
 if VERSION >= (3, 1):
@@ -69,3 +70,17 @@ class TestJSONField(TestCase):
             JSONModel.objects.using('sqlite').filter(value__a='b'),
             [json_obj],
         )
+
+    def test_compile_json_path_special_chars(self):
+        path = connections['default'].ops.compile_json_path([
+            'owner',
+            'role name',
+            'a"b',
+            "o'reilly",
+        ])
+        self.assertEqual(path, "$.owner.\"role name\".\"a\\\"b\".\"o''reilly\"")
+
+    def test_compile_json_path_negative_index_not_supported(self):
+        with self.assertRaises(NotSupportedError):
+            connections['default'].ops.compile_json_path(['items', '-1'])
+

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -78,9 +78,18 @@ class TestJSONField(TestCase):
             'a"b',
             "o'reilly",
         ])
-        self.assertEqual(path, "$.owner.\"role name\".\"a\\\"b\".\"o''reilly\"")
+        self.assertEqual(path, "$.owner.\"role name\".\"a\\\"b\".\"o'reilly\"")
 
     def test_compile_json_path_negative_index_not_supported(self):
         with self.assertRaises(NotSupportedError):
             connections['default'].ops.compile_json_path(['items', '-1'])
+
+    @skipUnless(VERSION >= (3, 1), "JSONField not support in Django versions < 3.1")
+    def test_has_key_lookup_with_single_quote_key(self):
+        obj = JSONModel.objects.create(value={"o'reilly": 1, "safe": True})
+
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(value__has_key="o'reilly"),
+            [obj],
+        )
 


### PR DESCRIPTION
GH Issue: #483 

## Summary
- This PR fixes SQL Server JSON lookup/path behavior for Django 6.0 compatibility and removes JSON-related exclusions that now pass.
- Scope is intentionally limited to JSON path compilation, JSON key transform path usage, backend feature signaling, and targeted regression tests.

**Root Cause**
- JSON path compilation in some lookup paths did not consistently use backend-specific escaping rules.
- Negative JSON array indexing was not explicitly gated as unsupported.
- Exclusion list still contained many JSON tests that are now passing with current backend behavior.

**What Changed**
- compiler.py
  - Updated JSON KeyTransform SQL generation to always prefer backend JSON path compilation when available, ensuring SQL Server-safe escaping across Django versions.
- operations.py
  - Added explicit negative JSON index guard in `compile_json_path()` raising `NotSupportedError` for unsupported semantics.
  - Improved JSON path segment quoting/escaping for special characters and SQL literal safety.
- features.py
  - Declared `supports_json_negative_indexing = False`.
- test_jsonfield.py
  - Added regression tests for special-character JSON path compilation and negative-index unsupported behavior.
- settings.py
  - Removed now-passing Django 6.0 JSON exclusions (large JSON lookup cluster) and removed 5.2 special-character exclusions that are now green.

**Exclusions Updated**
- Removed JSON exclusion entries that are now validated as passing, including special-char lookup cases and broad JSON lookup/transform coverage.
- Kept exclusions that still represent known limitations/out-of-scope items.

**Risk / Compatibility**
- Changes are limited to JSON path handling and feature signaling.
- Cross-version behavior preserved by backend-path fallback logic and lane validation across 4.1→6.0.
- No unrelated backend areas were modified in this commit.