### PR TITLE
DOC: Add PR self-check gate prompt and reference it in Copilot instruction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -162,26 +162,11 @@ echo "yes" | python tests/runtests.py --settings=testapp.settings <module>
 - If a failure is outside the scope of your PR, ask whether to fix it or exclude it — don't leave it failing silently.
 - Always run the specific Django test modules affected by your change (e.g. `ordering`, `db_functions`, `composite_pk`) in addition to the unit tests (`python manage.py test testapp.tests`).
 
-## PR Self-Check Template (Django/SQL Backend Changes)
+## Prompt References
 
-### Checklist
-1. **Contract change declared**
-    - If a helper behavior changes (e.g., path builder), write one explicit rule: who returns raw values, who does SQL escaping/normalization, and where.
-2. **All call sites audited**
-    - grep every consumer of changed helper/symbol and verify each follows the new contract exactly once.
-3. **Integration test proof**
-    - Add at least one end-to-end ORM regression test for changed behavior, or run and document a concrete end-to-end upstream Django test that directly exercises the changed path.
-4. **Doc/comments synced**
-    - Update docstrings/comments to match implementation (no stale wording).
-5. **Exclusion hygiene**
-    - Remove only exclusions proven green in normal settings.
-    - For any kept exclusion, add a one-line reason.
-6. **Version matrix evidence**
-    - Run targeted tests + HOT guard on executable lanes; report PASS/FAIL/BLOCKED explicitly.
+Use prompt files via slash-style workspace paths:
 
-### Merge Gate (must all be true)
-- No unresolved contract ambiguity.
-- No double-escaping / double-transform pattern in call sites.
-- At least one integration regression proof for each behavior change.
-- Targeted tests green + HOT guard green (or BLOCKED with environment reason).
-- PR description includes root cause, fix scope, and exclusions touched.
+- `/.github/prompts/mssql-django-pr-self-check-gate.prompt.md` - Gated PR self-check workflow and merge gate criteria.
+- `/.github/prompts/mssql-django-dev-environment-setup.prompt.md` - Development environment setup.
+- `/.github/prompts/mssql-django-run-unit-tests.prompt.md` - mssql-django unit test workflow.
+- `/.github/prompts/mssql-django-run-django-test-suite.prompt.md` - Upstream Django suite workflow.

--- a/.github/prompts/mssql-django-pr-self-check-gate.prompt.md
+++ b/.github/prompts/mssql-django-pr-self-check-gate.prompt.md
@@ -95,9 +95,9 @@ python manage.py test testapp.tests.test_jsonfield --verbosity 2
 cd django
 PYTHONPATH=/workspaces/mssql-django/django python tests/runtests.py --settings=testapp.settings <module.or.test>
 
