### PR TITLE
FEAT: Support Django 6.1 - disable bitwise aggregate features

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -15,6 +15,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_on_delete_db_cascade = False
     supports_on_delete_db_null = False
     supports_on_delete_db_default = False
+    # Django 6.1 added bitwise aggregations (BIT_AND / BIT_OR / BIT_XOR), defaulting
+    # supports_bit_aggregations to True. SQL Server has no native bitwise aggregate
+    # function, so BitAnd/BitOr/BitXor raise a clean NotSupportedError instead.
+    supports_bit_aggregations = False
+    supports_default_in_bit_aggregations = False
     allows_group_by_select_index = False
     allow_sliced_subqueries_with_in = False
     can_introspect_autofield = True


### PR DESCRIPTION
[AB#46924](https://sqlclientdrivers.visualstudio.com/0103ffdb-aae3-4a4f-92ae-7c538078eca4/_workitems/edit/46924)

GitHub Issue: #551

Django 6.1 added bitwise aggregations, `BitAnd` / `BitOr` / `BitXor`, which emit `BIT_AND` / `BIT_OR` / `BIT_XOR` and are gated on `supports_bit_aggregations` (default True in `BaseDatabaseFeatures`). SQL Server has no native bitwise aggregate function:

```
Msg 195, Level 15, State 10
'BIT_AND' is not a recognized built-in function name.
```

this declares `supports_bit_aggregations` and `supports_default_in_bit_aggregations` False. Django skips the bitwise-aggregate tests, and `BitAggregate.as_sql()` raises a clean `NotSupportedError` at runtime instead of the driver's cryptic 195.

second of two PRs on AB#46924 (the first turned off DB-level ON DELETE). part of Django 6.1 compatibility support, tracked in #551.

**stacks on #553** (same file). base is `bewithgaurav/django-6.1-ondelete-features`; retarget to `dev` once #553 merges.

no testapp regression here: feature-flag declaration, validated by the Django suite. full 6.1 validation runs once 6.1 is enabled in CI (capstone PR). native emulation of bitwise aggregates is tracked as a follow-up.
