### PR TITLE
FIX: support IntegerChoices params in raw GROUP BY queries (#540)

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -797,15 +797,15 @@ class CursorWrapper(object):
             elif length > 4000:
                 return 'NVARCHAR(max)'
             return 'NVARCHAR(%s)' % len(value)
-        elif typ == int:
+        elif isinstance(value, bool):
+            return 'BIT'
+        elif isinstance(value, int):
             if value < 0x7FFFFFFF and value > -0x7FFFFFFF:
                 return 'INT'
             else:
                 return 'BIGINT'
         elif typ == float:
             return 'DOUBLE PRECISION'
-        elif typ == bool:
-            return 'BIT'
         elif isinstance(value, Decimal):
             return 'NUMERIC'
         elif isinstance(value, datetime.datetime):

--- a/testapp/tests/test_queries.py
+++ b/testapp/tests/test_queries.py
@@ -43,6 +43,23 @@ class TestBinaryfieldGroupby(TestCase):
             cursor.execute(f"SELECT binary FROM {BinaryData._meta.db_table} WHERE binary = %s GROUP BY binary", [bytes("ABC", 'utf-8')])
 
 
+class TestIntegerChoicesGroupby(TestCase):
+    # Regression test for #540: an IntegerChoices value (an int subclass) passed to a
+    # raw query containing GROUP BY raised NotImplementedError because _as_sql_type used
+    # an exact type check (typ == int) instead of isinstance.
+    def test_integerchoices_param(self):
+        class StatusChoices(models.IntegerChoices):
+            NOT_STARTED = 1
+            IN_PROGRESS = 2
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"SELECT id FROM {Author._meta.db_table} WHERE id <= %s GROUP BY id",
+                [StatusChoices.IN_PROGRESS],
+            )
+            cursor.fetchall()
+
+
 @skipUnlessDBFeature("supports_expression_defaults")
 class DbDefaultBulkCreateRegressionTests(TransactionTestCase):
     """Regression tests for Django 6.0 db_default bulk insert alignment.


### PR DESCRIPTION
raw query with a GROUP BY clause plus an IntegerChoices arg raised NotImplementedError:

```
NotImplementedError: Not supported type <enum 'StatusChoices'> (StatusChoices.IN_PROGRESS)
```

root cause: any query containing GROUP BY goes through `format_group_by_params`, which types each param and calls `_as_sql_type`. that function used exact type checks (`typ == int`), and `type(IntegerChoices_value)` is the enum class, not `int`. even though it subclasses int, `enum_cls == int` is False, so it fell through to the raise. plain ints and the ORM path never hit this. regression from #354.

fix: switch the int/bool branches to `isinstance`. bool moves above int because bool is itself an int subclass and must not fall into the int branch.

verified against SQL Server 2022:
- before: IntegerChoices arg raised NotImplementedError
- after: IntegerChoices arg returns correct rows, bool still binds BIT, plain int unchanged
- full testapp suite: 208 passed (3 skipped, 3 expected failures, all pre-existing)

added a regression test (`TestIntegerChoicesGroupby`) that fails without the fix with the exact NotImplementedError above.

Closes #540