### PR TITLE
CHORE: add GitHub->ADO mirror sync pipeline

### DIFF
--- a/OneBranchPipelines/github-ado-sync.yml
+++ b/OneBranchPipelines/github-ado-sync.yml
@@ -12,12 +12,12 @@
 #
 # Base state: the ADO repo is seeded once via an ADO "Import repository" from
 # https://github.com/microsoft/mssql-django (full history, no force). After
-# that, ADO main is always an ancestor of GitHub main, so each run is a plain
+# that, ADO dev is always an ancestor of GitHub dev, so each run is a plain
 # fast-forward push (ff != force) needing only Contribute on the repo.
 #
 # Prerequisites:
 # - Pipeline source repository = Azure DevOps sqlclientdrivers/mssql-django.
-# - Build Service identity has Contribute (push) on the repo; mirror `main`
+# - Build Service identity has Contribute (push) on the repo; mirror `dev`
 #   does not require PRs (it is a mirror, not a human dev branch).
 
 name: GitHub-Mirror-$(Date:yyyyMMdd)$(Rev:.r)
@@ -27,7 +27,7 @@ schedules:
   displayName: Daily GitHub -> ADO mirror
   branches:
     include:
-    - main
+    - dev
   always: true
 
 trigger: none
@@ -50,24 +50,24 @@ steps:
     git config user.email "sync@microsoft.com"
     git config user.name  "ADO Mirror Bot"
 
-    # Fetch GitHub main's real commits + tags. Public repo -> no auth, no
+    # Fetch GitHub dev's real commits + tags. Public repo -> no auth, no
     # service connection (keeps the pipeline source ADO-only for SDL).
     git remote add github https://github.com/microsoft/mssql-django.git
-    git fetch --tags github main
+    git fetch --tags github dev
 
     GH_SHA="$(git rev-parse FETCH_HEAD)"
     ADO_SHA="$(git rev-parse HEAD)"
-    echo "GitHub main: $GH_SHA"
-    echo "ADO   main: $ADO_SHA"
+    echo "GitHub dev: $GH_SHA"
+    echo "ADO   dev: $ADO_SHA"
 
     if [ "$GH_SHA" = "$ADO_SHA" ]; then
       echo "Already in sync. Nothing to do."
       exit 0
     fi
 
-    # Fast-forward ADO main to GitHub main's actual commit graph. History is
+    # Fast-forward ADO dev to GitHub dev's actual commit graph. History is
     # preserved (real commits, same SHAs) and this is NOT a force-push. A
     # non-fast-forward here means unexpected divergence and will fail loudly.
-    git push origin "$GH_SHA:refs/heads/main"
+    git push origin "$GH_SHA:refs/heads/dev"
     git push origin --tags
-  displayName: Mirror GitHub main -> ADO main (history preserved, no force)
+  displayName: Mirror GitHub dev -> ADO dev (history preserved, no force)

--- a/OneBranchPipelines/github-ado-sync.yml
+++ b/OneBranchPipelines/github-ado-sync.yml
@@ -1,39 +1,38 @@
+# =============================================================================
 # GitHub -> Azure DevOps mirror sync for microsoft/mssql-django.
+# =============================================================================
+# Keeps the ADO mirror in step with GitHub using the PULL REQUEST mechanism
+# (same as mssql-python) while PRESERVING FULL COMMIT HISTORY -- real commits,
+# identical SHAs -- instead of python's squashed replace-all commit.
 #
-# GitHub is the source of truth. This pipeline keeps the Azure DevOps mirror
-# (sqlclientdrivers/mssql-django) identical to GitHub, PRESERVING FULL COMMIT
-# HISTORY (identical SHAs) by pushing GitHub's real commits -- never a squashed
-# single-diff commit, and never a force-push.
+#   1. Fetch GitHub dev's real commit graph.
+#   2. Push those actual commits (fast-forward) to a fresh intermediate ADO
+#      sync branch -- never a direct push to main, never a force-push.
+#   3. Open a PR from the sync branch into main, completed as a MERGE
+#      (--squash false) so every individual commit + SHA is retained.
 #
-# Branch mapping: GitHub's default branch is `dev`; the Azure DevOps mirror's
-# default/stable branch is `main` (ADO/1ES conventions -- TSA, Ownership
-# Enforcer, OneBranch official builds -- expect `main`). Branch names need not
-# match across the two remotes, so we sync GitHub `dev` -> ADO `main`.
+# No direct writes to main. No force. No ado-only hacks (this file mirrors to
+# GitHub like everything else).
 #
