### PR TITLE
FEAT: Support Django 6.1 - return ON DELETE rule from FK introspection

### DIFF
--- a/mssql/introspection.py
+++ b/mssql/introspection.py
@@ -11,6 +11,7 @@ from django.db.backends.base.introspection import BaseDatabaseIntrospection
 from django.db.backends.base.introspection import FieldInfo as BaseFieldInfo
 from django.db.backends.base.introspection import TableInfo as BaseTableInfo
 from django.db.models.indexes import Index
+from django.db.models import DO_NOTHING
 from django.conf import settings
 
 SQL_AUTOFIELD = -777555
@@ -197,7 +198,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     def get_relations(self, cursor, table_name):
         """
         Returns a dictionary of {field_name: (field_name_other_table, other_table)}
-        representing all relationships to the given table.
+        representing all relationships to the given table. On Django 6.1+ the value
+        is a 3-tuple that also carries the introspected on-delete rule.
         """
         # CONSTRAINT_COLUMN_USAGE: http://msdn2.microsoft.com/en-us/library/ms174431.aspx
         # CONSTRAINT_TABLE_USAGE:  http://msdn2.microsoft.com/en-us/library/ms179883.aspx
@@ -206,7 +208,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         sql = f"""
 SELECT e.COLUMN_NAME AS column_name,
   c.TABLE_NAME AS referenced_table_name,
-  d.COLUMN_NAME AS referenced_column_name
+  d.COLUMN_NAME AS referenced_column_name,
+  b.DELETE_RULE AS delete_rule
 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS a
 INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS b
   ON a.CONSTRAINT_NAME = b.CONSTRAINT_NAME AND a.TABLE_SCHEMA = b.CONSTRAINT_SCHEMA
@@ -218,7 +221,16 @@ INNER JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS e
   ON a.CONSTRAINT_NAME = e.CONSTRAINT_NAME AND a.TABLE_SCHEMA = e.TABLE_SCHEMA
 WHERE a.TABLE_SCHEMA = {get_schema_name()} AND a.TABLE_NAME = %s AND a.CONSTRAINT_TYPE = 'FOREIGN KEY'"""
         cursor.execute(sql, (table_name,))
-        return dict([[item[0], (item[2], item[1])] for item in cursor.fetchall()])
+        rows = cursor.fetchall()
+        if VERSION >= (6, 1):
+            # Django 6.1 expects (ref_column, ref_table, db_on_delete). Django creates
+            # SQL Server FKs with NO ACTION (on_delete is emulated in the ORM), which
+            # on_delete_types maps to DO_NOTHING.
+            return dict(
+                [item[0], (item[2], item[1], self.on_delete_types.get(item[3], DO_NOTHING))]
+                for item in rows
+            )
+        return dict([[item[0], (item[2], item[1])] for item in rows])
 
     def get_key_columns(self, cursor, table_name):
         """


### PR DESCRIPTION
[AB#46926](https://sqlclientdrivers.visualstudio.com/0103ffdb-aae3-4a4f-92ae-7c538078eca4/_workitems/edit/46926)

GitHub Issue: #551

Django 6.1 changed `DatabaseIntrospection.get_relations()` to return a 3-tuple per relation, `(referenced_column, referenced_table, db_on_delete)`, adding the introspected ON DELETE rule. `inspectdb` and relation introspection now unpack that third element, so our 2-tuple raised:

```
ValueError: not enough values to unpack (expected 3, got 2)
```

on 6.1 that broke `inspectdb` and `introspection.test_get_relations`.

fix: on Django 6.1+, also select `DELETE_RULE` from `REFERENTIAL_CONSTRAINTS` and map it through `on_delete_types`. SQL Server creates FKs with NO ACTION (since `on_delete` is emulated in the ORM), which maps to `DO_NOTHING`. the returned value is `(ref_column, ref_table, db_on_delete)` on 6.1+ and the original 2-tuple on older versions, gated on `VERSION >= (6, 1)`.

a testapp regression test for the introspection shape follows in a stacked PR. part of Django 6.1 compatibility support, tracked in #551.
