### PR TITLE
CHORE: add Django 6.1 RC1 to CI test matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,16 @@ jobs:
 
     strategy:
       matrix:
+        Python3.14 - Django 6.1:
+          python.version: '3.14'
+          tox.env: 'py314-django61'
+        Python3.13 - Django 6.1:
+          python.version: '3.13'
+          tox.env: 'py313-django61'
+        Python3.12 - Django 6.1:
+          python.version: '3.12'
+          tox.env: 'py312-django61'
+
         Python3.14 - Django 6.0:
           python.version: '3.14'
           tox.env: 'py314-django60'
@@ -172,6 +182,16 @@ jobs:
 
     strategy:
       matrix:
+        Python3.14 - Django 6.1:
+          python.version: '3.14'
+          tox.env: 'py314-django61'
+        Python3.13 - Django 6.1:
+          python.version: '3.13'
+          tox.env: 'py313-django61'
+        Python3.12 - Django 6.1:
+          python.version: '3.12'
+          tox.env: 'py312-django61'
+
         Python3.14 - Django 6.0:
           python.version: '3.14'
           tox.env: 'py314-django60'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,43 +93,6 @@ jobs:
           python.version: '3.8'
           tox.env: 'py38-django42'
 
-        Python3.11 - Django 4.1:
-          python.version: '3.11'
-          tox.env: 'py311-django41'
-        Python3.10 - Django 4.1:
-          python.version: '3.10'
-          tox.env: 'py310-django41'
-        Python 3.9 - Django 4.1:
-          python.version: '3.9'
-          tox.env: 'py39-django41'
-        Python 3.8 - Django 4.1:
-          python.version: '3.8'
-          tox.env: 'py38-django41'
-
-        Python3.11 - Django 4.0:
-          python.version: '3.11'
-          tox.env: 'py311-django40'
-        Python3.10 - Django 4.0:
-          python.version: '3.10'
-          tox.env: 'py310-django40'
-        Python 3.9 - Django 4.0:
-          python.version: '3.9'
-          tox.env: 'py39-django40'
-        Python 3.8 - Django 4.0:
-          python.version: '3.8'
-          tox.env: 'py38-django40'
-
-        Python3.11 - Django 3.2:
-          python.version: '3.11'
-          tox.env: 'py311-django32'
-        Python 3.9 - Django 3.2:
-          python.version: '3.9'
-          tox.env: 'py39-django32'
-        Python 3.8 - Django 3.2:
-          python.version: '3.8'
-          tox.env: 'py38-django32'
-
-
     steps:
       - task: CredScan@3
         inputs:
@@ -250,42 +213,6 @@ jobs:
         Python 3.8 - Django 4.2:
           python.version: '3.8'
           tox.env: 'py38-django42'
-
-        Python3.11 - Django 4.1:
-          python.version: '3.11'
-          tox.env: 'py311-django41'
-        Python3.10 - Django 4.1:
-          python.version: '3.10'
-          tox.env: 'py310-django41'
-        Python 3.9 - Django 4.1:
-          python.version: '3.9'
-          tox.env: 'py39-django41'
-        Python 3.8 - Django 4.1:
-          python.version: '3.8'
-          tox.env: 'py38-django41'
-
-        Python3.11 - Django 4.0:
-          python.version: '3.11'
-          tox.env: 'py311-django40'
-        Python3.10 - Django 4.0:
-          python.version: '3.10'
-          tox.env: 'py310-django40'
-        Python 3.9 - Django 4.0:
-          python.version: '3.9'
-          tox.env: 'py39-django40'
-        Python 3.8 - Django 4.0:
-          python.version: '3.8'
-          tox.env: 'py38-django40'
-
-        Python3.11 - Django 3.2:
-          python.version: '3.11'
-          tox.env: 'py311-django32'
-        Python 3.9 - Django 3.2:
-          python.version: '3.9'
-          tox.env: 'py39-django32'
-        Python 3.8 - Django 3.2:
-          python.version: '3.8'
-          tox.env: 'py38-django32'
 
     steps:
       - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,71 +27,71 @@ jobs:
         Python3.14 - Django 6.1:
           python.version: '3.14'
           tox.env: 'py314-django61'
