### PR TITLE
RELEASE: 1.7.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='mssql-django',
-    version='1.7.3',
+    version='1.7.4',
     description='Django backend for Microsoft SQL Server',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## mssql-django 1.7.4 Release Notes (July 2026)

mssql-django 1.7.4 is a patch release that fixes two bugs in raw and annotated `GROUP BY` query handling.

---

## Bug Fixes

### FIX: Preserve escaped `%%` in `GROUP BY` params (#537, closes #476)

- **What changed:** `GROUP BY` queries mixing escaped `%%` literals with real params no longer raise `IndexError`; placeholder rewriting now only touches `%%` and `%s`.
- **Who benefits:** Anyone running raw/annotated `GROUP BY` queries with escaped percent literals.
- **Impact:** Those queries run correctly instead of erroring (also fixes one #394 case of silently wrong rows).

### FIX: Support `IntegerChoices` params in raw `GROUP BY` queries (#541, closes #540)

- **What changed:** Passing an `IntegerChoices` value into a raw `GROUP BY` query no longer raises `NotImplementedError`; type checks now use `isinstance`.
- **Who benefits:** Anyone passing enum choices as params into raw `GROUP BY` queries.
- **Impact:** Enum choices bind correctly; `bool` still binds `BIT`, plain `int` unchanged.

---

## Test Improvements

- Regression tests for the escaped-`%%` and unescaped-`%` `GROUP BY` paths (#537)
- Regression test for `IntegerChoices` in a raw `GROUP BY` query (#541)

---

## Version Compatibility

| Component | Supported Versions |
|---|---|
| Django | 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0 |
| Python | 3.8 – 3.14 |
| SQL Server | 2016, 2017, 2019, 2022, 2025; Azure SQL DB / Managed Instance / Microsoft Fabric |
| ODBC Driver | 17 or 18 for SQL Server (v18 is the default) |

---

## Breaking Changes

None. This is a fully backward-compatible patch release.

---

## Contributors

All changes in this release were made by the maintainers. Thanks to @josh-rum for reporting #540.

---

## Full Changelog

PRs included: #537, #541
