### PR TITLE
chore: Update nightly schedule to 2:30 AM IST (9 PM UTC)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,8 @@ pr:
       - dev
 
 schedules:
-- cron: "0 9 * * *"
-  displayName: Daily midnight build
+- cron: "0 21 * * *"
+  displayName: Daily nightly build (2:30 AM IST)
   branches:
     include:
     - dev


### PR DESCRIPTION
Updates the Azure Pipelines scheduled build from 9 AM UTC (2:30 PM IST) to 9 PM UTC (2:30 AM IST) for a true nightly run in IST.