-        Python3.13 - Django 6.1:
-          python.version: '3.13'
-          tox.env: 'py313-django61'
-        Python3.12 - Django 6.1:
-          python.version: '3.12'
-          tox.env: 'py312-django61'
+#         Python3.13 - Django 6.1:
+#           python.version: '3.13'
+#           tox.env: 'py313-django61'
+#         Python3.12 - Django 6.1:
+#           python.version: '3.12'
+#           tox.env: 'py312-django61'
 
-        Python3.14 - Django 6.0:
-          python.version: '3.14'
-          tox.env: 'py314-django60'
-        Python3.13 - Django 6.0:
-          python.version: '3.13'
-          tox.env: 'py313-django60'
-        Python3.12 - Django 6.0:
-          python.version: '3.12'
-          tox.env: 'py312-django60'
+#         Python3.14 - Django 6.0:
+#           python.version: '3.14'
+#           tox.env: 'py314-django60'
+#         Python3.13 - Django 6.0:
+#           python.version: '3.13'
+#           tox.env: 'py313-django60'
+#         Python3.12 - Django 6.0:
+#           python.version: '3.12'
+#           tox.env: 'py312-django60'
 
-        Python3.13 - Django 5.2:
-          python.version: '3.13'
-          tox.env: 'py313-django52'
-        Python3.12 - Django 5.2:
-          python.version: '3.12'
-          tox.env: 'py312-django52'
-        Python3.11 - Django 5.2:
-          python.version: '3.11'
-          tox.env: 'py311-django52'
-        Python3.10 - Django 5.2:
-          python.version: '3.10'
-          tox.env: 'py310-django52'
+#         Python3.13 - Django 5.2:
+#           python.version: '3.13'
+#           tox.env: 'py313-django52'
+#         Python3.12 - Django 5.2:
+#           python.version: '3.12'
+#           tox.env: 'py312-django52'
+#         Python3.11 - Django 5.2:
+#           python.version: '3.11'
+#           tox.env: 'py311-django52'
+#         Python3.10 - Django 5.2:
+#           python.version: '3.10'
+#           tox.env: 'py310-django52'
 
-        Python3.13 - Django 5.1:
-          python.version: '3.13'
-          tox.env: 'py313-django51'
-        Python3.12 - Django 5.1:
-          python.version: '3.12'
-          tox.env: 'py312-django51'
-        Python3.11 - Django 5.1:
-          python.version: '3.11'
-          tox.env: 'py311-django51'
-        Python3.10 - Django 5.1:
-          python.version: '3.10'
-          tox.env: 'py310-django51'
+#         Python3.13 - Django 5.1:
+#           python.version: '3.13'
+#           tox.env: 'py313-django51'
+#         Python3.12 - Django 5.1:
+#           python.version: '3.12'
+#           tox.env: 'py312-django51'
+#         Python3.11 - Django 5.1:
+#           python.version: '3.11'
+#           tox.env: 'py311-django51'
+#         Python3.10 - Django 5.1:
+#           python.version: '3.10'
+#           tox.env: 'py310-django51'
 
-        Python3.12 - Django 5.0:
-          python.version: '3.12'
-          tox.env: 'py312-django50'
-        Python3.11 - Django 5.0:
-          python.version: '3.11'
-          tox.env: 'py311-django50'
-        Python3.10 - Django 5.0:
-          python.version: '3.10'
-          tox.env: 'py310-django50'
+#         Python3.12 - Django 5.0:
+#           python.version: '3.12'
+#           tox.env: 'py312-django50'
+#         Python3.11 - Django 5.0:
+#           python.version: '3.11'
+#           tox.env: 'py311-django50'
+#         Python3.10 - Django 5.0:
+#           python.version: '3.10'
+#           tox.env: 'py310-django50'
 
