### PR TITLE
FIX: Preserve escaped %% in format_group_by_params to fix IndexError on GROUP BY queries

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -712,8 +712,15 @@ class CursorWrapper(object):
         return sql
 
     def format_group_by_params(self, query, params):
-        # Prepare query for string formatting
-        query = re.sub(r'%\w+', '{}', query)
+        # Prepare query for string formatting. Match the literal '%%' escape
+        # first so it is preserved verbatim, otherwise a '%%abc%%' literal
+        # (e.g. inside a LIKE pattern) would be misparsed as a parameter
+        # placeholder (issue #476). Only '%s' is a real placeholder here;
+        # format_sql() below uses %-formatting with a tuple of '?' strings.
+        def _placeholder_sub(match):
+            token = match.group(0)
+            return token if token == '%%' else '{}'
+        query = re.sub(r'%%|%s', _placeholder_sub, query)
 
         if params:
             # Insert None params directly into the query

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -44,12 +44,20 @@ class TestBinaryfieldGroupby(TestCase):
 
 
 class TestGroupByEscapedPercent(TestCase):
-    """Regression test for issue #476.
+    """Regression tests for issue #476 and the over-matching behind #394.
 
-    A raw SQL query that combines a GROUP BY clause, an escaped %% literal
-    (e.g. inside a LIKE pattern), and a positional parameter used to raise
-    IndexError because format_group_by_params treated the escaped %% as a
-    parameter placeholder.
+    format_group_by_params rewrites parameter placeholders in any query that
+    contains a GROUP BY clause. The old ``re.sub(r'%\\w+', '{}', query)``
+    matched far more than real placeholders:
+
+    - it split escaped ``%%`` literals, injecting a phantom placeholder and
+      raising ``IndexError`` (issue #476, loud), and
+    - it swallowed unescaped ``%word`` patterns such as ``LIKE '%abc%'``,
+      rewriting them to ``LIKE '{}%'`` and silently returning the wrong rows
+      (issue #394, silent).
+
+    The fix narrows the match to ``%%`` (preserved verbatim) and ``%s`` (the
+    only real placeholder). These tests fail on ``dev`` and pass on the fix.
     """
 
     @classmethod
@@ -61,6 +69,9 @@ class TestGroupByEscapedPercent(TestCase):
         ])
 
     def test_like_with_escaped_percent_and_group_by(self):
+        # Issue #476: escaped %% inside a LIKE pattern plus a real %s param.
+        # The old regex mis-parsed %% and injected a phantom placeholder, so
+        # query.format() raised IndexError.
         table = Author._meta.db_table
         sql = (
             f"SELECT name, COUNT(*) FROM {table} "
@@ -72,18 +83,21 @@ class TestGroupByEscapedPercent(TestCase):
             rows = sorted(cursor.fetchall())
         self.assertEqual(rows, [('%abc%', 2)])
 
-    def test_escaped_percent_with_placeholder_outside_literal(self):
-        # '%%' as a SQL-Server literal '%' concatenated with a real %s
-        # placeholder. Exercises the '%%' + '%s' adjacency without putting
-        # the placeholder inside a string literal.
+    def test_unescaped_percent_pattern_no_params_preserved(self):
+        # Issue #394: a GROUP BY query with an unescaped `%word` LIKE pattern
+        # and no params. The old `%\w+` regex rewrote `%abc` to `{}`, turning
+        # LIKE '%abc%' into LIKE '{}%' and silently returning zero rows. The
+        # narrowed regex leaves the pattern untouched, so the correct rows
+        # come back. This also guards the `%\w+` -> `%s` narrowing: a token
+        # that looks like a printf spec must no longer be treated as one.
         table = Author._meta.db_table
         sql = (
             f"SELECT name, COUNT(*) FROM {table} "
-            f"WHERE name = '%%' + %s "
+            f"WHERE name LIKE '%abc%' "
             f"GROUP BY name"
         )
         with connection.cursor() as cursor:
-            cursor.execute(sql, ['abc%'])
+            cursor.execute(sql)
             rows = sorted(cursor.fetchall())
         self.assertEqual(rows, [('%abc%', 2)])
 

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -71,25 +71,27 @@ class TestGroupByEscapedPercent(TestCase):
     def test_like_with_escaped_percent_and_group_by(self):
         # Issue #476: escaped %% inside a LIKE pattern plus a real %s param.
         # The old regex mis-parsed %% and injected a phantom placeholder, so
-        # query.format() raised IndexError.
+        # query.format() raised IndexError. The %s param drives the DECLARE
+        # path in format_group_by_params; the predicate is tied to the data.
         table = Author._meta.db_table
         sql = (
             f"SELECT name, COUNT(*) FROM {table} "
-            f"WHERE name LIKE '%%abc%%' AND id >= %s "
+            f"WHERE name LIKE '%%abc%%' AND name <> %s "
             f"GROUP BY name"
         )
         with connection.cursor() as cursor:
-            cursor.execute(sql, [1])
+            cursor.execute(sql, ['xyz'])
             rows = sorted(cursor.fetchall())
         self.assertEqual(rows, [('%abc%', 2)])
 
     def test_unescaped_percent_pattern_no_params_preserved(self):
         # Issue #394: a GROUP BY query with an unescaped `%word` LIKE pattern
-        # and no params. The old `%\w+` regex rewrote `%abc` to `{}`, turning
-        # LIKE '%abc%' into LIKE '{}%' and silently returning zero rows. The
-        # narrowed regex leaves the pattern untouched, so the correct rows
-        # come back. This also guards the `%\w+` -> `%s` narrowing: a token
-        # that looks like a printf spec must no longer be treated as one.
+        # and no params. The old `%\w+` regex matched `%abc` and rewrote it to
+        # `{}`, turning LIKE '%abc%' into LIKE '{}%' and silently returning
+        # zero rows. The narrowed `%%|%s` regex no longer matches word chars
+        # after a `%`, so the pattern is left untouched and the correct rows
+        # come back. This is a no-param query, so it guards the regex narrowing
+        # itself, not the DECLARE path (that is covered above).
         table = Author._meta.db_table
         sql = (
             f"SELECT name, COUNT(*) FROM {table} "

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -43,6 +43,51 @@ class TestBinaryfieldGroupby(TestCase):
             cursor.execute(f"SELECT binary FROM {BinaryData._meta.db_table} WHERE binary = %s GROUP BY binary", [bytes("ABC", 'utf-8')])
 
 
+class TestGroupByEscapedPercent(TestCase):
+    """Regression test for issue #476.
+
+    A raw SQL query that combines a GROUP BY clause, an escaped %% literal
+    (e.g. inside a LIKE pattern), and a positional parameter used to raise
+    IndexError because format_group_by_params treated the escaped %% as a
+    parameter placeholder.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        Author.objects.bulk_create([
+            Author(name='%abc%'),
+            Author(name='xyz'),
+            Author(name='%abc%'),
+        ])
+
+    def test_like_with_escaped_percent_and_group_by(self):
+        table = Author._meta.db_table
+        sql = (
+            f"SELECT name, COUNT(*) FROM {table} "
+            f"WHERE name LIKE '%%abc%%' AND id >= %s "
+            f"GROUP BY name"
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(sql, [1])
+            rows = sorted(cursor.fetchall())
+        self.assertEqual(rows, [('%abc%', 2)])
+
+    def test_escaped_percent_with_placeholder_outside_literal(self):
+        # '%%' as a SQL-Server literal '%' concatenated with a real %s
+        # placeholder. Exercises the '%%' + '%s' adjacency without putting
+        # the placeholder inside a string literal.
+        table = Author._meta.db_table
+        sql = (
+            f"SELECT name, COUNT(*) FROM {table} "
+            f"WHERE name = '%%' + %s "
+            f"GROUP BY name"
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(sql, ['abc%'])
+            rows = sorted(cursor.fetchall())
+        self.assertEqual(rows, [('%abc%', 2)])
+
+
 @skipUnlessDBFeature("supports_expression_defaults")
 class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
     """Regression tests for Django 6.0 db_default bulk insert alignment.


### PR DESCRIPTION
fixes #476.

`format_group_by_params` runs `re.sub(r'%\w+', '{}', query)` on any query with a GROUP BY, then `query.format(*args)`. that regex matches far more than real placeholders. it splits `%%abc%%` literals, injecting a phantom `{}` and raising `IndexError: Replacement index N out of range` when a query has GROUP BY + `%%`-escape + a real param.

the fix narrows the match to `%%` (preserved verbatim) and `%s` (the only real placeholder). `format_sql` only ever emits `%s`, so nothing else should be touched.

### also fixes one #394 case
an unescaped `%word` pattern like `LIKE '%abc%'` in a no-param query. the old `%\w+` rewrote it to `LIKE '{}%'` and silently returned the wrong rows. the narrowed regex leaves it alone.

### what this does NOT fix (still #394, needs a quote-aware rewrite)
- a real `%s` inside a string literal is still read as a placeholder.
- an unescaped `%` that is not `%s` (e.g. `%d`, `%p`) in a query that also carries params still breaks in `format_sql`'s `%`-formatting. that surfaces as a loud TypeError/ValueError now, not silent bad data, but it is not handled here.

tracked for a follow-up that parses SQL literal-aware instead of regex-substituting unparsed text.

### tests (both fail on dev, pass here)
- `test_like_with_escaped_percent_and_group_by`: #476, escaped `%%` plus a param. IndexError on dev.
- `test_unescaped_percent_pattern_no_params_preserved`: #394, `LIKE '%abc%'` no params. wrong rows on dev.

full testapp suite: 180 passed locally against SQL Server 2022.