-# SDL-friendly by design: this pipeline's SOURCE repository is the Azure DevOps
-# mssql-django repo (checkout: self), NOT GitHub. It performs only a plain,
-# unauthenticated `git fetch` of the PUBLIC GitHub repo inside the script -- no
-# GitHub service connection and no GitHub-sourced pipeline.
+# SDL-clean: the pipeline SOURCE is the ADO mirror (checkout: self). It performs
+# only a plain, unauthenticated `git fetch` of the PUBLIC GitHub repo -- no
+# GitHub service connection.
 #
-# Base state: the ADO repo is seeded once via an ADO "Import repository" from
-# https://github.com/microsoft/mssql-django (full history, no force), then its
-# `main` branch is set to GitHub dev's HEAD. After that, ADO main is always an
-# ancestor of GitHub dev, so each run is a plain fast-forward push (ff != force)
-# needing only Contribute on the repo.
+# Branch mapping: GitHub `dev` -> ADO `main` (ADO/1ES conventions expect main).
 #
-# Prerequisites:
-# - Pipeline source repository = Azure DevOps sqlclientdrivers/mssql-django.
-# - Build Service identity has Contribute (push) on the repo; mirror `main`
-#   does not require PRs (it is a mirror, not a human dev branch).
+# Build Service (System.AccessToken) permissions required on this repo:
+#   - Contribute            (push the sync branch)
+#   - Contribute to PRs     (create + auto-complete the pull request)
+# =============================================================================
 
-name: GitHub-Mirror-$(Date:yyyyMMdd)$(Rev:.r)
+name: GitHub-Sync-$(Date:yyyyMMdd)$(Rev:.r)
 
 schedules:
-- cron: "30 11 * * *"          # daily 17:00 IST (matches mssql-python's sync)
+- cron: "30 11 * * *"           # daily 17:00 IST (matches mssql-python)
   displayName: Daily GitHub -> ADO mirror
   branches:
     include:
-    - main                     # the ADO mirror branch this pipeline lives on
+    - main
   always: true
 
 trigger: none
@@ -42,11 +41,11 @@ pr: none
 pool:
   name: Django-1ES-pool
   demands:
-  - imageOverride -equals MMSUbuntu20.04
+  - imageOverride -equals Ubuntu22.04-AzurePipelines
 
 steps:
-- checkout: self               # Azure DevOps mssql-django mirror (source = ADO)
-  persistCredentials: true     # allows push back to ADO via System.AccessToken
+- checkout: self                # Azure DevOps mssql-django mirror (source = ADO)
+  persistCredentials: true      # git push to ADO via System.AccessToken
   fetchDepth: 0
   fetchTags: true
 
@@ -56,24 +55,47 @@ steps:
     git config user.email "sync@microsoft.com"
     git config user.name  "ADO Mirror Bot"
 
-    # Fetch GitHub dev's real commits + tags. Public repo -> no auth, no
-    # service connection (keeps the pipeline source ADO-only for SDL).
+    # 1. Fetch GitHub dev's real commits (public repo -> no auth, SDL-clean).
     git remote add github https://github.com/microsoft/mssql-django.git
     git fetch --tags github dev
-
     GH_SHA="$(git rev-parse FETCH_HEAD)"
-    ADO_SHA="$(git rev-parse HEAD)"
-    echo "GitHub dev  : $GH_SHA"
-    echo "ADO    main : $ADO_SHA"
+    echo "GitHub dev is at $GH_SHA"
 
-    if [ "$GH_SHA" = "$ADO_SHA" ]; then
-      echo "Already in sync. Nothing to do."
+    git fetch origin main
+    MAIN_SHA="$(git rev-parse FETCH_HEAD)"
+    echo "ADO main is at $MAIN_SHA"
+
+    # No-op if main already contains GitHub dev's tip.
+    if git merge-base --is-ancestor "$GH_SHA" "$MAIN_SHA"; then
+      echo "ADO main already contains GitHub dev ($GH_SHA). Nothing to sync."
       exit 0
     fi
 
