### PR TITLE
FIX: honor database time zone when adapting datetimes

### DIFF
--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -614,10 +614,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
         if timezone.is_aware(value):
             if settings.USE_TZ:
-                # When support for time zones is enabled, Django stores datetime information
-                # in UTC in the database and uses time-zone-aware objects internally
-                # source: https://docs.djangoproject.com/en/dev/topics/i18n/timezones/#overview
-                value = value.astimezone(datetime.timezone.utc)
+                value = timezone.make_naive(value, self.connection.timezone)
             else:
                 # When USE_TZ is False, settings.TIME_ZONE is the time zone in
                 # which Django will store all datetimes

--- a/mssql/operations.py
+++ b/mssql/operations.py
@@ -31,15 +31,20 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def _convert_field_to_tz(self, field_name, tzname):
         if tzname and settings.USE_TZ and self.connection.timezone_name != tzname:
-            offset = self._get_utcoffset(tzname)
+            offset = self._get_timezone_offset(tzname)
             field_name = 'DATEADD(second, %d, %s)' % (offset, field_name)
         return field_name
 
     def _convert_sql_to_tz(self, sql, params, tzname):
         if tzname and settings.USE_TZ and self.connection.timezone_name != tzname:
-            offset = self._get_utcoffset(tzname)
+            offset = self._get_timezone_offset(tzname)
             sql = 'DATEADD(second, %d, %s)' % (offset, sql)
         return sql, params
+
+    def _get_timezone_offset(self, tzname):
+        connection_tzname = self.connection.timezone_name
+        connection_offset = self._get_utcoffset(connection_tzname) if connection_tzname else 0
+        return self._get_utcoffset(tzname) - connection_offset
 
     def _get_utcoffset(self, tzname):
         """

--- a/testapp/tests/test_timezones.py
+++ b/testapp/tests/test_timezones.py
@@ -2,11 +2,29 @@
 # Licensed under the BSD license.
 
 import datetime
+from types import SimpleNamespace
+
 from django.db import connection
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
 
+from mssql.operations import DatabaseOperations
+
 from ..models import TimeZone
+
+
+class TestDatabaseOperations(SimpleTestCase):
+
+    @override_settings(USE_TZ=True)
+    def test_adapt_datetimefield_value_uses_database_timezone(self):
+        database_timezone = datetime.timezone(datetime.timedelta(hours=3))
+        operations = DatabaseOperations(SimpleNamespace(timezone=database_timezone))
+        value = datetime.datetime(2026, 1, 15, 12, tzinfo=datetime.timezone.utc)
+
+        adapted = operations.adapt_datetimefield_value(value)
+
+        self.assertEqual(adapted, datetime.datetime(2026, 1, 15, 15))
+
 
 class TestDateTimeField(TestCase):
 

--- a/testapp/tests/test_timezones.py
+++ b/testapp/tests/test_timezones.py
@@ -14,16 +14,71 @@ from ..models import TimeZone
 
 
 class TestDatabaseOperations(SimpleTestCase):
-
     @override_settings(USE_TZ=True)
     def test_adapt_datetimefield_value_uses_database_timezone(self):
         database_timezone = datetime.timezone(datetime.timedelta(hours=3))
-        operations = DatabaseOperations(SimpleNamespace(timezone=database_timezone))
+        operations = DatabaseOperations(
+            SimpleNamespace(
+                timezone=database_timezone,
+                timezone_name="Africa/Nairobi",
+            )
+        )
         value = datetime.datetime(2026, 1, 15, 12, tzinfo=datetime.timezone.utc)
 
         adapted = operations.adapt_datetimefield_value(value)
 
         self.assertEqual(adapted, datetime.datetime(2026, 1, 15, 15))
+
+    @override_settings(USE_TZ=True)
+    def test_datetime_sql_conversion_uses_database_timezone(self):
+        operations = DatabaseOperations(SimpleNamespace(timezone_name="Asia/Bangkok"))
+        expected_sql = "DATEADD(second, -14400, column)"
+
+        self.assertEqual(
+            operations._convert_field_to_tz("column", "Africa/Nairobi"),
+            expected_sql,
+        )
+        self.assertEqual(
+            operations._convert_sql_to_tz(
+                "column",
+                ("parameter",),
+                "Africa/Nairobi",
+            ),
+            (expected_sql, ("parameter",)),
+        )
+
+    @override_settings(USE_TZ=True)
+    def test_datetime_sql_conversion_from_utc(self):
+        expected_sql = "DATEADD(second, 10800, column)"
+
+        for timezone_name in (None, "UTC"):
+            with self.subTest(timezone_name=timezone_name):
+                operations = DatabaseOperations(
+                    SimpleNamespace(timezone_name=timezone_name)
+                )
+                self.assertEqual(
+                    operations._convert_field_to_tz("column", "Africa/Nairobi"),
+                    expected_sql,
+                )
+
+    @override_settings(USE_TZ=True)
+    def test_datetime_sql_conversion_skips_matching_timezone(self):
+        operations = DatabaseOperations(
+            SimpleNamespace(timezone_name="Africa/Nairobi")
+        )
+
+        self.assertEqual(
+            operations._convert_field_to_tz("column", "Africa/Nairobi"),
+            "column",
+        )
+        self.assertEqual(
+            operations._convert_sql_to_tz(
+                "column",
+                ("parameter",),
+                "Africa/Nairobi",
+            ),
+            ("column", ("parameter",)),
+        )
 
 
 class TestDateTimeField(TestCase):


### PR DESCRIPTION
Uses the database connection's time zone when adapting aware datetime values and when converting datetime lookup SQL to another time zone.

Adds regressions for non-UTC parameter adaptation, cross-time-zone lookup conversion, UTC defaults, and matching time zones.

Tested with `python manage.py test testapp.tests.test_timezones.TestDatabaseOperations --noinput`.

Fixes #371