### PR TITLE
Fix FieldDoesNotExist when AlterField with descending index fields (#405)

### DIFF
--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -951,7 +951,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # --------------------------------------------------------------------------------
             for index in model._meta.indexes:
                 # Get the field objects for this index
-                index_fields = [model._meta.get_field(field_name) for field_name in index.fields]
+                index_fields = [model._meta.get_field(field_name) for field_name, _ in index.fields_orders]
                 index_columns_list = [field.column for field in index_fields]
 
                 # Restore if: AutoField change (all indexes dropped) OR field is in this index
@@ -1107,7 +1107,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                  index_columns.append(columns)
 
         for index in model._meta.indexes:
-            columns = [model._meta.get_field(field).column for field in index.fields]
+            columns = [model._meta.get_field(field_name).column for field_name, _ in index.fields_orders]
             if old_field.column in columns:
                 index_columns.append(columns)
 


### PR DESCRIPTION
Fixes #405

  Problem

  `_delete_indexes` in `schema.py` iterates over index.fields and passes each value directly to `model._meta.get_field()`. When an index uses descending ordering (e.g.
  `fields=['-started_at']), index.fields` contains the raw string with the - prefix.` get_field('-started_at')` fails with `FieldDoesNotExist`.

  This causes any AlterField migration to crash if the model has a Meta.indexes entry with descending fields.

  Minimal reproduction

 ```
 class MyModel(models.Model):
      name = models.CharField(max_length=100)
      date = models.DateTimeField()
      optional = models.TextField(default='')

      class Meta:
          indexes = [
              models.Index(fields=['-date'], name='idx_date_desc'),
          ]

  # Migration that triggers the bug:
  migrations.AlterField(
      model_name='mymodel',
      name='optional',
      field=models.TextField(null=True),
  )

```
  django.core.exceptions.FieldDoesNotExist: MyModel has no field named '-date'

  Fix

  Replace `index.fields` with `index.fields_orders` which returns `(field_name, order_direction)` tuples — the field name is already stripped of the - prefix.

Two occurrences fixed in _delete_indexes (line 1110) and in the index restoration loop (line 954).