-    # Fast-forward ADO main to GitHub dev's actual commit graph. History is
-    # preserved (real commits, same SHAs) and this is NOT a force-push. A
-    # non-fast-forward here means unexpected divergence and will fail loudly.
-    git push origin "$GH_SHA:refs/heads/main"
-    git push origin --tags
-  displayName: Mirror GitHub dev -> ADO main (history preserved, no force)
+    # 2. Push GitHub dev's actual commit graph to a fresh sync branch. GitHub
+    #    history is append-only, so this is a fast-forward -- no force, and it
+    #    never touches main. History + SHAs are preserved exactly.
+    SYNC_BRANCH="sync/github-dev-$(date -u +%Y%m%d-%H%M%S)"
+    echo "Pushing GitHub dev commits to $SYNC_BRANCH"
+    git push origin "$GH_SHA:refs/heads/$SYNC_BRANCH"
+
+    # 3. Open a PR sync -> main, auto-completed as a MERGE (not squash) so the
+    #    individual commits are retained on main.
+    export AZURE_DEVOPS_EXT_PAT="$SYSTEM_ACCESSTOKEN"
+    az extension add --name azure-devops --only-show-errors || true
+
+    az repos pr create \
+      --organization "$SYSTEM_COLLECTIONURI" \
+      --project "$SYSTEM_TEAMPROJECT" \
+      --repository mssql-django \
+      --source-branch "$SYNC_BRANCH" \
+      --target-branch main \
+      --title "Sync GitHub dev -> main ($GH_SHA)" \
+      --description "Automated history-preserving sync of GitHub microsoft/mssql-django dev into ADO main. Completed as a MERGE (not squash) to retain individual commits and their SHAs." \
+      --squash false \
+      --delete-source-branch true \
+      --auto-complete true
+  displayName: Sync GitHub dev -> ADO main via PR (history preserved, no force)
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    SYSTEM_COLLECTIONURI: $(System.TeamFoundationCollectionUri)
+    SYSTEM_TEAMPROJECT: $(System.TeamProject)

--- a/OneBranchPipelines/github-ado-sync.yml
+++ b/OneBranchPipelines/github-ado-sync.yml
@@ -5,19 +5,25 @@
 # HISTORY (identical SHAs) by pushing GitHub's real commits -- never a squashed
 # single-diff commit, and never a force-push.
 #
+# Branch mapping: GitHub's default branch is `dev`; the Azure DevOps mirror's
+# default/stable branch is `main` (ADO/1ES conventions -- TSA, Ownership
+# Enforcer, OneBranch official builds -- expect `main`). Branch names need not
+# match across the two remotes, so we sync GitHub `dev` -> ADO `main`.
+#
 # SDL-friendly by design: this pipeline's SOURCE repository is the Azure DevOps
 # mssql-django repo (checkout: self), NOT GitHub. It performs only a plain,
 # unauthenticated `git fetch` of the PUBLIC GitHub repo inside the script -- no
 # GitHub service connection and no GitHub-sourced pipeline.
 #
 # Base state: the ADO repo is seeded once via an ADO "Import repository" from
-# https://github.com/microsoft/mssql-django (full history, no force). After
-# that, ADO dev is always an ancestor of GitHub dev, so each run is a plain
-# fast-forward push (ff != force) needing only Contribute on the repo.
+# https://github.com/microsoft/mssql-django (full history, no force), then its
+# `main` branch is set to GitHub dev's HEAD. After that, ADO main is always an
+# ancestor of GitHub dev, so each run is a plain fast-forward push (ff != force)
+# needing only Contribute on the repo.
 #
 # Prerequisites:
 # - Pipeline source repository = Azure DevOps sqlclientdrivers/mssql-django.
-# - Build Service identity has Contribute (push) on the repo; mirror `dev`
+# - Build Service identity has Contribute (push) on the repo; mirror `main`
 #   does not require PRs (it is a mirror, not a human dev branch).
 
 name: GitHub-Mirror-$(Date:yyyyMMdd)$(Rev:.r)
@@ -27,7 +33,7 @@ schedules:
   displayName: Daily GitHub -> ADO mirror
   branches:
     include:
-    - dev
+    - main                     # the ADO mirror branch this pipeline lives on
   always: true
 
 trigger: none
@@ -57,17 +63,17 @@ steps:
 
     GH_SHA="$(git rev-parse FETCH_HEAD)"
     ADO_SHA="$(git rev-parse HEAD)"
-    echo "GitHub dev: $GH_SHA"
-    echo "ADO   dev: $ADO_SHA"
+    echo "GitHub dev  : $GH_SHA"
+    echo "ADO    main : $ADO_SHA"
 
     if [ "$GH_SHA" = "$ADO_SHA" ]; then
       echo "Already in sync. Nothing to do."
       exit 0
     fi
 
-    # Fast-forward ADO dev to GitHub dev's actual commit graph. History is
+    # Fast-forward ADO main to GitHub dev's actual commit graph. History is
     # preserved (real commits, same SHAs) and this is NOT a force-push. A
     # non-fast-forward here means unexpected divergence and will fail loudly.
-    git push origin "$GH_SHA:refs/heads/dev"
+    git push origin "$GH_SHA:refs/heads/main"
     git push origin --tags
-  displayName: Mirror GitHub dev -> ADO dev (history preserved, no force)
+  displayName: Mirror GitHub dev -> ADO main (history preserved, no force)

