### PR TITLE
FIX: Remove return in finally that swallows exceptions (#417)

### DIFF
--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -16,15 +16,13 @@ def _check_jsonfield_supported_sqlite():
     # Info about JSONField support in SQLite: https://code.djangoproject.com/wiki/JSON1Extension
     import sqlite3
 
-    supports_jsonfield = True
     try:
         conn = sqlite3.connect(':memory:')
         cursor = conn.cursor()
         cursor.execute('SELECT JSON(\'{"a": "b"}\')')
+        return True
     except sqlite3.OperationalError:
-        supports_jsonfield = False
-    finally:
-        return supports_jsonfield
+        return False
 
 
 class TestJSONField(TestCase):


### PR DESCRIPTION
Issue: #417

Simplify `_check_jsonfield_supported_sqlite()` to return directly from `try`/`except` instead of using a variable with `return` in `finally`.

The `finally`-return pattern silently swallows **all** exceptions including `KeyboardInterrupt` and other `BaseException` subclasses.

Test-only change, no production code affected.