### PR TITLE
FIX: skip Trusted_Connection/SSPI when Authentication= is explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tests/local_settings.py
 # Virtual Env
 /venv/
 .idea/
+logs/
+result.xml

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -296,6 +296,22 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             conn_params['NAME'] = 'master'
         return conn_params
 
+    # Authentication modes where the ODBC driver handles credential
+    # acquisition, so the backend must not inject PWD.
+    _AUTH_MODES_WITHOUT_PASSWORD = frozenset({
+        'activedirectoryintegrated',
+        'activedirectoryinteractive',
+        'activedirectorymsi',
+        'activedirectorydefault',
+        'activedirectorydeviceflow',
+    })
+
+    @staticmethod
+    def _get_authentication_mode(extra_params):
+        """Return the normalized Authentication mode from extra_params, or None."""
+        match = re.search(r'(?i)(?:^|;)\s*Authentication\s*=\s*([^;]+)', extra_params)
+        return match.group(1).strip().lower() if match else None
+
     def _build_connection_string(self, conn_params, driver):
         """Build ODBC connection string for the given driver."""
         database = conn_params['NAME']
@@ -308,6 +324,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         options = conn_params.get('OPTIONS', {})
         dsn = options.get('dsn', None)
         options_extra_params = options.get('extra_params', '')
+        auth_mode = self._get_authentication_mode(options_extra_params)
 
         # Microsoft driver names assumed here are:
         # * SQL Server Native Client 10.0/11.0
@@ -341,10 +358,15 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         if user:
             cstr_parts['UID'] = user
-            if 'Authentication=ActiveDirectoryInteractive' not in options_extra_params:
+            if auth_mode not in self._AUTH_MODES_WITHOUT_PASSWORD:
                 cstr_parts['PWD'] = password
         elif 'TOKEN' not in conn_params:
-            if ms_drivers.match(driver) and 'Authentication=ActiveDirectoryMsi' not in options_extra_params:
+            if auth_mode is not None:
+                # User supplied an explicit Authentication= keyword;
+                # do not inject Trusted_Connection or Integrated Security
+                # as the ODBC driver rejects that combination (FA001).
+                pass
+            elif ms_drivers.match(driver):
                 cstr_parts['Trusted_Connection'] = trusted_connection
             else:
                 cstr_parts['Integrated Security'] = 'SSPI'

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -308,9 +308,36 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     @staticmethod
     def _get_authentication_mode(extra_params):
-        """Return the normalized Authentication mode from extra_params, or None."""
-        match = re.search(r'(?i)(?:^|;)\s*Authentication\s*=\s*([^;]+)', extra_params)
-        return match.group(1).strip().lower() if match else None
+        """Return the normalized Authentication mode from extra_params, or None.
+
+        Parses semicolon-delimited key=value pairs while skipping content
+        inside braced values ({...}), which may contain literal semicolons
+        per the ODBC connection string spec (MS-ODBCSTR).
+
+        NOTE: this is a minimal parser sufficient for extracting a single
+        key. For a full spec-compliant ODBC connection string parser with
+        brace escaping, duplicate detection, and validation, see
+        mssql-python's ``connection_string_parser._ConnectionStringParser``.
+        """
+        if not extra_params:
+            return None
+        depth = 0
+        start = 0
+        for i, ch in enumerate(extra_params):
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth = max(0, depth - 1)
+            elif ch == ';' and depth == 0:
+                key, _, value = extra_params[start:i].partition('=')
+                if key.strip().lower() == 'authentication':
+                    return value.strip().lower()
+                start = i + 1
+        # last segment (no trailing semicolon)
+        key, _, value = extra_params[start:].partition('=')
+        if key.strip().lower() == 'authentication':
+            return value.strip().lower()
+        return None
 
     def _build_connection_string(self, conn_params, driver):
         """Build ODBC connection string for the given driver."""
@@ -323,7 +350,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         options = conn_params.get('OPTIONS', {})
         dsn = options.get('dsn', None)
-        options_extra_params = options.get('extra_params', '')
+        options_extra_params = options.get('extra_params') or ''
         auth_mode = self._get_authentication_mode(options_extra_params)
 
         # Microsoft driver names assumed here are:

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -307,37 +307,115 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     })
 
     @staticmethod