--- a/OneBranchPipelines/github-ado-sync.yml
+++ b/OneBranchPipelines/github-ado-sync.yml
@@ -1,0 +1,73 @@
+# GitHub -> Azure DevOps mirror sync for microsoft/mssql-django.
+#
+# GitHub is the source of truth. This pipeline keeps the Azure DevOps mirror
+# (sqlclientdrivers/mssql-django) identical to GitHub, PRESERVING FULL COMMIT
+# HISTORY (identical SHAs) by pushing GitHub's real commits -- never a squashed
+# single-diff commit, and never a force-push.
+#
+# SDL-friendly by design: this pipeline's SOURCE repository is the Azure DevOps
+# mssql-django repo (checkout: self), NOT GitHub. It performs only a plain,
+# unauthenticated `git fetch` of the PUBLIC GitHub repo inside the script -- no
+# GitHub service connection and no GitHub-sourced pipeline.
+#
+# Base state: the ADO repo is seeded once via an ADO "Import repository" from
+# https://github.com/microsoft/mssql-django (full history, no force). After
+# that, ADO main is always an ancestor of GitHub main, so each run is a plain
+# fast-forward push (ff != force) needing only Contribute on the repo.
+#
+# Prerequisites:
+# - Pipeline source repository = Azure DevOps sqlclientdrivers/mssql-django.
+# - Build Service identity has Contribute (push) on the repo; mirror `main`
+#   does not require PRs (it is a mirror, not a human dev branch).
+
+name: GitHub-Mirror-$(Date:yyyyMMdd)$(Rev:.r)
+
+schedules:
+- cron: "30 11 * * *"          # daily 17:00 IST (matches mssql-python's sync)
+  displayName: Daily GitHub -> ADO mirror
+  branches:
+    include:
+    - main
+  always: true
+
+trigger: none
+pr: none
+
+pool:
+  name: Django-1ES-pool
+  demands:
+  - imageOverride -equals MMSUbuntu20.04
+
+steps:
+- checkout: self               # Azure DevOps mssql-django mirror (source = ADO)
+  persistCredentials: true     # allows push back to ADO via System.AccessToken
+  fetchDepth: 0
+  fetchTags: true
+
+- script: |
+    set -euo pipefail
+
+    git config user.email "sync@microsoft.com"
+    git config user.name  "ADO Mirror Bot"
+
+    # Fetch GitHub main's real commits + tags. Public repo -> no auth, no
+    # service connection (keeps the pipeline source ADO-only for SDL).
+    git remote add github https://github.com/microsoft/mssql-django.git
+    git fetch --tags github main
+
+    GH_SHA="$(git rev-parse FETCH_HEAD)"
+    ADO_SHA="$(git rev-parse HEAD)"
+    echo "GitHub main: $GH_SHA"
+    echo "ADO   main: $ADO_SHA"
+
+    if [ "$GH_SHA" = "$ADO_SHA" ]; then
+      echo "Already in sync. Nothing to do."
+      exit 0
+    fi
+
+    # Fast-forward ADO main to GitHub main's actual commit graph. History is
+    # preserved (real commits, same SHAs) and this is NOT a force-push. A
+    # non-fast-forward here means unexpected divergence and will fail loudly.
+    git push origin "$GH_SHA:refs/heads/main"
+    git push origin --tags
+  displayName: Mirror GitHub main -> ADO main (history preserved, no force)


### PR DESCRIPTION
## What

Adds the GitHub → Azure DevOps mirror sync pipeline: `OneBranchPipelines/github-ado-sync.yml`.

It keeps the ADO mirror (`sqlclientdrivers/mssql-django`) identical to GitHub, **preserving full commit history** (real commits, identical SHAs) via a **fast-forward push** — no squashed single-diff commit, and **no force-push**.

## Design (per discussion)

- **SDL-clean:** the pipeline's *source* is the ADO `mssql-django` repo (`checkout: self`), **not** GitHub. It only does a plain, unauthenticated `git fetch` of the public GitHub repo — no GitHub service connection, no GitHub-sourced pipeline.
- **History preserved:** pushes GitHub `main`'s actual commit graph (vs mssql-python's squashed replace-all).
- **No hacks:** zero ADO-only files, no `ado-only-paths.txt`. This YAML lives on GitHub and mirrors to ADO like everything else.
- **No force:** the ADO repo is seeded once via ADO **Import repository** (full history), after which every sync is a fast-forward. Needs only Build Service `Contribute`.
- Cadence + location match mssql-python (daily 17:00 IST, `OneBranchPipelines/`).

## Assumes / sequencing

- Targets GitHub **`main`** — land **after** the `dev`→`main` default-branch switch.
- ADO side (joint step): re-import the mirror from GitHub, create the pipeline definition (source = ADO mirror), grant Build Service `Contribute`.

**Draft** until the ADO mirror is re-imported and the pipeline definition is created.
