### PR TITLE
CHORE: add OneBranch official + dummy release pipelines

### DIFF
--- a/OneBranchPipelines/dummy-release-pipeline.yml
+++ b/OneBranchPipelines/dummy-release-pipeline.yml
@@ -1,0 +1,107 @@
+# =============================================================================
+# OneBranch DUMMY / TEST Release pipeline for mssql-django.
+# WARNING: TEST ONLY -- never publishes to PyPI.
+# =============================================================================
+# Exercises the full download + ESRP release path against a Maven ContentType
+# (instead of PyPI) so the ESRP wiring can be validated WITHOUT any risk of a
+# real production release. Always NonOfficial.
+# =============================================================================
+
+name: $(Year:YY)$(DayOfYear)$(Rev:.r)-Dummy-Release
+
+trigger: none
+pr: none
+
+parameters:
+  - name: performDummyRelease
+    displayName: '[TEST] Perform Dummy ESRP Release (Maven - NOT PyPI)'
+    type: boolean
+    default: true    # Safe: Maven ContentType, never touches PyPI.
+
+variables:
+  - template: /OneBranchPipelines/variables/common-variables.yml@self
+  - template: /OneBranchPipelines/variables/onebranch-variables.yml@self
+  - group: 'ESRP Federated Creds (AME)'
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: 'OneBranch.Pipelines/GovernedTemplates'
+      ref: 'refs/heads/main'
+  pipelines:
+    - pipeline: buildPipeline
+      source: 'Build-Release-Package-Pipeline'
+      trigger: none
+
+extends:
+  template: 'v2/OneBranch.NonOfficial.CrossPlat.yml@templates'
+  parameters:
+    globalSdl:
+      sbom:
+        enabled: true
+      credscan:
+        enabled: true
+      policheck:
+        break: true
+
+    stages:
+      - stage: TestReleasePackage
+        displayName: '[TEST] Dummy Release - Validate ESRP Workflow'
+        jobs:
+
+          - job: PrepAndValidate
+            displayName: '[TEST] Download and Validate Artifact'
+            pool:
+              type: linux
+              isCustom: true
+              name: Django-1ES-pool
+              demands:
+              - imageOverride -equals Ubuntu22.04-AzurePipelines
+            variables:
+              ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+            steps:
+              - download: buildPipeline
+                displayName: '[TEST] Download drop from Build pipeline'
+              - task: Bash@3
+                displayName: '[TEST] List artifact contents'
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    set -euo pipefail
+                    DIST="$(Pipeline.Workspace)/buildPipeline/drop_build_build"
+                    echo "=== [TEST] artifact contents ==="
+                    ls -la "$DIST"
+
+          - ${{ if eq(parameters.performDummyRelease, true) }}:
+            - job: DummyRelease
+              displayName: '[TEST] Dummy ESRP Release (Maven)'
+              dependsOn: PrepAndValidate
+              templateContext:
+                type: releaseJob
+                isProduction: false
+              pool:
+                type: linux
+              variables:
+                ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+              steps:
+                - download: buildPipeline
+                  displayName: '[TEST] Download drop from Build pipeline'
+                - task: EsrpRelease@9
+                  displayName: '[TEST] Dummy ESRP Release (Maven - NOT PyPI)'
+                  inputs:
+                    connectedservicename: '$(ESRPConnectedServiceName)'
+                    usemanagedidentity: true
+                    keyvaultname: '$(AuthAKVName)'
+                    signcertname: '$(AuthSignCertName)'
+                    clientid: '$(EsrpClientId)'
+                    Intent: 'PackageDistribution'
+                    ContentType: 'Maven'   # placeholder - deliberately NOT PyPI
+                    ContentSource: 'Folder'
+                    FolderLocation: '$(Pipeline.Workspace)/buildPipeline/drop_build_build'
+                    WaitForReleaseCompletion: true
+                    Owners: '$(owner)'
+                    Approvers: '$(approver)'
+                    ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                    MainPublisher: 'ESRPRELPACMAN'
+                    DomainTenantId: '$(DomainTenantId)'

