### PR TITLE
FIX: Django 6.0 db_default bulk insert alignment

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -161,3 +161,27 @@ echo "yes" | python tests/runtests.py --settings=testapp.settings <module>
 - **All tests must be green before submitting.** If a test fails due to a SQL Server limitation (not a bug you introduced), add it to `EXCLUDED_TESTS` in `testapp/settings.py` with a comment explaining why.
 - If a failure is outside the scope of your PR, ask whether to fix it or exclude it — don't leave it failing silently.
 - Always run the specific Django test modules affected by your change (e.g. `ordering`, `db_functions`, `composite_pk`) in addition to the unit tests (`python manage.py test testapp.tests`).
+
+## PR Self-Check Template (Django/SQL Backend Changes)
+
+### Checklist
+1. **Contract change declared**
+    - If a helper behavior changes (e.g., path builder), write one explicit rule: who returns raw values, who does SQL escaping/normalization, and where.
+2. **All call sites audited**
+    - grep every consumer of changed helper/symbol and verify each follows the new contract exactly once.
+3. **Integration test proof**
+    - Add at least one end-to-end ORM regression test for changed behavior, or run and document a concrete end-to-end upstream Django test that directly exercises the changed path.
+4. **Doc/comments synced**
+    - Update docstrings/comments to match implementation (no stale wording).
+5. **Exclusion hygiene**
+    - Remove only exclusions proven green in normal settings.
+    - For any kept exclusion, add a one-line reason.
+6. **Version matrix evidence**
+    - Run targeted tests + HOT guard on executable lanes; report PASS/FAIL/BLOCKED explicitly.
+
+### Merge Gate (must all be true)
+- No unresolved contract ambiguity.
+- No double-escaping / double-transform pattern in call sites.
+- At least one integration regression proof for each behavior change.
+- Targeted tests green + HOT guard green (or BLOCKED with environment reason).
+- PR description includes root cause, fix scope, and exclusions touched.

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -2,6 +2,7 @@
 # Licensed under the BSD license.
 
 import types
+from functools import partial
 from itertools import chain
 
 import django
@@ -27,9 +28,9 @@ if django.VERSION >= (4, 2):
 # columns into a single comma-separated SQL string. We expand these at
 # the expression level in get_order_by() so each ORDER BY item is always
 # a single column expression.
-try:
+if django.VERSION >= (5, 2):
     from django.db.models.expressions import ColPairs
-except ImportError:
+else:
     ColPairs = None
 
 def _as_sql_agv(self, compiler, connection):
@@ -687,13 +688,53 @@ class SQLInsertCompiler(compiler.SQLInsertCompiler, SQLCompiler):
         result = ['INSERT INTO %s' % qn(opts.db_table)]
 
         if self.query.fields:
-            fields = self.query.fields
+            fields = list(self.query.fields)
+            supports_default_keyword_in_bulk_insert = (
+                self.connection.features.supports_default_keyword_in_bulk_insert
+            )
             result.append('(%s)' % ', '.join(qn(f.column) for f in fields))
             values_format = 'VALUES (%s)'
-            value_rows = [
-                [self.prepare_value(field, self.pre_save_val(field, obj)) for field in fields]
-                for obj in self.query.objs
-            ]
+
+            if django.VERSION < (6, 0):
+                value_rows = [
+                    [self.prepare_value(field, self.pre_save_val(field, obj)) for field in fields]
+                    for obj in self.query.objs
+                ]
+            else:
+                from django.db.models.expressions import DatabaseDefault
+
+                value_cols = []
+                for field in list(fields):
+                    field_prepare = partial(self.prepare_value, field)
+                    field_pre_save = partial(self.pre_save_val, field)
+                    field_values = [
+                        field_prepare(field_pre_save(obj)) for obj in self.query.objs
+                    ]
+
+                    if not field.has_db_default():
+                        value_cols.append(field_values)
+                        continue
+
+                    if len(fields) > 1 and all(
+                        isinstance(value, DatabaseDefault) for value in field_values
+                    ):
+                        fields.remove(field)
+                        continue
+
+                    if supports_default_keyword_in_bulk_insert:
+                        value_cols.append(field_values)
+                        continue
+
+                    prepared_db_default = field_prepare(field.db_default)
+                    field_values = [
+                        prepared_db_default
+                        if isinstance(value, DatabaseDefault)
+                        else value
+                        for value in field_values
+                    ]
+                    value_cols.append(field_values)
+                value_rows = list(zip(*value_cols))
+                result[-1] = '(%s)' % ', '.join(qn(f.column) for f in fields)
         else:
             values_format = '%s VALUES'
             # An empty object.

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -397,8 +397,6 @@ if VERSION >= (6, 0):
         # Query count differences due to SQL Server parameter limits
         'lookup.tests.LookupTests.test_in_bulk_lots_of_ids',
         'foreign_object.tests.ForeignObjectModelValidationTests.test_validate_constraints_success_case_single_query',
