### PR TITLE
FIX: AttributeError on .explain() for Django 4.0+ 

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -504,9 +504,15 @@ class SQLCompiler(compiler.SQLCompiler):
 
             explain = self.query.explain_info if django.VERSION >= (4, 0) else self.query.explain_query
             if explain:
+                if django.VERSION >= (4, 0):
+                    explain_format = explain.format
+                    explain_options = explain.options
+                else:
+                    explain_format = self.query.explain_format
+                    explain_options = self.query.explain_options
                 result.insert(0, self.connection.ops.explain_query_prefix(
-                    self.query.explain_format,
-                    **self.query.explain_options
+                    explain_format,
+                    **explain_options
                 ))
 
             if order_by:

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -7,7 +7,7 @@ from django.db.models.functions import Now
 from django.test import TransactionTestCase, TestCase, skipUnlessDBFeature
 from django.utils import timezone
 
-from ..models import Author, BinaryData
+from ..models import Author, BinaryData, Editor
 
 
 class TestTableWithTrigger(TransactionTestCase):
@@ -178,3 +178,18 @@ class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
             self.assertNotIn("SCOPE_IDENTITY", ctx[0]["sql"])
         finally:
             connection.features_class.can_return_rows_from_bulk_insert = old_return_rows_flag
+
+
+class ExplainRegressionTests(TestCase):
+    """Regression test for #409: explain() AttributeError on Django 4.0+.
+
+    Django 4.0 replaced query.explain_format/explain_options with
+    query.explain_info. The compiler must read the correct attributes
+    so .explain() raises NotSupportedError (not AttributeError).
+    """
+
+    def test_explain_raises_not_supported(self):
+        """explain() should raise NotSupportedError, not AttributeError."""
+        qs = Author.objects.all()
+        with self.assertRaises(django.db.utils.NotSupportedError):
+            qs.explain()


### PR DESCRIPTION
Issue: #409 
Django 4.0 replaced query.explain_format and query.explain_options with query.explain_info (a namedtuple with .format and .options). The compiler was still referencing the removed attributes, causing an AttributeError when .explain() was called (e.g. via DjangoQL in Django admin).
