### PR TITLE
FIX: db_default insert returning fallback mismatch

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -912,17 +912,41 @@ class SQLInsertCompiler(compiler.SQLInsertCompiler, SQLCompiler):
                     result.append('SELECT CAST(SCOPE_IDENTITY() AS bigint)')
                 else:
                     params = []
+                    table_name = qn(opts.db_table)
+                    tmp_table_name = '#django_returning_insert'
+                    returned_columns = ', '.join(qn(field.column) for field in returned_fields)
+                    select_into_columns = []
+                    for field in returned_fields:
+                        column_sql = qn(field.column)
+                        if isinstance(field, AutoField):
+                            select_into_columns.append(f'CAST({column_sql} AS bigint) AS {column_sql}')
+                        else:
+                            select_into_columns.append(column_sql)
+
                     r_sql, self.returning_params = self.connection.ops.return_insert_columns(returned_fields)
+                    if r_sql and self.returning_params:
+                        params.append(self.returning_params)
+
+                    insert_sql = result[:]
                     if r_sql:
-                        result.append(r_sql)
-                        params += [self.returning_params]
+                        insert_sql.append(f'{r_sql} INTO {tmp_table_name}')
                     if not self.query.fields:
-                        result.append('DEFAULT VALUES')
+                        insert_sql.append('DEFAULT VALUES')
                     else:
-                        result.append(values_format % ', '.join(placeholder_rows[0]))
-                        params = [param_rows[0]]
-                        if r_sql:
-                            params += [self.returning_params]
+                        insert_sql.append(values_format % ', '.join(placeholder_rows[0]))
+                        params.append(param_rows[0])
+
+                    sql_batch = '; '.join([
+                        'SET NOCOUNT ON',
+                        f"SELECT TOP 0 {', '.join(select_into_columns)} INTO {tmp_table_name} FROM {table_name}",
+                        ' '.join(insert_sql),
+                        f'SELECT {returned_columns} FROM {tmp_table_name}',
+                        f'DROP TABLE {tmp_table_name}',
+                    ])
+                    sql = [(sql_batch, tuple(chain.from_iterable(params)))]
+                    if self.query.fields:
+                        sql = self.fix_auto(sql, opts, fields, qn)
+                    return sql
             sql = [(" ".join(result), tuple(chain.from_iterable(params)))]
         else:
             if can_bulk:

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -7,6 +7,7 @@ from itertools import chain
 
 import django
 from django.db.models.aggregates import Avg, Count, StdDev, Variance
+from django.db.models import AutoField
 if django.VERSION >= (6, 0):
     from django.db.models.aggregates import StringAgg
 from django.db.models.expressions import Col, OuterRef, Ref, Subquery, Value, Window
@@ -895,10 +896,33 @@ class SQLInsertCompiler(compiler.SQLInsertCompiler, SQLCompiler):
                 params += param_rows
                 result.append(self.connection.ops.bulk_insert_sql(fields, placeholder_rows))
             else:
-                result.insert(0, 'SET NOCOUNT ON')
-                result.append((values_format + ';') % ', '.join(placeholder_rows[0]))
-                params = [param_rows[0]]
-                result.append('SELECT CAST(SCOPE_IDENTITY() AS bigint)')
+                returned_fields = self.get_returned_fields()
+                use_scope_identity = (
+                    len(returned_fields) == 1 and isinstance(returned_fields[0], AutoField)
+                )
+
+                if use_scope_identity:
+                    result.insert(0, 'SET NOCOUNT ON')
+                    if not self.query.fields:
+                        result.append('DEFAULT VALUES;')
+                        params = []
+                    else:
+                        result.append((values_format + ';') % ', '.join(placeholder_rows[0]))
+                        params = [param_rows[0]]
+                    result.append('SELECT CAST(SCOPE_IDENTITY() AS bigint)')
+                else:
+                    params = []
+                    r_sql, self.returning_params = self.connection.ops.return_insert_columns(returned_fields)
+                    if r_sql:
+                        result.append(r_sql)
+                        params += [self.returning_params]
+                    if not self.query.fields:
+                        result.append('DEFAULT VALUES')
+                    else:
+                        result.append(values_format % ', '.join(placeholder_rows[0]))
+                        params = [param_rows[0]]
+                        if r_sql:
+                            params += [self.returning_params]
             sql = [(" ".join(result), tuple(chain.from_iterable(params)))]
         else:
             if can_bulk:

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -938,6 +938,7 @@ class SQLInsertCompiler(compiler.SQLInsertCompiler, SQLCompiler):
 
                     sql_batch = '; '.join([
                         'SET NOCOUNT ON',
+                        f"IF OBJECT_ID('tempdb..{tmp_table_name}') IS NOT NULL DROP TABLE {tmp_table_name}",
                         f"SELECT TOP 0 {', '.join(select_into_columns)} INTO {tmp_table_name} FROM {table_name}",
                         ' '.join(insert_sql),
                         f'SELECT {returned_columns} FROM {tmp_table_name}',

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -157,3 +157,24 @@ class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
             ctx[0]["sql"].count(created_at_quoted_name),
             2 if connection.features.can_return_rows_from_bulk_insert else 1,
         )
+
+    def test_single_insert_with_returning_fields_when_bulk_rows_unsupported(self):
+        """Single-row create must still return all db_returning fields.
+
+        Regression for a path where can_return_rows_from_bulk_insert=False
+        caused SQLInsertCompiler to use SCOPE_IDENTITY() (1 column) while
+        Django expected all returning fields, leading to IndexError.
+        """
+        model = self.DbDefaultBulkInsertModel
+        old_return_rows_flag = connection.features_class.can_return_rows_from_bulk_insert
+        connection.features_class.can_return_rows_from_bulk_insert = False
+        try:
+            with self.assertNumQueries(1) as ctx:
+                obj = model.objects.create(name="single")
+
+            self.assertIsNotNone(obj.pk)
+            self.assertIsNotNone(obj.created_at)
+            self.assertIn("OUTPUT INSERTED", ctx[0]["sql"])
+            self.assertNotIn("SCOPE_IDENTITY", ctx[0]["sql"])
+        finally:
+            connection.features_class.can_return_rows_from_bulk_insert = old_return_rows_flag


### PR DESCRIPTION
## Summary
- This fixes a Django 6 insert-returning mismatch on SQL Server when can_return_rows_from_bulk_insert is false.
- In that path, single-row insert could return only one value via SCOPE_IDENTITY while Django expected multiple returning fields, which could raise IndexError during converter application.

**Root cause**
- The fallback branch treated all single-row returning cases the same, even when returning_fields contained more than one column.

**What changed**
Updated compiler.py so:
- SCOPE_IDENTITY fallback is used only for single AutoField returning (keeps trigger-safe behavior).
- Multi-field returning uses OUTPUT INSERTED with the expected column shape.
Added regression in test_queries.py:
- DbDefaultBulkCreateRegressionTests.test_single_insert_with_returning_fields_when_bulk_rows_unsupported

**Why this is safe**
- Preserves existing trigger-compatible behavior for classic single-id inserts.
- Only changes behavior for multi-field returning cases where shape mismatch previously occurred.

**Validation**
Passed targeted regression:
- DbDefaultBulkCreateRegressionTests.test_single_insert_with_returning_fields_when_bulk_rows_unsupported
- Passed trigger regression:
- TestTableWithTrigger.test_insert_into_table_with_trigger
Passed module:
- testapp.tests.test_queries (4 tests)