### PR TITLE
FIX: run GitHub->ADO sync on windows-latest with az + link work item

### DIFF
--- a/OneBranchPipelines/github-ado-sync.yml
+++ b/OneBranchPipelines/github-ado-sync.yml
@@ -8,15 +8,17 @@
 #   1. Fetch GitHub dev's real commit graph.
 #   2. Push those actual commits (fast-forward) to a fresh intermediate ADO
 #      sync branch -- never a direct push to main, never a force-push.
-#   3. Open a PR from the sync branch into main, completed as a MERGE
-#      (--squash false) so every individual commit + SHA is retained.
+#   3. Open a PR from the sync branch into main and auto-complete it as a MERGE
+#      (--squash false) so every individual commit + SHA is retained on main.
+#      Every sync PR links the tracking work item (46645, "GH<>ADO Sync PRs").
+#
+# Runs on windows-latest (Microsoft-hosted) where the Azure CLI is preinstalled,
+# so PR creation uses `az repos pr` -- same tooling as the mssql-python sync.
 #
 # No direct writes to main. No force. No ado-only hacks (this file mirrors to
-# GitHub like everything else).
-#
-# SDL-clean: the pipeline SOURCE is the ADO mirror (checkout: self). It performs
-# only a plain, unauthenticated `git fetch` of the PUBLIC GitHub repo -- no
-# GitHub service connection.
+# GitHub like everything else). SDL-clean: the pipeline SOURCE is the ADO mirror
+# (checkout: self); it only does a plain, unauthenticated `git fetch` of the
+# PUBLIC GitHub repo -- no GitHub service connection.
 #
 # Branch mapping: GitHub `dev` -> ADO `main` (ADO/1ES conventions expect main).
 #
@@ -39,9 +41,7 @@ trigger: none
 pr: none
 
 pool:
-  name: Django-1ES-pool
-  demands:
-  - imageOverride -equals Ubuntu22.04-AzurePipelines
+  vmImage: 'windows-latest'
 
 steps:
 - checkout: self                # Azure DevOps mssql-django mirror (source = ADO)
@@ -49,8 +49,8 @@ steps:
   fetchDepth: 0
   fetchTags: true
 
-- script: |
-    set -euo pipefail
+- pwsh: |
+    $ErrorActionPreference = 'Stop'
 
     git config user.email "sync@microsoft.com"
     git config user.name  "ADO Mirror Bot"
@@ -58,44 +58,50 @@ steps:
     # 1. Fetch GitHub dev's real commits (public repo -> no auth, SDL-clean).
     git remote add github https://github.com/microsoft/mssql-django.git
     git fetch --tags github dev
-    GH_SHA="$(git rev-parse FETCH_HEAD)"
-    echo "GitHub dev is at $GH_SHA"
+    if ($LASTEXITCODE -ne 0) { throw "git fetch github dev failed" }
+    $ghSha = (git rev-parse FETCH_HEAD).Trim()
+    Write-Host "GitHub dev is at $ghSha"
 
     git fetch origin main
-    MAIN_SHA="$(git rev-parse FETCH_HEAD)"
-    echo "ADO main is at $MAIN_SHA"
+    $mainSha = (git rev-parse FETCH_HEAD).Trim()
+    Write-Host "ADO main is at $mainSha"
 
     # No-op if main already contains GitHub dev's tip.
-    if git merge-base --is-ancestor "$GH_SHA" "$MAIN_SHA"; then
-      echo "ADO main already contains GitHub dev ($GH_SHA). Nothing to sync."
+    git merge-base --is-ancestor $ghSha $mainSha
+    if ($LASTEXITCODE -eq 0) {
+      Write-Host "ADO main already contains GitHub dev ($ghSha). Nothing to sync."
       exit 0
-    fi
+    }
 
     # 2. Push GitHub dev's actual commit graph to a fresh sync branch. GitHub
     #    history is append-only, so this is a fast-forward -- no force, and it
     #    never touches main. History + SHAs are preserved exactly.
