### PR TITLE
RELEASE: 1.7.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='mssql-django',
-    version='1.7.1',
+    version='1.7.2',
     description='Django backend for Microsoft SQL Server',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Release 1.7.2

### Bug Fixes

- **FIX: AttributeError on `.explain()` for Django 4.0+** (#524, closes #409)
  Django 4.0 replaced `query.explain_format`/`query.explain_options` with `query.explain_info`. The compiler now reads the correct attributes based on Django version.

- **FIX: DATETIMEOFFSET timezone support and `Now()` with `USE_TZ=True`** (#484, closes #371, closes #136)
  - `handle_datetimeoffset` now correctly parses the timezone offset from SQL Server binary data, returning timezone-aware datetimes for `DATETIMEOFFSET` columns.
  - `Now()` now emits `SYSDATETIMEOFFSET()` when `USE_TZ=True`, fixing incorrect timestamps on non-UTC SQL Server hosts.

### Maintenance

- **ci: Update nightly schedule to 2:30 AM IST (9 PM UTC)** (#523)

### Test Improvements


- **FIX: Remove `return` in `finally` that swallows exceptions** (#526, closes #417)
  Test utility `_check_jsonfield_supported_sqlite()` no longer silently swallows `BaseException` subclasses.

- Added timezone offset tests: UTC, +05:30 (IST), -05:00 (EST), -09:30 (Marquesas), +05:45 (Nepal)
- Added `NowSQLTemplateTests` verifying `SYSDATETIMEOFFSET` vs `SYSDATETIME` based on `USE_TZ`
- Added `ExplainRegressionTests` for `.explain()` behavior