### PR TITLE
FEAT: Support Django 6.1 - use quote_name in query compiler

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -400,7 +400,12 @@ class SQLCompiler(compiler.SQLCompiler):
                 # SQL Server requires an order-by clause for offsetting
                 if do_offset:
                     meta = self.query.get_meta()
-                    qn = self.quote_name_unless_alias
+                    # Django 6.1 deprecated SQLCompiler.quote_name_unless_alias()
+                    # in favour of .quote_name(); the latter doesn't exist before 6.1.
+                    if django.VERSION >= (6, 1):
+                        qn = self.quote_name
+                    else:
+                        qn = self.quote_name_unless_alias
                     offsetting_order_by = '%s.%s' % (qn(meta.db_table), qn(meta.pk.db_column or meta.pk.column))
                     if do_offset_emulation:
                         if order_by:


### PR DESCRIPTION
[AB#46925](https://sqlclientdrivers.visualstudio.com/0103ffdb-aae3-4a4f-92ae-7c538078eca4/_workitems/edit/46925)

GitHub Issue: #551

Django 6.1 deprecated `SQLCompiler.quote_name_unless_alias()` in favour of `SQLCompiler.quote_name()`. our offset-emulation path calls it to build the ordering clause SQL Server requires for `OFFSET`. Django's test suite runs deprecation warnings as errors, so on 6.1 this raised:

```
RemovedInDjango70Warning: SQLCompiler.quote_name_unless_alias() is deprecated. Use .quote_name() instead.
```

that took out every LIMIT / OFFSET / slice / count query on 6.1 (the whole cluster of pagination, ordering, sliced-queryset and count tests).

fix: use `self.quote_name` on Django 6.1+, keep `quote_name_unless_alias` on older versions. `quote_name` doesn't exist before 6.1, so the branch is gated on `django.VERSION >= (6, 1)`. also clears the deprecation ahead of its removal in Django 7.0.

a regression test for the offset/slice path follows in a stacked PR. part of Django 6.1 compatibility support, tracked in #551.
