### PR TITLE
FIX: Django 6.0 batching and ORDER BY compatibility

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -404,7 +404,8 @@ class SQLCompiler(compiler.SQLCompiler):
                                     seen_unqualified.add(col_name)
                                 ordering.append(o_sql)
                                 params.extend(o_params)
-                            offsetting_order_by = ', '.join(ordering)
+                            if ordering:
+                                offsetting_order_by = ', '.join(ordering)
                             order_by = []
                         out_cols.append('ROW_NUMBER() OVER (ORDER BY %s) AS [rn]' % offsetting_order_by)
                     elif not order_by:
@@ -508,6 +509,15 @@ class SQLCompiler(compiler.SQLCompiler):
                     result.append('ORDER BY %s' % ', '.join(ordering))
                 else:
                     order_by = []
+                    if do_offset and supports_offset_clause:
+                        meta = self.query.get_meta()
+                        qn = self.quote_name_unless_alias
+                        result.append(
+                            'ORDER BY %s.%s ASC' % (
+                                qn(meta.db_table),
+                                qn(meta.pk.db_column or meta.pk.column),
+                            )
+                        )
 
                 # For subqueres with an ORDER BY clause, SQL Server also
                 # requires a TOP or OFFSET clause which is not generated for

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -232,6 +232,27 @@ compiler.cursor_iter = _cursor_iter
 
 class SQLCompiler(compiler.SQLCompiler):
 