+    def _parse_extra_params(extra_params):
+        """Parse an ODBC extra_params string into a ``{key: value}`` dict.
+
+        Implements the tokenisation rules from the MS-ODBCSTR specification:
+        - Semicolon-separated ``key=value`` pairs
+        - Braced values: ``{value}`` (may contain semicolons and ``=``)
+        - Escaped closing braces: ``}}`` → ``}``
+        - Opening braces inside a braced value need no escaping
+
+        Parsing is lenient: segments with a missing ``=`` are silently
+        skipped.  An unclosed braced value consumes to end-of-string and
+        is stored as-is (no crash, no silent discard) so that
+        ``extra_params`` from Django settings never causes an unexpected
+        exception.
+
+        Adapted from *mssql-python*'s ``_ConnectionStringParser._parse``
+        (MIT-licensed, Microsoft Corporation) which has 59+ unit tests
+        against the full MS-ODBCSTR spec.  Validation, keyword allow-list,
+        and duplicate detection were removed because ``extra_params`` is an
+        unstructured escape hatch where the user is responsible for
+        correctness.
+
+        Reference:
+            https://learn.microsoft.com/en-us/openspecs/sql_server_protocols/ms-odbcstr
+        """
+        if not extra_params:
+            return {}
+
+        params = {}
+        pos = 0
+        length = len(extra_params)
+
+        while pos < length:
+            # skip whitespace and semicolons between pairs
+            while pos < length and extra_params[pos] in ' \t;':
+                pos += 1
+            if pos >= length:
+                break
+
+            # --- key ---
+            key_start = pos
+            while pos < length and extra_params[pos] not in '=;':
+                pos += 1
+
+            if pos >= length or extra_params[pos] != '=':
+                # no '=' found — skip to next semicolon
+                while pos < length and extra_params[pos] != ';':
+                    pos += 1
+                continue
+
+            key = extra_params[key_start:pos].strip().lower()
+            pos += 1  # skip '='
+
+            if not key:
+                while pos < length and extra_params[pos] != ';':
+                    pos += 1
+                continue
+
+            # --- value ---
+            # skip whitespace before value
+            while pos < length and extra_params[pos] in ' \t':
+                pos += 1
+
+            if pos >= length:
+                params.setdefault(key, '')
+                break
+
+            if extra_params[pos] == '{':
+                # braced value
+                pos += 1  # skip opening '{'
+                value_chars = []
+                while pos < length:
+                    ch = extra_params[pos]
+                    if ch == '}':
+                        if pos + 1 < length and extra_params[pos + 1] == '}':
+                            value_chars.append('}')
+                            pos += 2
+                        else:
+                            pos += 1  # skip closing '}'
+                            break
+                    else:
+                        value_chars.append(ch)
+                        pos += 1
+                params.setdefault(key, ''.join(value_chars))
+            else:
+                # simple value — read until semicolon or end
+                value_start = pos
+                while pos < length and extra_params[pos] != ';':
+                    pos += 1
+                params.setdefault(key, extra_params[value_start:pos].rstrip())
+
+        return params
+
+    @staticmethod
     def _get_authentication_mode(extra_params):
         """Return the normalized Authentication mode from extra_params, or None.
 
-        Parses semicolon-delimited key=value pairs while skipping content
-        inside braced values ({...}), which may contain literal semicolons
-        per the ODBC connection string spec (MS-ODBCSTR).
-
-        NOTE: this is a minimal parser sufficient for extracting a single
-        key. For a full spec-compliant ODBC connection string parser with
-        brace escaping, duplicate detection, and validation, see
-        mssql-python's ``connection_string_parser._ConnectionStringParser``.
+        Returns ``None`` when the ``Authentication`` key is absent.
+        Returns ``''`` (empty string) when the key is present with an empty
+        value — callers can distinguish "not specified" from "explicitly
+        cleared".
         """
         if not extra_params:
             return None
-        depth = 0
-        start = 0
-        for i, ch in enumerate(extra_params):
-            if ch == '{':
-                depth += 1
-            elif ch == '}':
-                depth = max(0, depth - 1)
-            elif ch == ';' and depth == 0:
-                key, _, value = extra_params[start:i].partition('=')
-                if key.strip().lower() == 'authentication':
-                    return value.strip().lower()
-                start = i + 1
-        # last segment (no trailing semicolon)
-        key, _, value = extra_params[start:].partition('=')
-        if key.strip().lower() == 'authentication':
-            return value.strip().lower()
-        return None
+        params = DatabaseWrapper._parse_extra_params(extra_params)
+        value = params.get('authentication')
+        if value is None:
+            return None
+        return value.strip().lower()
 
     def _build_connection_string(self, conn_params, driver):
         """Build ODBC connection string for the given driver."""