-        # Bulk create output column count
-        'bulk_create.tests.BulkCreateTests.test_db_default_field_excluded',
         # DEFAULT_AUTO_FIELD behavior - testapp models use explicit AutoField
         'model_options.test_default_pk.TestDefaultPK.test_default_value_of_default_auto_field_setting',
         # Introspection returns IntegerField for AutoField-generated columns

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -1,3 +1,5 @@
+import unittest
+
 import django.db.utils
 from django import VERSION
 from django.db import connections, connection, models
@@ -6,6 +8,7 @@ from django.test import TransactionTestCase, TestCase, skipUnlessDBFeature
 from django.utils import timezone
 
 from ..models import Author, BinaryData
+
 
 class TestTableWithTrigger(TransactionTestCase):
     def test_insert_into_table_with_trigger(self):
@@ -32,6 +35,7 @@ class TestTableWithTrigger(TransactionTestCase):
                 cursor.execute("DROP TRIGGER TestTrigger")
             connection.features_class.can_return_rows_from_bulk_insert = old_return_rows_flag
 
+
 class TestBinaryfieldGroupby(TestCase):
     def test_varbinary(self):
         with connection.cursor() as cursor:
@@ -40,13 +44,34 @@ class TestBinaryfieldGroupby(TestCase):
 
 @skipUnlessDBFeature("supports_expression_defaults")
 class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
+    """Regression tests for Django 6.0 db_default bulk insert alignment.
+
+    Django 6.0 introduced DatabaseDefault sentinel values for fields with
+    db_default. Our SQLInsertCompiler.as_sql() override must correctly:
+      - Exclude a db_default column from the INSERT column list when *every*
+        row uses the database default (letting the server supply the value).
+      - Include the column when at least one row supplies an explicit value
+        (mixing explicit values with DEFAULT keyword or prepared db_default).
+
+    These tests create a raw table with a server-side DEFAULT SYSDATETIME()
+    to exercise both paths end-to-end against SQL Server.
+    """
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
+        # This feature is Django 6.0+ only; skip cleanly on older versions.
+        # Note: raise unittest.SkipTest, not cls.skipTest(), because
+        # skipTest() is an instance method and cannot be called from
+        # setUpClass (a classmethod).
         if VERSION < (6, 0):
-            cls.skipTest("db_default bulk insert alignment is Django 6.0+ specific")
+            raise unittest.SkipTest(
+                "db_default bulk insert alignment is Django 6.0+ specific"
+            )
 
+        # Unmanaged model so Django doesn't try to create/drop the table
+        # via migrations — we handle that with raw SQL below.
         class DbDefaultBulkInsertModel(models.Model):
             name = models.CharField(max_length=100)
             created_at = models.DateTimeField(db_default=Now())