-# HOT matrix
-cd /workspaces/mssql-django
-./scripts/run_hot_matrix.sh --mode guard
+# HOT matrix / CI guard
+# Run or verify the HOT matrix / CI guard workflow for this branch in your CI system
+# and record its status (PASS / FAIL / BLOCKED) in the gate summary.
 ```
 
 ## Required Output Format

--- a/.github/prompts/mssql-django-pr-self-check-gate.prompt.md
+++ b/.github/prompts/mssql-django-pr-self-check-gate.prompt.md
@@ -1,4 +1,3 @@
-````prompt
 # mssql-django Gated PR Self-Check
 
 Use this prompt before merging any backend/compiler/schema PR.
@@ -133,5 +132,3 @@ For each touched exclusion:
 - `testapp/runners.py` marks excluded tests as expected-failure (`x`) under normal settings. Do not treat `x` alone as proof of backend failure for exclusion decisions.
 - For exclusion removal decisions, always re-run candidate tests directly under `testapp.settings` and inspect actual pass/fail outcomes.
 - Prefer expression-level/compiler-level fixes over SQL string surgery.
-
-````

--- a/.github/prompts/mssql-django-pr-self-check-gate.prompt.md
+++ b/.github/prompts/mssql-django-pr-self-check-gate.prompt.md
@@ -1,0 +1,137 @@
+````prompt
+# mssql-django Gated PR Self-Check
+
+Use this prompt before merging any backend/compiler/schema PR.
+
+## Objective
+
+Run a **merge gate** that prevents regressions from:
+- contract ambiguity,
+- double-escaping/double-transforms,
+- fast-path branches bypassing shared safety logic,
+- stale test exclusions,
+- insufficient integration proof.
+
+The output must be a clear **PASS / FAIL / BLOCKED** decision with evidence.
+
+## Inputs
+
+- PR branch name
+- Target branch (usually `dev`)
+- Changed files (`git diff --name-only <target>...HEAD`)
+- Related Django test modules for changed areas
+
+## Required Checks (in order)
+
+### 1) Contract change declared
+For every behavior-changing helper/symbol, declare one explicit contract:
+- who returns raw values,
+- who escapes/normalizes,
+- where transformation happens,
+- and whether call sites must change.
+
+### 2) All call sites audited
+Audit all consumers of changed symbols and verify:
+- contract applied exactly once,
+- no mixed old/new behavior,
+- no hidden secondary escaping/transform.
+
+### 3) Fast-path invariants preserved
+If a fast-path exists (special-case `continue`/`return`/short-circuit), prove it does not bypass shared safety logic:
+- ORDER BY dedupe,
+- alias handling,
+- parameter ordering,
+- escaping rules,
+- pagination/order requirements.
+
+If it does bypass shared logic, fix by integrating with shared path, not by adding ad-hoc string post-processing.
+
+### 4) Integration test proof
+Provide end-to-end proof for each behavior change:
+- Add local regression tests under `testapp/tests/` when applicable.
+- Run upstream Django tests that exercise the same path.
+- Include at least one regression that targets the **risky edge** (duplicate/equivalent path, alias path, mixed type path, etc.).
+
+### 5) Doc/comments synced
+Ensure comments and PR description match current behavior:
+- remove stale “still failing” language if test now passes,
+- add concise reasons for any remaining exclusions.
+
+### 6) Exclusion hygiene (strict)
+For any exclusion touched in `testapp/settings.py`:
+- Verify candidate removals under **normal settings** (`testapp.settings`), not only fast profile.
+- If using `settings_fast`, treat as exploratory only; confirm final decision with `testapp.settings`.
+- Keep only exclusions that are proven failing due to true SQL Server limitation or out-of-scope known issue.
+
+### 7) Version matrix evidence
+Run targeted tests plus HOT guard matrix and report:
+- PASS lanes,
+- FAIL lanes,
+- BLOCKED lanes with concrete environment reason.
+
+## Merge Gate (must all be true)
+
+- No unresolved contract ambiguity.
+- No double-escaping / double-transform pattern in call sites.
+- No fast-path branch bypassing shared invariants without explicit handling.
+- Integration regression proof exists for each behavior change.
+- Exclusion changes are validated under `testapp.settings`.
+- Targeted tests green + HOT guard green (or BLOCKED with environment reason).
+- PR description includes root cause, fix scope, and exclusions touched.
+
+## Recommended Evidence Commands
+
+```bash
+# Diff scope
+git --no-pager diff --name-status origin/dev...HEAD
+git --no-pager diff --stat origin/dev...HEAD
+
+# Local backend tests
+python manage.py test testapp.tests --verbosity 2
+
+# Targeted local module
+python manage.py test testapp.tests.test_jsonfield --verbosity 2
+
+# Upstream targeted test(s)
+cd django
+PYTHONPATH=/workspaces/mssql-django/django python tests/runtests.py --settings=testapp.settings <module.or.test>
+
+# HOT matrix
+cd /workspaces/mssql-django
+./scripts/run_hot_matrix.sh --mode guard
+```
+
+## Required Output Format
+
+### Gate Summary
+- Overall: PASS / FAIL / BLOCKED
+- Scope: changed files + behavior areas
+
+### Checklist Results
+- Contract change declared: PASS/FAIL (+ evidence)
+- Call-site audit: PASS/FAIL (+ evidence)
+- Fast-path invariants: PASS/FAIL (+ evidence)
+- Integration test proof: PASS/FAIL (+ tests run)
+- Doc/comments sync: PASS/FAIL (+ note)
+- Exclusion hygiene: PASS/FAIL (+ list kept/removed)
+- Version matrix evidence: PASS/FAIL/BLOCKED (+ lanes)
+
+### Exclusions Decision Table
+For each touched exclusion:
+- test id
+- decision (keep/remove)
+- reason
+- proof command
+- result
+
+### Merge Recommendation
+- Merge now / Needs fixes
+- If fixes needed, list minimal required changes.
+
+## Notes specific to mssql-django
+
+- `testapp/runners.py` marks excluded tests as expected-failure (`x`) under normal settings. Do not treat `x` alone as proof of backend failure for exclusion decisions.
+- For exclusion removal decisions, always re-run candidate tests directly under `testapp.settings` and inspect actual pass/fail outcomes.
+- Prefer expression-level/compiler-level fixes over SQL string surgery.
+
+````

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -7,7 +7,11 @@ from itertools import chain
 
 import django
 from django.db.models.aggregates import Avg, Count, StdDev, Variance
-from django.db.models.expressions import Ref, Subquery, Value, Window
+from django.db.models import AutoField
+if django.VERSION >= (6, 0):
+    from django.db.models.aggregates import StringAgg
+from django.db.models.expressions import Col, OuterRef, Ref, Subquery, Value, Window
+from django.db.models.expressions import ResolvedOuterRef
 from django.db.models.functions import (
     Chr, ConcatPair, Greatest, Least, Length, LPad, Random, Repeat, RPad, StrIndex, Substr, Trim
 )
@@ -152,6 +156,36 @@ def _as_sql_variance(self, compiler, connection):
     if self.function == 'VAR_POP':
         function = '%sP' % function
     return self.as_sql(compiler, connection, function=function)
+
+
+def _as_sql_stringagg(self, compiler, connection):
+    if self.order_by and _contains_outerref(self.order_by, compiler.query):
+        node = self.copy()
+        node.order_by = None
+        return node.as_sql(compiler, connection)
+
+    template = None
+    if self.order_by:
+        template = '%(function)s(%(distinct)s%(expressions)s) WITHIN GROUP (%(order_by)s)%(filter)s'
+    return self.as_sql(compiler, connection, template=template)
+
+
+def _contains_outerref(expression, query=None):
+    if expression is None:
+        return False
+    if isinstance(expression, (OuterRef, ResolvedOuterRef)):
+        return True
+    if isinstance(expression, Col) and query is not None:
+        query_aliases = set(query.alias_map) if getattr(query, 'alias_map', None) else set()
+        if expression.alias not in query_aliases:
+            return True
+
+    source_expressions = getattr(expression, 'get_source_expressions', None)
+    if source_expressions is None:
+        return False
+
+    return any(_contains_outerref(expr, query) for expr in expression.get_source_expressions() if expr is not None)
+
 
 def _as_sql_window(self, compiler, connection, template=None):
     # Get the expressions supported by the backend
@@ -703,6 +737,8 @@ class SQLCompiler(compiler.SQLCompiler):
             as_microsoft = _as_sql_trim
         elif isinstance(node, Variance):
             as_microsoft = _as_sql_variance
+        elif django.VERSION >= (6, 0) and isinstance(node, StringAgg):
+            as_microsoft = _as_sql_stringagg
         if django.VERSION >= (3, 1):
             if isinstance(node, json_KeyTransform):
                 as_microsoft = _as_sql_json_keytransform
@@ -860,10 +896,58 @@ class SQLInsertCompiler(compiler.SQLInsertCompiler, SQLCompiler):
                 params += param_rows
                 result.append(self.connection.ops.bulk_insert_sql(fields, placeholder_rows))
             else:
-                result.insert(0, 'SET NOCOUNT ON')
-                result.append((values_format + ';') % ', '.join(placeholder_rows[0]))
-                params = [param_rows[0]]
-                result.append('SELECT CAST(SCOPE_IDENTITY() AS bigint)')
+                returned_fields = self.get_returned_fields()
+                use_scope_identity = (
+                    len(returned_fields) == 1 and isinstance(returned_fields[0], AutoField)
+                )
+
+                if use_scope_identity:
+                    result.insert(0, 'SET NOCOUNT ON')
+                    if not self.query.fields:
+                        result.append('DEFAULT VALUES;')
+                        params = []
+                    else:
+                        result.append((values_format + ';') % ', '.join(placeholder_rows[0]))
+                        params = [param_rows[0]]
+                    result.append('SELECT CAST(SCOPE_IDENTITY() AS bigint)')
+                else:
+                    params = []
+                    table_name = qn(opts.db_table)
+                    tmp_table_name = '#django_returning_insert'
+                    returned_columns = ', '.join(qn(field.column) for field in returned_fields)
+                    select_into_columns = []
+                    for field in returned_fields:
+                        column_sql = qn(field.column)
+                        if isinstance(field, AutoField):
+                            select_into_columns.append(f'CAST({column_sql} AS bigint) AS {column_sql}')
+                        else:
+                            select_into_columns.append(column_sql)
+
+                    r_sql, self.returning_params = self.connection.ops.return_insert_columns(returned_fields)
+                    if r_sql and self.returning_params:
+                        params.append(self.returning_params)
+
+                    insert_sql = result[:]
+                    if r_sql:
+                        insert_sql.append(f'{r_sql} INTO {tmp_table_name}')
+                    if not self.query.fields:
+                        insert_sql.append('DEFAULT VALUES')
+                    else:
+                        insert_sql.append(values_format % ', '.join(placeholder_rows[0]))
+                        params.append(param_rows[0])
+
+                    sql_batch = '; '.join([
+                        'SET NOCOUNT ON',
+                        f"IF OBJECT_ID('tempdb..{tmp_table_name}') IS NOT NULL DROP TABLE {tmp_table_name}",
+                        f"SELECT TOP 0 {', '.join(select_into_columns)} INTO {tmp_table_name} FROM {table_name}",
+                        ' '.join(insert_sql),
+                        f'SELECT {returned_columns} FROM {tmp_table_name}',
+                        f'DROP TABLE {tmp_table_name}',
+                    ])
+                    sql = [(sql_batch, tuple(chain.from_iterable(params)))]
+                    if self.query.fields:
+                        sql = self.fix_auto(sql, opts, fields, qn)
+                    return sql
             sql = [(" ".join(result), tuple(chain.from_iterable(params)))]
         else:
             if can_bulk:

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -45,6 +45,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_json_field_contains = False
     supports_json_negative_indexing = False
     supports_order_by_nulls_modifier = False
+    supports_aggregate_order_by_clause = True
+    supports_order_by_in_aggregate = True
     supports_over_clause = True
     supports_paramstyle_pyformat = False
     supports_primitives_in_json_field = False

--- a/testapp/tests/test_expressions.py
+++ b/testapp/tests/test_expressions.py
@@ -11,7 +11,10 @@ from django.test import TestCase, skipUnlessDBFeature
 
 from django.db.models.aggregates import Count, Sum
 
-from ..models import Author, Book, Comment, Post, Editor, ModelWithNullableFieldsOfDifferentTypes
+if VERSION >= (6, 0):
+    from django.db.models import StringAgg
+
+from ..models import Author, Book, Comment, Post, Editor, ModelWithNullableFieldsOfDifferentTypes, Publisher
 
 
 DJANGO3 = VERSION[0] >= 3
@@ -171,3 +174,43 @@ class TestBulkUpdate(TestCase):
         self.assertCountEqual(ModelWithNullableFieldsOfDifferentTypes.objects.filter(int_value__isnull=True), objs)
         self.assertCountEqual(ModelWithNullableFieldsOfDifferentTypes.objects.filter(name__isnull=True), objs)
         self.assertCountEqual(ModelWithNullableFieldsOfDifferentTypes.objects.filter(date__isnull=True), objs)
+
+
+class TestStringAggOrderingRegression(TestCase):
+    @skipUnless(VERSION >= (6, 0), "StringAgg ordering is Django 6.0+")
+    def test_stringagg_honors_ordering(self):
+        Author.objects.bulk_create([
+            Author(name='Charlie'),
+            Author(name='Alice'),
+            Author(name='Bob'),
+        ])
+        with self.assertNumQueries(1) as ctx:
+            result = Author.objects.aggregate(
+                names=StringAgg('name', delimiter=Value(', '), order_by=F('name'))
+            )
+        self.assertEqual(result['names'], 'Alice, Bob, Charlie')
+        self.assertIn('WITHIN GROUP (', ctx[0]['sql'])
+        self.assertIn('ORDER BY [testapp_author].[name]', ctx[0]['sql'])
+
+    @skipUnless(VERSION >= (6, 0), "StringAgg ordering is Django 6.0+")
+    def test_stringagg_order_by_outerref_does_not_use_within_group(self):
+        publisher_1 = Publisher.objects.create(name='p1')
+        Book.objects.create(name='Alpha', publisher=publisher_1)
+
+        with self.assertNumQueries(1) as ctx:
+            values = list(
+                Publisher.objects.filter(pk=publisher_1.pk).annotate(
+                    names=Subquery(
+                        Book.objects.annotate(
+                            names=StringAgg(
+                                'name',
+                                delimiter=Value(';'),
+                                order_by=OuterRef('pk'),
+                            )
+                        ).values('names')[:1]
+                    )
+                ).values_list('names', flat=True)
+            )
+
+        self.assertEqual(values, ['Alpha'])
+        self.assertNotIn('WITHIN GROUP', ctx[0]['sql'])

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -157,3 +157,24 @@ class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
             ctx[0]["sql"].count(created_at_quoted_name),
             2 if connection.features.can_return_rows_from_bulk_insert else 1,
         )
+
+    def test_single_insert_with_returning_fields_when_bulk_rows_unsupported(self):
+        """Single-row create must still return all db_returning fields.
+
+        Regression for a path where can_return_rows_from_bulk_insert=False
+        caused SQLInsertCompiler to use SCOPE_IDENTITY() (1 column) while
+        Django expected all returning fields, leading to IndexError.
+        """
+        model = self.DbDefaultBulkInsertModel
+        old_return_rows_flag = connection.features_class.can_return_rows_from_bulk_insert
+        connection.features_class.can_return_rows_from_bulk_insert = False
+        try:
+            with self.assertNumQueries(1) as ctx:
+                obj = model.objects.create(name="single")
+
+            self.assertIsNotNone(obj.pk)
+            self.assertIsNotNone(obj.created_at)
+            self.assertIn("OUTPUT INSERTED", ctx[0]["sql"])
+            self.assertNotIn("SCOPE_IDENTITY", ctx[0]["sql"])
+        finally:
+            connection.features_class.can_return_rows_from_bulk_insert = old_return_rows_flag


### PR DESCRIPTION
Contains stacked PR changes from #511 & #512 , since the fixes are adhoc - test validations etc. will be satisfied with this PR

Below is the summary which this PR targets:

This pull request updates the contributor documentation to replace the inline Django/SQL backend PR self-check template with a reference to new, dedicated prompt files. The main change is the removal of the detailed checklist and merge gate criteria from `.github/copilot-instructions.md` and the introduction of `.github/prompts/mssql-django-pr-self-check-gate.prompt.md`, which now contains the full gated PR self-check workflow.

**Documentation workflow improvements:**

* Replaced the inline PR self-check template in `.github/copilot-instructions.md` with references to external prompt files for PR self-check, development environment setup, and test workflows, streamlining contributor guidance.

**Prompt file additions:**

* Added `.github/prompts/mssql-django-pr-self-check-gate.prompt.md`, which provides a comprehensive, step-by-step merge gate checklist for backend/compiler/schema PRs, including contract declaration, call-site audit, fast-path invariants, integration proof, exclusion hygiene, and version matrix evidence.