--- a/testapp/tests/test_base.py
+++ b/testapp/tests/test_base.py
@@ -511,6 +511,100 @@ class TestDatabaseWrapperBuildConnectionString(SimpleTestCase):
         """Test that _get_authentication_mode handles None gracefully."""
         self.assertIsNone(DatabaseWrapper._get_authentication_mode(None))
 
+    def test_get_authentication_mode_braced_auth_value(self):
+        """Test that braced Authentication value is correctly unbraced and stripped."""
+        result = DatabaseWrapper._get_authentication_mode(
+            'Authentication={ActiveDirectoryIntegrated}'
+        )
+        self.assertEqual(result, 'activedirectoryintegrated')
+
+    def test_get_authentication_mode_braced_auth_value_with_whitespace(self):
+        """Test that whitespace inside braced Authentication value is stripped."""
+        result = DatabaseWrapper._get_authentication_mode(
+            'Authentication={ ActiveDirectoryIntegrated }'
+        )
+        self.assertEqual(result, 'activedirectoryintegrated')
+
+    def test_get_authentication_mode_empty_auth_value(self):
+        """Test that Authentication= with empty value returns empty string, not None."""
+        result = DatabaseWrapper._get_authentication_mode(
+            'Authentication=;Server=localhost'
+        )
+        self.assertEqual(result, '')
+
+    def test_parse_extra_params_simple(self):
+        """Test basic key=value parsing."""
+        result = DatabaseWrapper._parse_extra_params(
+            'Encrypt=yes;TrustServerCertificate=yes'
+        )
+        self.assertEqual(result, {'encrypt': 'yes', 'trustservercertificate': 'yes'})
+
+    def test_parse_extra_params_braced_value_with_semicolon(self):
+        """Test that semicolons inside braced values are not treated as delimiters."""
+        result = DatabaseWrapper._parse_extra_params(
+            'Application Name={my;app};Encrypt=yes'
+        )
+        self.assertEqual(result['application name'], 'my;app')
+        self.assertEqual(result['encrypt'], 'yes')
+
+    def test_parse_extra_params_escaped_closing_brace(self):
+        """Test that }} inside a braced value is unescaped to }."""
+        result = DatabaseWrapper._parse_extra_params(
+            'PWD={p}}w}'
+        )
+        self.assertEqual(result['pwd'], 'p}w')
+
+    def test_parse_extra_params_open_brace_in_braced_value(self):
+        """Test that { inside a braced value is kept as-is per MS-ODBCSTR spec."""
+        result = DatabaseWrapper._parse_extra_params(
+            'App={foo{bar}'
+        )
+        self.assertEqual(result['app'], 'foo{bar')
+
+    def test_parse_extra_params_equals_in_braced_value(self):
+        """Test that = inside a braced value does not split key/value."""
+        result = DatabaseWrapper._parse_extra_params(
+            'App={key=val};Encrypt=yes'
+        )
+        self.assertEqual(result['app'], 'key=val')
+
+    def test_parse_extra_params_empty_string(self):
+        """Test that empty string returns empty dict."""
+        self.assertEqual(DatabaseWrapper._parse_extra_params(''), {})
+
+    def test_parse_extra_params_none(self):
+        """Test that None returns empty dict."""
+        self.assertEqual(DatabaseWrapper._parse_extra_params(None), {})
+
+    def test_parse_extra_params_trailing_semicolons(self):
+        """Test that trailing semicolons are handled gracefully."""
+        result = DatabaseWrapper._parse_extra_params(
+            'Encrypt=yes;;;'
+        )
+        self.assertEqual(result, {'encrypt': 'yes'})
+
+    def test_parse_extra_params_whitespace_around_equals(self):
+        """Test that whitespace around key and value is stripped."""
+        result = DatabaseWrapper._parse_extra_params(
+            '  Authentication = ActiveDirectoryIntegrated '
+        )
+        self.assertEqual(result['authentication'], 'ActiveDirectoryIntegrated')
+
+    def test_parse_extra_params_unclosed_brace_skipped(self):
+        """Test that unclosed braced value is silently consumed without crashing."""
+        result = DatabaseWrapper._parse_extra_params(
+            'App={unclosed;Authentication=SqlPassword'
+        )
+        # unclosed brace consumes to end of string; Authentication is inside it
+        self.assertNotIn('authentication', result)
+
+    def test_parse_extra_params_first_key_wins(self):
+        """Test that first occurrence of a key wins (setdefault semantics)."""
+        result = DatabaseWrapper._parse_extra_params(
+            'Encrypt=yes;Encrypt=no'
+        )
+        self.assertEqual(result['encrypt'], 'yes')
+
     def test_connection_string_active_directory_interactive_no_user(self):
         """Test ActiveDirectoryInteractive without USER skips Trusted_Connection."""
         conn_params = {

--- a/testapp/tests/test_base.py
+++ b/testapp/tests/test_base.py
@@ -500,6 +500,57 @@ class TestDatabaseWrapperBuildConnectionString(SimpleTestCase):
         )
         self.assertEqual(result, 'sqlpassword')
 