+    def _resolve_order_by_source_expression(self, expression, dereference_ref=True):
+        if expression is None:
+            return None
+        source_expressions = expression.get_source_expressions()
+        if not source_expressions:
+            return None
+        source = source_expressions[0]
+        if dereference_ref and isinstance(source, Ref):
+            ref_source_expressions = source.get_source_expressions()
+            if ref_source_expressions:
+                source = ref_source_expressions[0]
+        return source
+
+    def _is_constant_order_by_expression(self, expression):
+        if django.VERSION >= (4, 2):
+            unresolved = self._resolve_order_by_source_expression(expression, dereference_ref=False)
+            if isinstance(unresolved, Ref):
+                return False
+        source = self._resolve_order_by_source_expression(expression)
+        return source is not None and self._is_constant_expression(source)
+
     def get_order_by(self):
         """
         Expand ColPairs-based OrderBy expressions into individual per-column
@@ -351,12 +372,14 @@ class SQLCompiler(compiler.SQLCompiler):
                             seen_full = set()  # Full column refs (qualified or unqualified)
                             seen_unqualified = set()  # Just column names from unqualified refs
                             for expr, (o_sql, o_params, _) in order_by:
+                                if self._is_constant_order_by_expression(expr):
+                                    continue
                                 # value_expression in OVER clause cannot refer to
                                 # expressions or aliases in the select list. See:
                                 # http://msdn.microsoft.com/en-us/library/ms189461.aspx
-                                src = next(iter(expr.get_source_expressions()))
+                                src = self._resolve_order_by_source_expression(expr, dereference_ref=False)
                                 if isinstance(src, Ref):
-                                    src = next(iter(src.get_source_expressions()))
+                                    src = self._resolve_order_by_source_expression(expr)
                                     o_sql, _ = src.as_sql(self, self.connection)
                                     odir = 'DESC' if expr.descending else 'ASC'
                                     o_sql = '%s %s' % (o_sql, odir)
@@ -432,7 +455,10 @@ class SQLCompiler(compiler.SQLCompiler):
                 if grouping:
                     if distinct_fields:
                         raise NotImplementedError('annotate() + distinct(fields) is not implemented.')
-                    order_by = order_by or self.connection.ops.force_no_ordering()
+                    if self.query.default_ordering and not self.query.order_by:
+                        order_by = self.connection.ops.force_no_ordering()
+                    else:
+                        order_by = order_by or self.connection.ops.force_no_ordering()
                     result.append('GROUP BY %s' % ', '.join(grouping))
 
                 if having:
@@ -451,8 +477,10 @@ class SQLCompiler(compiler.SQLCompiler):
                 seen_full = set()  # Full column refs (qualified or unqualified)
                 seen_unqualified = set()  # Just column names from unqualified refs
                 for expr, (o_sql, o_params, _) in order_by:
+                    if self._is_constant_order_by_expression(expr):
+                        continue
                     if expr:
-                        src = next(iter(expr.get_source_expressions()))
+                        src = self._resolve_order_by_source_expression(expr)
                         if isinstance(src, Random):
                             # ORDER BY RAND() doesn't return rows in random order
                             # replace it with NEWID()
@@ -475,14 +503,17 @@ class SQLCompiler(compiler.SQLCompiler):
                         seen_unqualified.add(col_name)
                     ordering.append(o_sql)
                     params.extend(o_params)
-                result.append('ORDER BY %s' % ', '.join(ordering))
+                if ordering:
+                    result.append('ORDER BY %s' % ', '.join(ordering))
+                else:
+                    order_by = []
 
                 # For subqueres with an ORDER BY clause, SQL Server also
                 # requires a TOP or OFFSET clause which is not generated for
                 # Django 2.x.  See https://github.com/microsoft/mssql-django/issues/12
                 # Add OFFSET for all Django versions.
                 # https://github.com/microsoft/mssql-django/issues/109
-                if not (do_offset or do_limit) and supports_offset_clause:
+                if ordering and not (do_offset or do_limit) and supports_offset_clause:
                     result.append("OFFSET 0 ROWS")
 
             # SQL Server requires the backend-specific emulation (2008 or earlier)
@@ -546,12 +577,18 @@ class SQLCompiler(compiler.SQLCompiler):
         return self._filter_subquery_and_constant_expressions(expressions)
 
     def _is_constant_expression(self, expression):
+        if expression is None:
+            return False
         if isinstance(expression, Value):
             return True
+        if not hasattr(expression, 'get_source_expressions'):
+            return False
         sub_exprs = expression.get_source_expressions()
         if not sub_exprs:
             return False
         for each in sub_exprs:
+            if each is None:
+                return False
             if not self._is_constant_expression(each):
                 return False
         return True

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -118,13 +118,15 @@ def sqlserver_mod(self, compiler, connection):
     # Compile the left-hand side (lhs) expression to SQL and parameters.
     lhs_sql, lhs_params = compiler.compile(expr[0])
     # Compile the right-hand side (rhs) expression to SQL and parameters.
-    rhs_sql, rhs_params = compiler.compile(expr[1])   
+    rhs_sql, rhs_params = compiler.compile(expr[1])
+    lhs_params = tuple(lhs_params)
+    rhs_params = tuple(rhs_params)
     # Build the SQL template for modulo using ABS, FLOOR, and SIGN functions.
     template = '(ABS(%s) - FLOOR(ABS(%s) / ABS(%s)) * ABS(%s)) * SIGN(%s) * SIGN(%s)'  
     # Substitute the compiled SQL expressions into the template.
     sql = template % (lhs_sql, lhs_sql, rhs_sql, rhs_sql, lhs_sql, rhs_sql)   
     # Combine all parameters in the correct order for the SQL statement.
-    params = lhs_params + lhs_params + rhs_params + rhs_params + lhs_params + rhs_params    
+    params = lhs_params + lhs_params + rhs_params + rhs_params + lhs_params + rhs_params
     try:
         # return sql,params
         return sql, params

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -70,6 +70,29 @@ class DatabaseOperations(BaseDatabaseOperations):
         # query parameters for the `sp_executesql` call. This should only take
         # up 2 parameters but I've had this error when sending 2098 parameters.
         max_query_params = 2050
+
+        if objs and not hasattr(objs[0], '_meta'):
+            return max_query_params // fields_len
+
+        if objs and hasattr(objs[0], '_meta'):
+            if all(isinstance(field, str) for field in fields):
+                # Deletion collector batching calls this with a single string
+                # field name (from Collector.get_del_batches()). Treat that
+                # shape as delete batching, not insert/update batching, so we
+                # don't apply the extra /2 reduction that can split large
+                # cascade deletes into one additional query.
+                if fields_len == 1:
+                    return max_query_params // fields_len
+                return min(max_insert_rows, max_query_params // fields_len // 2)
+
+            obj_model = objs[0].__class__
+            field_models = {
+                field.model for field in fields
+                if hasattr(field, 'model') and field.model is not None
+            }
+            if field_models and any(field_model is not obj_model for field_model in field_models):
+                return max_query_params // fields_len
+
         # inserts are capped at 1000 rows regardless of number of query params.
         # bulk_update CASE...WHEN...THEN statement sometimes takes 2 parameters per field
         return min(max_insert_rows, max_query_params // fields_len // 2)
@@ -543,6 +566,8 @@ class DatabaseOperations(BaseDatabaseOperations):
     def subtract_temporals(self, internal_type, lhs, rhs):
         lhs_sql, lhs_params = lhs
         rhs_sql, rhs_params = rhs
+        lhs_params = tuple(lhs_params)
+        rhs_params = tuple(rhs_params)
         if internal_type == 'DateField':
             sql = "CAST(DATEDIFF(day, %(rhs)s, %(lhs)s) AS bigint) * 86400 * 1000000"
             params = rhs_params + lhs_params

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -350,7 +350,7 @@ if VERSION >= (6, 0):
         'migrations.test_commands.MakeMigrationsTests.test_makemigrations_model_rename_interactive',
         'migrations.test_commands.MakeMigrationsTests.test_makemigrations_no_changes',
         'schema.tests.SchemaTests.test_remove_constraints_capital_letters',
-        # Query count differences still under investigation
+        # Constraint validation (single-query path) query count still under investigation
         'foreign_object.tests.ForeignObjectModelValidationTests.test_validate_constraints_success_case_single_query',
         # Bulk create output column count
         'bulk_create.tests.BulkCreateTests.test_db_default_field_excluded',

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -324,21 +324,9 @@ if VERSION >= (5, 1):
 # Django 6.0 specific exclusions
 if VERSION >= (6, 0):
     EXCLUDED_TESTS.extend([
-        # ORDER BY with GROUP BY - SQL Server limitation with order_with_respect_to bulk_create
-        'order_with_respect_to.tests.OrderWithRespectToBaseTests.test_bulk_create_allows_duplicate_order_values',
-        'order_with_respect_to.tests.OrderWithRespectToBaseTests.test_bulk_create_mixed_scenario',
-        'order_with_respect_to.tests.OrderWithRespectToBaseTests.test_bulk_create_multiple_parents',
-        'order_with_respect_to.tests.OrderWithRespectToBaseTests.test_bulk_create_respects_mixed_manual_order',
-        'order_with_respect_to.tests.OrderWithRespectToBaseTests.test_bulk_create_with_empty_parent',
-        'order_with_respect_to.tests.OrderWithRespectToBaseTests.test_bulk_create_with_existing_children',
-        # ORDER BY with CASE WHEN constant value - SQL Server limitation
+        # Constant CASE ORDER BY compiles to a parameterized ordering expression
+        # that SQL Server rejects (error 1008).
         'ordering.tests.OrderingTests.test_order_by_case_when_constant_value',
-        
-        # Parameter type handling - Django 6.0 changed params from list to tuple in some places
-        'aggregation.tests.AggregateTestCase.test_order_by_aggregate_transform',
-        'expressions.tests.FTimeDeltaTests.test_date_subtraction',
-        'expressions.tests.FTimeDeltaTests.test_datetime_subtraction',
-        'expressions.tests.FTimeDeltaTests.test_time_subtraction',
         
         # JSONField - UUID serialization and negative array index handling needed
         'model_fields.test_jsonfield.TestQuerying.test_deep_negative_lookup_array',
@@ -394,8 +382,7 @@ if VERSION >= (6, 0):
         'migrations.test_commands.MakeMigrationsTests.test_makemigrations_model_rename_interactive',
         'migrations.test_commands.MakeMigrationsTests.test_makemigrations_no_changes',
         'schema.tests.SchemaTests.test_remove_constraints_capital_letters',
-        # Query count differences due to SQL Server parameter limits
-        'lookup.tests.LookupTests.test_in_bulk_lots_of_ids',
+        # Query count differences still under investigation
         'foreign_object.tests.ForeignObjectModelValidationTests.test_validate_constraints_success_case_single_query',
         # Bulk create output column count
         'bulk_create.tests.BulkCreateTests.test_db_default_field_excluded',

--- a/testapp/tests/test_expressions.py
+++ b/testapp/tests/test_expressions.py
@@ -116,6 +116,14 @@ class TestOrderingRegressions(TestCase):
             ['alice', 'bob', 'charlie'],
         )
 
+    def test_order_by_case_when_constant_value_with_offset_executes(self):
+        queryset = Author.objects.order_by(Value(1))[1:3]
+        expected = list(Author.objects.order_by('pk').values_list('name', flat=True))[1:3]
+        self.assertEqual(
+            list(queryset.values_list('name', flat=True)),
+            expected,
+        )
+
 
 class TestModuloExpressionRegressions(TestCase):
     def test_modulo_expression_with_value_parameter_executes(self):

--- a/testapp/tests/test_expressions.py
+++ b/testapp/tests/test_expressions.py
@@ -94,6 +94,37 @@ class TestGroupBy(TestCase):
             output_field=CharField())).values('age').annotate(sum=Sum('id'))
         self.assertEqual(list(annotated_queryset.all()), [])
 
+
+class TestOrderingRegressions(TestCase):
+    def setUp(self):
+        Author.objects.bulk_create([
+            Author(name='alice'),
+            Author(name='bob'),
+            Author(name='charlie'),
+        ])
+
+    def test_order_by_case_when_constant_value_executes(self):
+        queryset = Author.objects.order_by(
+            Case(
+                When(name__isnull=False, then=Value(1)),
+                default=Value(1),
+                output_field=IntegerField(),
+            )
+        )
+        self.assertCountEqual(
+            list(queryset.values_list('name', flat=True)),
+            ['alice', 'bob', 'charlie'],
+        )
+
+
+class TestModuloExpressionRegressions(TestCase):
+    def test_modulo_expression_with_value_parameter_executes(self):
+        author = Author.objects.create(name='mod-author')
+        annotated = Author.objects.filter(pk=author.pk).annotate(
+            mod_value=F('pk') % Value(2)
+        ).values_list('mod_value', flat=True)
+        self.assertEqual(list(annotated), [author.pk % 2])
+
 @skipUnless(DJANGO3, "Django 3 specific tests")
 @skipUnlessDBFeature("order_by_nulls_first")
 class TestOrderBy(TestCase):


### PR DESCRIPTION
GH Issue: #483 

## Summary

  - This PR fixes Django 6.0 compatibility issues in SQL Server batching, ORDER BY compilation, and parameter container handling.
  - It also removes exclusions that now pass because of these fixes.
- Root causes
  - Django 6.0/related paths pass params in tuple/list shapes that broke concatenation assumptions.
  - SQL Server ORDER BY generation still emitted constant-only ordering expressions and duplicate/invalid ordering shapes in grouped/annotated paths.
  - Batch sizing logic treated non-insert paths too aggressively, causing avoidable query splits and query-count mismatches.

**What changed**
  - functions.py
    - Normalized MOD expression params to tuples before concatenation.
  - operations.py
    - Added scalar-object and model-mismatch branches in bulk_batch_size() to use parameter-budget sizing when appropriate.
    - Added delete-collector single-string-field handling to avoid extra splitting.
    - Normalized subtract_temporals() params to tuples.
  - compiler.py
    - Added expression-level constant ORDER BY detection helpers.
    - Skips constant ORDER BY expressions that SQL Server rejects.
    - Improved Ref source resolution in ORDER BY handling.
    - Avoids emitting ORDER BY/OFFSET when ordering list becomes empty after filtering.
    - Hardened constant-expression recursion for None/non-expression nodes.
  - settings.py
    - Unexcluded now-passing Django 6.0 tests