-    SYNC_BRANCH="sync/github-dev-$(date -u +%Y%m%d-%H%M%S)"
-    echo "Pushing GitHub dev commits to $SYNC_BRANCH"
-    git push origin "$GH_SHA:refs/heads/$SYNC_BRANCH"
+    $syncBranch = "sync/github-dev-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+    Write-Host "Pushing GitHub dev commits to $syncBranch"
+    git push origin "$($ghSha):refs/heads/$syncBranch"
+    if ($LASTEXITCODE -ne 0) { throw "push to $syncBranch failed" }
 
-    # 3. Open a PR sync -> main, auto-completed as a MERGE (not squash) so the
-    #    individual commits are retained on main.
-    export AZURE_DEVOPS_EXT_PAT="$SYSTEM_ACCESSTOKEN"
-    az extension add --name azure-devops --only-show-errors || true
+    # 3. Open a PR sync -> main and auto-complete as a MERGE (--squash false) so
+    #    the individual commits are retained on main.
+    $env:AZURE_DEVOPS_EXT_PAT = "$(System.AccessToken)"
+    az extension add --name azure-devops --only-show-errors
 
-    az repos pr create \
-      --organization "$SYSTEM_COLLECTIONURI" \
-      --project "$SYSTEM_TEAMPROJECT" \
-      --repository mssql-django \
-      --source-branch "$SYNC_BRANCH" \
-      --target-branch main \
-      --title "Sync GitHub dev -> main ($GH_SHA)" \
-      --description "Automated history-preserving sync of GitHub microsoft/mssql-django dev into ADO main. Completed as a MERGE (not squash) to retain individual commits and their SHAs." \
-      --squash false \
-      --delete-source-branch true \
-      --auto-complete true
+    az repos pr create `
+      --organization "$(System.TeamFoundationCollectionUri)" `
+      --project "$(System.TeamProject)" `
+      --repository mssql-django `
+      --source-branch "$syncBranch" `
+      --target-branch main `
+      --title "Sync GitHub dev -> main ($ghSha)" `
+      --description "Automated history-preserving sync of GitHub microsoft/mssql-django dev into ADO main. Auto-completed as a MERGE (not squash) to retain individual commits and their SHAs." `
+      --squash false `
+      --work-items 46645 `
+      --delete-source-branch true `
+      --auto-complete true `
+      --output table
+    if ($LASTEXITCODE -ne 0) { throw "az repos pr create failed" }
+
+    Write-Host "PR created and set to auto-complete (merge, no force). Sync done."
   displayName: Sync GitHub dev -> ADO main via PR (history preserved, no force)
   env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    SYSTEM_COLLECTIONURI: $(System.TeamFoundationCollectionUri)
-    SYSTEM_TEAMPROJECT: $(System.TeamProject)
+    AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)


### PR DESCRIPTION
## What

Fixes the GitHub → ADO mirror sync (`OneBranchPipelines/github-ado-sync.yml`), which was merged in #547 but **fails at runtime** with `az: command not found`.

## Why it failed

The merged version runs `az repos pr create` on the **`Django-1ES-pool`** Linux image, which does **not** ship the Azure CLI on PATH. (mssql-python's sync only works because it runs on `windows-latest`, where az is preinstalled.)

## Changes

- **Move the job to `windows-latest`** (Microsoft-hosted, az preinstalled) — same tooling as the mssql-python sync. Script converted to `pwsh`.
- **Link the tracking work item** on every sync PR: `--work-items 46645` ("GH<>ADO Sync PRs" / AB#46645) — traceability + satisfies the work-item policy on `main`.
- Behavior unchanged otherwise: pushes GitHub `dev`'s **real commits** to a `sync/github-dev-<ts>` branch and opens a PR auto-completed as a **MERGE** (`--squash false`) — history preserved, no direct push to `main`, no force.

## Note

`main`'s **Proof of Presence + Minimum reviewers + Status** policies still require a human to complete each sync PR (by design — these are org/1ES controls). This PR only fixes the runtime failure + adds work-item linking.
