### PR TITLE
CHORE: refactor PR code coverage measurement

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -402,6 +402,12 @@ jobs:
           MSSQL_HOST: 127.0.0.1
 
       - task: PublishCodeCoverageResults@1
+        # Every Linux leg produces a django/coverage.xml and, without a guard,
+        # they all publish to the same artifact path so the posted number is a
+        # nondeterministic upload race across the matrix. Pin publishing to the
+        # newest supported stack (Python 3.14 / Django 6.0) so the number is
+        # deterministic and reflects the most backend code paths exercised.
+        condition: and(succeeded(), eq(variables['tox.env'], 'py314-django60'))
         inputs:
           codeCoverageTool: 'Cobertura'
           summaryFileLocation: 'django/coverage.xml'

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,7 @@ if python -c "import django; exit(0 if django.VERSION >= (5, 2) else 1)"; then
     COMPOSITE_PK_TESTS="composite_pk"
 fi
 
-PYTHONPATH=.. coverage run tests/runtests.py --settings=testapp.settings --noinput \
+PYTHONPATH=.. coverage run --parallel-mode tests/runtests.py --settings=testapp.settings --noinput \
     aggregation \
     aggregation_regress \
     annotations \
@@ -118,5 +118,14 @@ PYTHONPATH=.. coverage run tests/runtests.py --settings=testapp.settings --noinp
     update \
     update_only_fields
 
-python -m coverage xml --include '*mssql*' --omit '*virtualenvs*' -o coverage.xml
+# Combine the testapp suite run (parallel data in the repo root) with the Django
+# suite run (parallel data here in django/), so mssql-django's own tests count
+# toward coverage instead of only Django's suite. Both runs record the same
+# absolute mssql/*.py paths, so combine simply unions their line hits.
+python -m coverage combine .. .
+# '*/mssql/*' matches a real path segment, so it captures the mssql backend
+# package under both CI (s/mssql/...) and a local checkout named mssql-django,
+# without accidentally pulling in testapp/ test files.
+python -m coverage xml --include '*/mssql/*' --omit '*virtualenvs*' -o coverage.xml
+python -m coverage report --include '*/mssql/*' || true
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ passenv =
     MSSQL_*
 
 commands =
-    python manage.py test --noinput
+    coverage run --parallel-mode manage.py test --noinput
     bash test.sh
 
 deps =


### PR DESCRIPTION
two changes to how PR code coverage gets measured. no product code touched.

**pin the published report to one matrix leg**

every Linux leg runs test.sh, writes django/coverage.xml, and publishes to the same artifact path. so the posted number is whichever leg wins the upload race. across the matrix that swings ~8.5 points (70.7% on django 3.2 up to 79.2% on django 6.0) for identical code, and the Windows job publishes nothing. pinned PublishCodeCoverageResults to the py314-django60 leg so the number is deterministic and reflects the newest supported stack (most backend paths exercised).

**count the testapp suite, not just Django's**

today only tests/runtests.py runs under `coverage run`. `manage.py test` (our own testapp suite) runs uninstrumented, so every regression test we add is invisible to the number. now:

- tox wraps the testapp run in `coverage run --parallel-mode`
- test.sh runs runtests in `--parallel-mode` too, then `coverage combine` merges both data sets before `coverage xml`
- include narrowed from `*mssql*` to `*/mssql/*` (segment-anchored, so a local checkout named mssql-django can't pull testapp files into the report)

net effect: coverage reflects the mssql backend exercised by both suites combined, and it's stable run to run.

verified locally against sql2022: combine unions hits across the two runs (1534 union 1540 = 1556 covered), report contains only mssql/*.py, testapp files excluded.
