### PR TITLE
RELEASE: 1.7.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='mssql-django',
-    version='1.7.2',
+    version='1.7.3',
     description='Django backend for Microsoft SQL Server',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Release 1.7.3

### Bug Fixes

- **FIX: Use class-level dicts for server property caches** (#532, closes #531)
  Subclassing `DatabaseWrapper` raised `KeyError: 'sql_server_version'` on first
  connection (a regression from #518). The server-property cache now uses explicit
  class-level dicts accessed via `self.`, so lookups resolve through the MRO and
  subclasses work correctly. Benefits anyone extending the backend wrapper.

- **FIX: Skip Trusted_Connection/SSPI when Authentication= is explicit** (#533, #529)
  When `extra_params` set an explicit `Authentication=` mode (e.g.
  `ActiveDirectoryIntegrated`), the backend could still inject
  `Trusted_Connection=yes`, which the ODBC driver rejects. Connection-string
  building now parses the auth mode and skips `Trusted_Connection`/SSPI for any
  explicit `Authentication=`, and skips `PWD` only for known passwordless modes.
  Fixes Azure AD / Entra auth combinations without regressing `SqlPassword`,
  `ActiveDirectoryPassword`, or `ActiveDirectoryServicePrincipal`.

### Test Improvements

- 11 new connection-string tests covering explicit `Authentication=` modes,
  case-insensitive detection, multi-param strings, and the FreeTDS path (#533).
- Cache test helpers updated to use the new class-level dicts (#532).

### Infrastructure

- **CI: PR code coverage comments** (#538)
  GitHub Action polls ADO pipeline 2195, parses Cobertura XML, runs `diff-cover`
  for patch coverage, and posts a sticky PR comment with diff/overall coverage
  and build links. Handles same-repo and forked PRs.

### Version Compatibility

| Component | Supported Versions |
|---|---|
| Django | 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0 |
| Python | 3. 3.14 |8 
| SQL Server | 2016, 2017, 2019, 2022, 2025; Azure SQL DB / Managed Instance / Microsoft Fabric |
| ODBC Driver | 17 or 18 for SQL Server (v18 is the default) |

### Breaking Changes

None.

### Contributors

All changes by @bewithgaurav (maintainer). No external contributors this release.

### Full Changelog

PRs included: #532, #533, #538