@@ -77,6 +102,10 @@ class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        if VERSION < (6, 0):
+            # Table was never created when the test was skipped.
+            super().tearDownClass()
+            return
         with connection.cursor() as cursor:
             cursor.execute(
                 """
@@ -87,17 +116,33 @@ class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
         super().tearDownClass()
 
     def test_db_default_field_excluded_and_included(self):
+        """Verify created_at column presence in INSERT SQL for db_default.
+
+        Case 1 — all rows use the database default:
+          The column should be omitted from the INSERT column list so the
+          server-side DEFAULT kicks in.  The quoted column name appears only
+          in the OUTPUT INSERTED clause (if can_return_rows_from_bulk_insert)
+          or not at all.
+
+        Case 2 — at least one row supplies an explicit value:
+          The column must appear in the INSERT column list (so the explicit
+          value is written) *and* in OUTPUT INSERTED (if applicable).
+        """
         model = self.DbDefaultBulkInsertModel
         created_at_quoted_name = connection.ops.quote_name("created_at")
 
+        # --- Case 1: all rows rely on db_default for created_at ---
         with self.assertNumQueries(1) as ctx:
             model.objects.bulk_create([model(name="foo"), model(name="bar")])
 
+        # created_at should NOT be in the INSERT column list.
+        # It appears once only if OUTPUT INSERTED includes it.
         self.assertEqual(
             ctx[0]["sql"].count(created_at_quoted_name),
             1 if connection.features.can_return_rows_from_bulk_insert else 0,
         )
 
+        # --- Case 2: one row overrides created_at with an explicit value ---
         with self.assertNumQueries(1) as ctx:
             model.objects.bulk_create(
                 [
@@ -106,6 +151,8 @@ class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
                 ]
             )
 
+        # created_at must be in the INSERT column list (1 occurrence)
+        # plus OUTPUT INSERTED (1 more if can_return_rows_from_bulk_insert).
         self.assertEqual(
             ctx[0]["sql"].count(created_at_quoted_name),
             2 if connection.features.can_return_rows_from_bulk_insert else 1,

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -1,6 +1,9 @@
 import django.db.utils
-from django.db import connections, connection
-from django.test import TransactionTestCase, TestCase
+from django import VERSION
+from django.db import connections, connection, models
+from django.db.models.functions import Now
+from django.test import TransactionTestCase, TestCase, skipUnlessDBFeature
+from django.utils import timezone
 
 from ..models import Author, BinaryData
 
@@ -33,3 +36,77 @@ class TestBinaryfieldGroupby(TestCase):
     def test_varbinary(self):
         with connection.cursor() as cursor:
             cursor.execute(f"SELECT binary FROM {BinaryData._meta.db_table} WHERE binary = %s GROUP BY binary", [bytes("ABC", 'utf-8')])
+
+
+@skipUnlessDBFeature("supports_expression_defaults")
+class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        if VERSION < (6, 0):
+            cls.skipTest("db_default bulk insert alignment is Django 6.0+ specific")
+
+        class DbDefaultBulkInsertModel(models.Model):
+            name = models.CharField(max_length=100)
+            created_at = models.DateTimeField(db_default=Now())
+
+            class Meta:
+                app_label = "testapp"
+                db_table = "testapp_dbdefault_bulk_insert"
+                managed = False
+
+        cls.DbDefaultBulkInsertModel = DbDefaultBulkInsertModel
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                IF OBJECT_ID('testapp_dbdefault_bulk_insert', 'U') IS NOT NULL
+                    DROP TABLE testapp_dbdefault_bulk_insert
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE testapp_dbdefault_bulk_insert (
+                    id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+                    name NVARCHAR(100) NOT NULL,
+                    created_at DATETIME2 NOT NULL DEFAULT SYSDATETIME()
+                )
+                """
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                IF OBJECT_ID('testapp_dbdefault_bulk_insert', 'U') IS NOT NULL
+                    DROP TABLE testapp_dbdefault_bulk_insert
+                """
+            )
+        super().tearDownClass()
+
+    def test_db_default_field_excluded_and_included(self):
+        model = self.DbDefaultBulkInsertModel
+        created_at_quoted_name = connection.ops.quote_name("created_at")
+
+        with self.assertNumQueries(1) as ctx:
+            model.objects.bulk_create([model(name="foo"), model(name="bar")])
+
+        self.assertEqual(
+            ctx[0]["sql"].count(created_at_quoted_name),
+            1 if connection.features.can_return_rows_from_bulk_insert else 0,
+        )
+
+        with self.assertNumQueries(1) as ctx:
+            model.objects.bulk_create(
+                [
+                    model(name="baz", created_at=timezone.now()),
+                    model(name="qux"),
+                ]
+            )
+
+        self.assertEqual(
+            ctx[0]["sql"].count(created_at_quoted_name),
+            2 if connection.features.can_return_rows_from_bulk_insert else 1,
+        )


### PR DESCRIPTION
GH Issue: #483 

## **Summary**
  - Align SQL Server `SQLInsertCompiler` behavior with Django 6.0 `db_default` handling for bulk inserts.
  - Add cross-version guardrails so pre-6.0 paths retain existing behavior.
  - Remove one now-passing Django 6.0 exclusion tied to this fix.

**Root cause**
  - Django 6.0 changed bulk insert handling for fields with `db_default`/`DatabaseDefault`.
  - SQL Server backend insert SQL generation didn’t fully mirror Django 6.0 field-pruning/default substitution paths.
  - This caused mismatch in insert column selection for `db_default` scenarios.

**What changed**
  - compiler.py
    - Version-gated `ColPairs` import for Django `>= 5.2`.
    - Updated `SQLInsertCompiler.as_sql()`:
      - For Django `< 6.0`: keep existing value-row behavior.
      - For Django `>= 6.0`: apply `DatabaseDefault`-aware column pruning/substitution logic.
      - Handle `supports_default_keyword_in_bulk_insert` branch correctly.
      - Recompute insert column list after pruning.
    - Added missing `partial` import used by insert preparation flow.
  - settings.py
    - Removed exclusion:
      - `bulk_create.tests.BulkCreateTests.test_db_default_field_excluded`