--- a/OneBranchPipelines/official-release-pipeline.yml
+++ b/OneBranchPipelines/official-release-pipeline.yml
@@ -1,0 +1,134 @@
+# =============================================================================
+# OneBranch Official Release pipeline for mssql-django.
+# =============================================================================
+# Downloads the 'drop' artifact (sdist + wheel) produced by the
+# Build-Release-Package pipeline and releases it to PyPI via ESRP.
+#
+# ALWAYS Official. Gated by `releaseToPyPI` (default FALSE = dry run) so a run
+# never publishes by accident -- flip to true + re-run to actually release.
+# =============================================================================
+
+name: $(Year:YY)$(DayOfYear)$(Rev:.r)-Release
+
+# Manual trigger only - releases must be deliberate.
+trigger: none
+pr: none
+
+parameters:
+  - name: releaseToPyPI
+    displayName: 'Release to PyPI (Production)'
+    type: boolean
+    default: false   # Safety: default false to prevent accidental releases.
+
+variables:
+  - template: /OneBranchPipelines/variables/common-variables.yml@self
+  - template: /OneBranchPipelines/variables/onebranch-variables.yml@self
+  - group: 'ESRP Federated Creds (AME)'   # ESRP signing credentials
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: 'OneBranch.Pipelines/GovernedTemplates'
+      ref: 'refs/heads/main'
+  pipelines:
+    - pipeline: buildPipeline
+      source: 'Build-Release-Package-Pipeline'   # the build pipeline (PR #548)
+      trigger: none
+
+extends:
+  template: 'v2/OneBranch.Official.CrossPlat.yml@templates'
+  parameters:
+    globalSdl:
+      sbom:
+        enabled: true
+      credscan:
+        enabled: true
+      policheck:
+        break: true
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)/.config/tsaoptions.json
+
+    stages:
+      - stage: ReleasePackage
+        displayName: 'Release mssql-django to PyPI'
+        jobs:
+
+          # Job 1: download + validate the built artifact.
+          - job: PrepAndValidate
+            displayName: 'Download and Validate Artifact'
+            pool:
+              type: linux
+              isCustom: true
+              name: Django-1ES-pool
+              demands:
+              - imageOverride -equals Ubuntu22.04-AzurePipelines
+            variables:
+              ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+            steps:
+              - download: buildPipeline
+                displayName: 'Download drop from Build pipeline'
+              - task: Bash@3
+                displayName: 'Verify dist contents'
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    set -euo pipefail
+                    DIST="$(Pipeline.Workspace)/buildPipeline/drop_build_build"
+                    echo "=== artifact contents ==="
+                    ls -la "$DIST"
+                    test -n "$(find "$DIST" -name '*.whl' -o -name '*.tar.gz')" \
+                      || { echo "No wheel/sdist found in drop artifact"; exit 1; }
+              - ${{ if eq(parameters.releaseToPyPI, false) }}:
+                - task: Bash@3
+                  displayName: 'Dry Run - Release Skipped'
+                  inputs:
+                    targetType: 'inline'
+                    script: |
+                      echo "===================================="
+                      echo "DRY RUN MODE - No Release Performed"
+                      echo "releaseToPyPI=false. Verified the drop artifact only."
+                      echo "To release: set releaseToPyPI=true and re-run."
+                      echo "===================================="
+
+          # Job 2: ESRP release to PyPI (only when releaseToPyPI=true).
+          - ${{ if eq(parameters.releaseToPyPI, true) }}:
+            - job: PyPIRelease
+              displayName: 'ESRP Release to PyPI'
+              dependsOn: PrepAndValidate
+              templateContext:
+                type: releaseJob
+                isProduction: true
+              pool:
+                type: linux
+              variables:
+                ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+              steps:
+                - download: buildPipeline
+                  displayName: 'Download drop from Build pipeline'
+                - task: EsrpRelease@9
+                  displayName: 'ESRP Release to PyPI'
+                  inputs:
+                    connectedservicename: '$(ESRPConnectedServiceName)'
+                    usemanagedidentity: true
+                    keyvaultname: '$(AuthAKVName)'
+                    signcertname: '$(AuthSignCertName)'
+                    clientid: '$(EsrpClientId)'
+                    Intent: 'PackageDistribution'
+                    ContentType: 'PyPI'
+                    ContentSource: 'Folder'
+                    FolderLocation: '$(Pipeline.Workspace)/buildPipeline/drop_build_build'
+                    WaitForReleaseCompletion: true
+                    Owners: '$(owner)'
+                    Approvers: '$(approver)'
+                    ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                    MainPublisher: 'ESRPRELPACMAN'
+                    DomainTenantId: '$(DomainTenantId)'
+                - task: Bash@3
+                  displayName: 'Release Summary'
+                  inputs:
+                    targetType: 'inline'
+                    script: |
+                      echo "ESRP release to PyPI submitted."
+                      echo "Verify at https://pypi.org/project/mssql-django/"


### PR DESCRIPTION
## What

Completes the release loop on top of the build pipeline (#548):

| File | Template | Purpose |
|------|----------|---------|
| `official-release-pipeline.yml` | OneBranch **Official** | Download build `drop` → **ESRP release to PyPI**. Gated by `releaseToPyPI` (default **false** = dry run). |
| `dummy-release-pipeline.yml` | OneBranch **NonOfficial** | Exercise the full ESRP path against a **Maven** ContentType (never PyPI) to validate wiring safely. |

## Design

- **Safe by default:** the official pipeline's `releaseToPyPI` defaults to **false** — a run only downloads + validates the artifact (dry run). Flip to `true` + re-run to actually publish. The dummy pipeline never targets PyPI (Maven ContentType).
- **No hard-coded build definition id:** both consume the build output via a `pipelines:` resource (`download: buildPipeline`), resolving the `drop_build_build` artifact from the selected build run.
- **ESRP creds** come from the existing `ESRP Federated Creds (AME)` variable group (already present in the `mssql-django` project).
- Manual-trigger only (`trigger: none`) — releases must be deliberate.

## The complete loop (once all merged + wired)

```
GitHub dev --(github-ado-sync, #547)--> ADO main
                                          |
                    Build-Release-Package (#548) --> 'drop' (sdist + wheel)
                                          |
              +---------------------------+---------------------------+
              |                                                       |
   Official-Release (this PR)                          Dummy-Release (this PR)
   ESRP -> PyPI (gated)                                ESRP -> Maven (test only)
```

## Depends on

- #546 (variables + `.config/`), #548 (build pipeline).

**Draft** until the ADO release definitions are created.
