### PR TITLE
FEAT: Upgrade Windows CI to SQL Server 2025

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
     pool:
       name: Django-1ES-pool
       demands:
-      - imageOverride -equals JDBC-MMS2019-SQL2019-2
+      - imageOverride -equals JDBC-MMS2025-SQL2025
     timeoutInMinutes: 120
 
     strategy:


### PR DESCRIPTION
This pull request updates the build environment in the CI pipeline to use a newer SQL Server image.

* CI/CD configuration: Updated the `imageOverride` in the `azure-pipelines.yml` file from `JDBC-MMS2019-SQL2019-2` to `JDBC-MMS2025-SQL2025`, ensuring the pipeline runs against the latest SQL Server version.