### PR TITLE
FEAT: Support Django 6.1 - disable DB-level ON DELETE features

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -8,6 +8,13 @@ from django import VERSION as django_version
 if django_version >= (5, 2):    
     from django.db.models.fields.composite import CompositePrimaryKey
 class DatabaseFeatures(BaseDatabaseFeatures):
+    # Django 6.1 added database-level ON DELETE pushdown (DB_CASCADE / DB_SET_NULL /
+    # DB_SET_DEFAULT), defaulting these flags to True in BaseDatabaseFeatures. SQL Server
+    # rejects FK graphs with multiple cascade paths to the same table (error 1785), which
+    # the new delete-app models trigger, so we don't support DB-level ON DELETE here.
+    supports_on_delete_db_cascade = False
+    supports_on_delete_db_null = False
+    supports_on_delete_db_default = False
     allows_group_by_select_index = False
     allow_sliced_subqueries_with_in = False
     can_introspect_autofield = True

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -15,6 +15,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_on_delete_db_cascade = False
     supports_on_delete_db_null = False
     supports_on_delete_db_default = False
+    # Django 6.1 added bitwise aggregations (BIT_AND / BIT_OR / BIT_XOR), defaulting
+    # supports_bit_aggregations to True. SQL Server has no native bitwise aggregate
+    # function, so BitAnd/BitOr/BitXor raise a clean NotSupportedError instead.
+    supports_bit_aggregations = False
+    supports_default_in_bit_aggregations = False
     allows_group_by_select_index = False
     allow_sliced_subqueries_with_in = False
     can_introspect_autofield = True


### PR DESCRIPTION
[AB#46924](https://sqlclientdrivers.visualstudio.com/0103ffdb-aae3-4a4f-92ae-7c538078eca4/_workitems/edit/46924)

GitHub Issue: #551

Django 6.1 adds database-level ON DELETE pushdown (`DB_CASCADE` / `DB_SET_NULL` / `DB_SET_DEFAULT`), gated on three feature flags that default to True in `BaseDatabaseFeatures`. SQL Server rejects FK graphs with multiple cascade paths to the same table (error 1785), which Django's new `delete`-app test models trigger at test-database creation, so leaving these True breaks the suite before a single test runs.

this declares the three flags unsupported. Django falls back to ORM-level delete emulation, the same behavior as today, and the new delete-app models no longer break test-db creation on 6.1.

first of two PRs on AB#46924, the bitwise-aggregate half lands next. part of Django 6.1 compatibility support, tracked in #551.

no testapp regression here: this is a feature-flag declaration, validated by the Django suite. full 6.1 validation runs once 6.1 is enabled in CI (capstone PR).
