### PR TITLE
FIX: Use class-level dicts for server property caches to fix subclass KeyError

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -216,6 +216,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         17: 2025,
     }
 
+    _known_versions = {}
+    _known_azures = {}
+
     # https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-csharp-retry-windows/
     _transient_error_numbers = (
         '4060',
@@ -521,7 +524,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                 return cursor.execute('SELECT SYSDATETIME()').fetchone()[0]
 
     @cached_property
-    def sql_server_version(self, _known_versions={}):
+    def sql_server_version(self):
         """
         Get the SQL Server version.
 
@@ -529,37 +532,32 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         populating both this cache and the to_azure_sql_db cache to avoid
         extra round trips.
 
-        The _known_versions default dictionary is created on the class. This is
-        intentional - it allows us to cache this property's value across instances.
-        Therefore, when Django creates a new database connection using the same
-        alias, we won't need query the server again.
+        Results are cached in the class-level _known_versions dict so that
+        when Django creates a new connection using the same alias, we don't
+        query the server again.
         """
-        if self.alias not in _known_versions:
+        if self.alias not in self._known_versions:
             self._fetch_server_properties()
-        return _known_versions[self.alias]
+        return self._known_versions[self.alias]
 
     @cached_property
-    def to_azure_sql_db(self, _known_azures={}):
+    def to_azure_sql_db(self):
         """
         Whether this connection is to a Microsoft Azure database server.
 
-        The _known_azures default dictionary is created on the class. This is
-        intentional - it allows us to cache this property's value across instances.
-        Therefore, when Django creates a new database connection using the same
-        alias, we won't need query the server again.
+        Results are cached in the class-level _known_azures dict so that
+        when Django creates a new connection using the same alias, we don't
+        query the server again.
         """
-        if self.alias not in _known_azures:
+        if self.alias not in self._known_azures:
             self._fetch_server_properties()
-        return _known_azures[self.alias]
+        return self._known_azures[self.alias]
 
     def _fetch_server_properties(self):
         """
         Fetch ProductVersion and EngineEdition in a single query and populate
         both sql_server_version and to_azure_sql_db caches.
         """
-        _known_versions = type(self).__dict__['sql_server_version'].func.__defaults__[0]
-        _known_azures = type(self).__dict__['to_azure_sql_db'].func.__defaults__[0]
-
         with self.temporary_connection() as cursor:
             cursor.execute(
                 "SELECT CAST(SERVERPROPERTY('ProductVersion') AS varchar), "
@@ -568,13 +566,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             product_version, edition = cursor.fetchone()
 
         is_azure = edition in _AZURE_EDITIONS
-        _known_azures[self.alias] = is_azure
+        self._known_azures[self.alias] = is_azure
 
         if edition == EDITION_AZURE_SQL_FABRIC:
             # Fabric reports ProductVersion numbers that don't correspond to
             # on-premises SQL Server releases but has modern capabilities.
             # Treat it as the latest supported version.
-            _known_versions[self.alias] = max(self._sql_server_versions.values())
+            self._known_versions[self.alias] = max(self._sql_server_versions.values())
         else:
             # For on-prem and Azure SQL DB/Managed Instance, use ProductVersion
             # to determine version. Azure SQL DB/MI report ProductVersion 12.x
@@ -583,7 +581,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             ver = int(product_version.split('.')[0])
             if ver not in self._sql_server_versions:
                 raise NotSupportedError('SQL Server v%d is not supported.' % ver)
-            _known_versions[self.alias] = self._sql_server_versions[ver]
+            self._known_versions[self.alias] = self._sql_server_versions[ver]
 
     def _execute_foreach(self, sql, table_names=None):
         cursor = self.cursor()

--- a/testapp/tests/test_base.py
+++ b/testapp/tests/test_base.py
@@ -535,13 +535,9 @@ class TestEditionDetection(SimpleTestCase):
 
     def _clear_caches(self, wrapper):
         """Clear both class-level and instance-level caches."""
-        # Clear class-level mutable default dict caches
-        azure_cache = DatabaseWrapper.__dict__["to_azure_sql_db"].func.__defaults__[0]
-        azure_cache.pop(wrapper.alias, None)
-        version_cache = DatabaseWrapper.__dict__[
-            "sql_server_version"
-        ].func.__defaults__[0]
-        version_cache.pop(wrapper.alias, None)
+        # Clear class-level caches
+        DatabaseWrapper._known_azures.pop(wrapper.alias, None)
+        DatabaseWrapper._known_versions.pop(wrapper.alias, None)
         # Clear instance-level cached_property values
         wrapper.__dict__.pop("to_azure_sql_db", None)
         wrapper.__dict__.pop("sql_server_version", None)
@@ -615,12 +611,8 @@ class TestSqlServerVersionDetection(SimpleTestCase):
         wrapper.temporary_connection = mock.MagicMock(return_value=mock_ctx)
 
     def _clear_caches(self, wrapper):
-        azure_cache = DatabaseWrapper.__dict__["to_azure_sql_db"].func.__defaults__[0]
-        azure_cache.pop(wrapper.alias, None)
-        version_cache = DatabaseWrapper.__dict__[
-            "sql_server_version"
-        ].func.__defaults__[0]
-        version_cache.pop(wrapper.alias, None)
+        DatabaseWrapper._known_azures.pop(wrapper.alias, None)
+        DatabaseWrapper._known_versions.pop(wrapper.alias, None)
         wrapper.__dict__.pop("to_azure_sql_db", None)
         wrapper.__dict__.pop("sql_server_version", None)
 

--- a/testapp/tests/test_base.py
+++ b/testapp/tests/test_base.py
@@ -660,3 +660,30 @@ class TestSqlServerVersionDetection(SimpleTestCase):
         with self.assertRaises(NotSupportedError):
             _ = wrapper.sql_server_version
         self._clear_caches(wrapper)
+
+
+class TestDatabaseWrapperSubclass(SimpleTestCase):
+    """Regression test for #531: subclassing DatabaseWrapper must not crash."""
+
+    def test_subclass_server_properties_no_keyerror(self):
+        """Accessing sql_server_version on a subclass should not raise KeyError."""
+
+        class SubWrapper(DatabaseWrapper):
+            pass
+
+        wrapper = object.__new__(SubWrapper)
+        wrapper.alias = "test_subclass"
+
+        mock_cursor = mock.MagicMock()
+        mock_cursor.fetchone.return_value = ("16.0.4135.4", 3)
+        mock_ctx = mock.MagicMock()
+        mock_ctx.__enter__ = mock.MagicMock(return_value=mock_cursor)
+        mock_ctx.__exit__ = mock.MagicMock(return_value=False)
+        wrapper.temporary_connection = mock.MagicMock(return_value=mock_ctx)
+
+        self.assertEqual(wrapper.sql_server_version, 2022)
+        self.assertFalse(wrapper.to_azure_sql_db)
+        self.assertEqual(wrapper.temporary_connection.call_count, 1)
+
+        DatabaseWrapper._known_versions.pop("test_subclass", None)
+        DatabaseWrapper._known_azures.pop("test_subclass", None)


### PR DESCRIPTION
## Problem

Subclassing `DatabaseWrapper` raises `KeyError: 'sql_server_version'` on first connection. The `_fetch_server_properties()` method uses `type(self).__dict__['sql_server_version']` to introspect the mutable default dict cache, but when `self` is an instance of a subclass, `type(self)` is the subclass which doesn't have the `cached_property` descriptor in its own `__dict__` (it's inherited from the base class).

This is a regression from #518.

## Fix

Replace the mutable-default-argument caching pattern with explicit class-level dicts (`_known_versions` and `_known_azures`). `_fetch_server_properties()` now accesses them via `self.` which resolves through the MRO, so subclasses work correctly.

## Testing

All 177 existing tests pass. The test helpers (`_clear_caches`) are updated to use the new class-level dicts instead of introspecting `func.__defaults__`.

Closes #531