+    def test_get_authentication_mode_ignores_braced_values(self):
+        """Test that Authentication= inside a braced value is not detected."""
+        result = DatabaseWrapper._get_authentication_mode(
+            'Application Name={foo;Authentication=SqlPassword};Encrypt=yes'
+        )
+        self.assertIsNone(result)
+
+    def test_get_authentication_mode_none_extra_params(self):
+        """Test that _get_authentication_mode handles None gracefully."""
+        self.assertIsNone(DatabaseWrapper._get_authentication_mode(None))
+
+    def test_connection_string_active_directory_interactive_no_user(self):
+        """Test ActiveDirectoryInteractive without USER skips Trusted_Connection."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "server.database.windows.net",
+            "OPTIONS": {"extra_params": "Authentication=ActiveDirectoryInteractive"},
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertNotIn("Trusted_Connection=", result)
+        self.assertNotIn("Integrated Security=", result)
+
+    def test_connection_string_active_directory_service_principal_keeps_pwd(self):
+        """Test that PWD is still included with Authentication=ActiveDirectoryServicePrincipal."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "server.database.windows.net",
+            "USER": "app-id",
+            "PASSWORD": "client-secret",
+            "OPTIONS": {"extra_params": "Authentication=ActiveDirectoryServicePrincipal"},
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertIn("UID=app-id", result)
+        self.assertIn("PWD=client-secret", result)
+
+    def test_connection_string_extra_params_none(self):
+        """Test that extra_params=None does not crash."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "localhost",
+            "OPTIONS": {"extra_params": None},
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertIn("Trusted_Connection=yes", result)
+
 
 class TestCursorWrapperAsSqlType(SimpleTestCase):
     """Tests for CursorWrapper._as_sql_type method."""

--- a/testapp/tests/test_base.py
+++ b/testapp/tests/test_base.py
@@ -362,6 +362,145 @@ class TestDatabaseWrapperBuildConnectionString(SimpleTestCase):
         self.assertNotIn("PWD=", result)
 
 
+    def test_connection_string_active_directory_integrated_no_trusted_connection(self):
+        """Test that Trusted_Connection is not injected with ActiveDirectoryIntegrated.
+
+        Regression test for #529: Authentication=ActiveDirectoryIntegrated
+        without USER or TOKEN must not get Trusted_Connection=yes appended,
+        as the ODBC driver rejects that combination (FA001).
+        """
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "server.database.windows.net",
+            "OPTIONS": {"extra_params": "Authentication=ActiveDirectoryIntegrated"},
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertNotIn("Trusted_Connection=", result)
+        self.assertNotIn("Integrated Security=", result)
+        self.assertIn("Authentication=ActiveDirectoryIntegrated", result)
+
+    def test_connection_string_active_directory_msi_no_trusted_connection(self):
+        """Test that Trusted_Connection is not injected with ActiveDirectoryMsi."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "server.database.windows.net",
+            "OPTIONS": {"extra_params": "Authentication=ActiveDirectoryMsi"},
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertNotIn("Trusted_Connection=", result)
+        self.assertNotIn("Integrated Security=", result)
+
+    def test_connection_string_active_directory_default_no_trusted_connection(self):
+        """Test that Trusted_Connection is not injected with ActiveDirectoryDefault."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "server.database.windows.net",
+            "OPTIONS": {"extra_params": "Authentication=ActiveDirectoryDefault"},
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertNotIn("Trusted_Connection=", result)
+        self.assertNotIn("Integrated Security=", result)
+
+    def test_connection_string_sql_password_auth_keeps_pwd(self):
+        """Test that PWD is still included with Authentication=SqlPassword."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "server.database.windows.net",
+            "USER": "sqluser",
+            "PASSWORD": "secret",
+            "OPTIONS": {"extra_params": "Authentication=SqlPassword"},
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertIn("UID=sqluser", result)
+        self.assertIn("PWD=secret", result)
+        self.assertNotIn("Trusted_Connection=", result)
+
+    def test_connection_string_active_directory_password_keeps_pwd(self):
+        """Test that PWD is still included with Authentication=ActiveDirectoryPassword."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "server.database.windows.net",
+            "USER": "user@domain.com",
+            "PASSWORD": "secret",
+            "OPTIONS": {"extra_params": "Authentication=ActiveDirectoryPassword"},
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertIn("UID=user@domain.com", result)
+        self.assertIn("PWD=secret", result)
+
+    def test_connection_string_auth_keyword_case_insensitive(self):
+        """Test that Authentication= is detected case-insensitively."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "server.database.windows.net",
+            "OPTIONS": {"extra_params": "authentication=ActiveDirectoryIntegrated"},
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertNotIn("Trusted_Connection=", result)
+        self.assertNotIn("Integrated Security=", result)
+
+    def test_connection_string_auth_with_other_extra_params(self):
+        """Test Authentication= detection alongside other extra_params."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "server.database.windows.net",
+            "OPTIONS": {
+                "extra_params": "Encrypt=yes;Authentication=ActiveDirectoryIntegrated;TrustServerCertificate=yes",
+            },
+        }
+        driver = "ODBC Driver 18 for SQL Server"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertNotIn("Trusted_Connection=", result)
+        self.assertIn("Encrypt=yes", result)
+
+    def test_connection_string_freetds_auth_no_sspi(self):
+        """Test that FreeTDS also skips Integrated Security=SSPI when Authentication= is present."""
+        conn_params = {
+            "NAME": "testdb",
+            "HOST": "myserver",
+            "OPTIONS": {
+                "host_is_server": True,
+                "extra_params": "Authentication=ActiveDirectoryIntegrated",
+            },
+        }
+        driver = "FreeTDS"
+        result = self.wrapper._build_connection_string(conn_params, driver)
+
+        self.assertNotIn("Integrated Security=", result)
+        self.assertNotIn("Trusted_Connection=", result)
+
+    def test_get_authentication_mode_returns_none_for_empty(self):
+        """Test that _get_authentication_mode returns None for empty extra_params."""
+        self.assertIsNone(DatabaseWrapper._get_authentication_mode(''))
+
+    def test_get_authentication_mode_parses_value(self):
+        """Test that _get_authentication_mode extracts and normalizes the auth mode."""
+        result = DatabaseWrapper._get_authentication_mode(
+            'Encrypt=yes;Authentication=ActiveDirectoryIntegrated;Foo=bar'
+        )
+        self.assertEqual(result, 'activedirectoryintegrated')
+
+    def test_get_authentication_mode_case_insensitive(self):
+        """Test that _get_authentication_mode is case-insensitive on the keyword."""
+        result = DatabaseWrapper._get_authentication_mode(
+            'authentication=SqlPassword'
+        )
+        self.assertEqual(result, 'sqlpassword')
+
+
 class TestCursorWrapperAsSqlType(SimpleTestCase):
     """Tests for CursorWrapper._as_sql_type method."""
 


### PR DESCRIPTION
## Summary

When `extra_params` contains an explicit `Authentication=` keyword (e.g. `ActiveDirectoryIntegrated`), the backend must not inject `Trusted_Connection=yes` or `Integrated Security= the ODBC driver rejects that combination with FA001.SSPI` 

The previous code only special-cased `ActiveDirectoryMsi` (line 347) and `ActiveDirectoryInteractive` (line 344) individually. Any other `Authentication=` mode without `USER`/`TOKEN` fell through to `Trusted_Connection=yes`.

## Changes

**`mssql/base.py`**

- Add `_get_authentication_mode()` static  uses a boundary-aware, case-insensitive regex to parse the `Authentication=` value from `extra_params`.method 
- Add `_AUTH_MODES_WITHOUT_PASSWORD`  explicitly lists auth modes that do not use passwords (`ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`, `ActiveDirectoryMsi`, `ActiveDirectoryDefault`, `ActiveDirectoryDeviceFlow`).frozenset 
- Replace hardcoded substring checks with the parsed auth mode:
  - **No USER, no TOKEN branch:** skip `Trusted_Connection`/`SSPI` when *any* `Authentication=` is present (forward-compatible).
  - **USER branch:** skip `PWD` only for known passwordless modes (does not regress `SqlPassword`, `ActiveDirectoryPassword`, `ActiveDirectoryServicePrincipal`).

**`testapp/tests/test_base.py`**

- 11 new unit tests covering: `ActiveDirectoryIntegrated`, `ActiveDirectoryMsi`, `ActiveDirectoryDefault`, `SqlPassword` (keeps PWD), `ActiveDirectoryPassword` (keeps PWD), case-insensitive detection, multi-param strings, FreeTDS path, and the helper method directly.

## Testing

All 18 `TestDatabaseWrapperBuildConnectionString` tests pass (7 existing + 11 new).

Issue: #529