-        Python3.11 - Django 4.2:
-          python.version: '3.11'
-          tox.env: 'py311-django42'
-        Python3.10 - Django 4.2:
-          python.version: '3.10'
-          tox.env: 'py310-django42'
-        Python 3.9 - Django 4.2:
-          python.version: '3.9'
-          tox.env: 'py39-django42'
-        Python 3.8 - Django 4.2:
-          python.version: '3.8'
-          tox.env: 'py38-django42'
+#         Python3.11 - Django 4.2:
+#           python.version: '3.11'
+#           tox.env: 'py311-django42'
+#         Python3.10 - Django 4.2:
+#           python.version: '3.10'
+#           tox.env: 'py310-django42'
+#         Python 3.9 - Django 4.2:
+#           python.version: '3.9'
+#           tox.env: 'py39-django42'
+#         Python 3.8 - Django 4.2:
+#           python.version: '3.8'
+#           tox.env: 'py38-django42'
 
     steps:
       - task: CredScan@3
@@ -148,71 +148,71 @@ jobs:
         Python3.14 - Django 6.1:
           python.version: '3.14'
           tox.env: 'py314-django61'
-        Python3.13 - Django 6.1:
-          python.version: '3.13'
-          tox.env: 'py313-django61'
-        Python3.12 - Django 6.1:
-          python.version: '3.12'
-          tox.env: 'py312-django61'
+#         Python3.13 - Django 6.1:
+#           python.version: '3.13'
+#           tox.env: 'py313-django61'
+#         Python3.12 - Django 6.1:
+#           python.version: '3.12'
+#           tox.env: 'py312-django61'
 
-        Python3.14 - Django 6.0:
-          python.version: '3.14'
-          tox.env: 'py314-django60'
-        Python3.13 - Django 6.0:
-          python.version: '3.13'
-          tox.env: 'py313-django60'
-        Python3.12 - Django 6.0:
-          python.version: '3.12'
-          tox.env: 'py312-django60'
+#         Python3.14 - Django 6.0:
+#           python.version: '3.14'
+#           tox.env: 'py314-django60'
+#         Python3.13 - Django 6.0:
+#           python.version: '3.13'
+#           tox.env: 'py313-django60'
+#         Python3.12 - Django 6.0:
+#           python.version: '3.12'
+#           tox.env: 'py312-django60'
 
-        Python3.13 - Django 5.2:
-          python.version: '3.13'
-          tox.env: 'py313-django52'
-        Python3.12 - Django 5.2:
-          python.version: '3.12'
-          tox.env: 'py312-django52'
-        Python3.11 - Django 5.2:
-          python.version: '3.11'
-          tox.env: 'py311-django52'
-        Python3.10 - Django 5.2:
-          python.version: '3.10'
-          tox.env: 'py310-django52'
+#         Python3.13 - Django 5.2:
+#           python.version: '3.13'
+#           tox.env: 'py313-django52'
+#         Python3.12 - Django 5.2:
+#           python.version: '3.12'
+#           tox.env: 'py312-django52'
+#         Python3.11 - Django 5.2:
+#           python.version: '3.11'
+#           tox.env: 'py311-django52'
+#         Python3.10 - Django 5.2:
+#           python.version: '3.10'
+#           tox.env: 'py310-django52'
 
-        Python3.13 - Django 5.1:
-          python.version: '3.13'
-          tox.env: 'py313-django51'
-        Python3.12 - Django 5.1:
-          python.version: '3.12'
-          tox.env: 'py312-django51'
-        Python3.11 - Django 5.1:
-          python.version: '3.11'
-          tox.env: 'py311-django51'
-        Python3.10 - Django 5.1:
-          python.version: '3.10'
-          tox.env: 'py310-django51'
+#         Python3.13 - Django 5.1:
+#           python.version: '3.13'
+#           tox.env: 'py313-django51'
+#         Python3.12 - Django 5.1:
+#           python.version: '3.12'
+#           tox.env: 'py312-django51'
+#         Python3.11 - Django 5.1:
+#           python.version: '3.11'
+#           tox.env: 'py311-django51'
+#         Python3.10 - Django 5.1:
+#           python.version: '3.10'
+#           tox.env: 'py310-django51'
 
-        Python3.12 - Django 5.0:
-          python.version: '3.12'
-          tox.env: 'py312-django50'
-        Python3.11 - Django 5.0:
-          python.version: '3.11'
-          tox.env: 'py311-django50'
-        Python3.10 - Django 5.0:
-          python.version: '3.10'
-          tox.env: 'py310-django50'
+#         Python3.12 - Django 5.0:
+#           python.version: '3.12'
+#           tox.env: 'py312-django50'
+#         Python3.11 - Django 5.0:
+#           python.version: '3.11'
+#           tox.env: 'py311-django50'
+#         Python3.10 - Django 5.0:
+#           python.version: '3.10'
+#           tox.env: 'py310-django50'
 
-        Python3.11 - Django 4.2:
-          python.version: '3.11'
-          tox.env: 'py311-django42'
-        Python3.10 - Django 4.2:
-          python.version: '3.10'
-          tox.env: 'py310-django42'
-        Python 3.9 - Django 4.2:
-          python.version: '3.9'
-          tox.env: 'py39-django42'
-        Python 3.8 - Django 4.2:
-          python.version: '3.8'
-          tox.env: 'py38-django42'
+#         Python3.11 - Django 4.2:
+#           python.version: '3.11'
+#           tox.env: 'py311-django42'
+#         Python3.10 - Django 4.2:
+#           python.version: '3.10'
+#           tox.env: 'py310-django42'
+#         Python 3.9 - Django 4.2:
+#           python.version: '3.9'
+#           tox.env: 'py39-django42'
+#         Python 3.8 - Django 4.2:
+#           python.version: '3.8'
+#           tox.env: 'py38-django42'
 
     steps:
       - task: UsePythonVersion@0

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -8,6 +8,13 @@ from django import VERSION as django_version
 if django_version >= (5, 2):    
     from django.db.models.fields.composite import CompositePrimaryKey
 class DatabaseFeatures(BaseDatabaseFeatures):
+    # Django 6.1 added database-level ON DELETE pushdown (DB_CASCADE / DB_SET_NULL /
+    # DB_SET_DEFAULT), defaulting these flags to True in BaseDatabaseFeatures. SQL Server
+    # rejects FK graphs with multiple cascade paths to the same table (error 1785), which
+    # the new delete-app models trigger, so we don't support DB-level ON DELETE here.
+    supports_on_delete_db_cascade = False
+    supports_on_delete_db_null = False
+    supports_on_delete_db_default = False
     allows_group_by_select_index = False
     allow_sliced_subqueries_with_in = False
     can_introspect_autofield = True

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['testapp', 'testapp.*']),
     install_requires=[
-        'django>=3.2,<6.1',
+        'django>=3.2,<6.2',
         'pyodbc>=3.0',
         'pytz',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
        {py310, py311, py312, py313}-django51
        {py310, py311, py312, py313}-django52
        {py312, py313, py314}-django60
+       {py312, py313, py314}-django61
 
 [testenv]
 allowlist_externals =
@@ -31,3 +32,4 @@ deps =
     django51: django>=5.1,<5.2
     django52: django>=5.2,<5.3
     django60: django>=6.0,<6.1
+    django61: django>=6.1a1,<6.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
 envlist =
-       {py36,py37,py38,py39}-django32,
-       {py38, py39, py310}-django40,
-       {py38, py39, py310}-django41,
        {py38, py39, py310}-django42,
        {py310, py311, py312}-django50
        {py310, py311, py312, py313}-django51
@@ -24,9 +21,6 @@ deps =
     coverage==5.5
     unittest-xml-reporting
 
-    django32: django==3.2.*
-    django40: django>=4.0a1,<4.1
-    django41: django>=4.1a1,<4.2
     django42: django>=4.2,<4.3
     django50: django>=5.0,<5.1
     django51: django>=5.1,<5.2


### PR DESCRIPTION
draft, exploratory only, not for merge yet. adds django 6.1rc1 to CI so we can see what breaks before 6.1 final ships and scope the work to keep the backend green.

what changed:
- new tox env `py{312,313,314}-django61` pinned to `django>=6.1a1,<6.2`, which resolves to 6.1rc1 today
- wired into both the windows and linux ADO matrices, mirroring the 6.0 rows (6.1 needs python 3.12+, same as 6.0)
- bumped `setup.py` `install_requires` cap to `<6.2` so the package install during tox doesn't downgrade django back off 6.1rc1

no changes to `mssql/*`. leaving as draft so no reviewers get pinged. once CI runs I will triage the failures into a punch list of what it takes to support 6.1.
