### PR TITLE
FEAT: Support Django 6.1 - add test exclusions for SQL Server limitations

### DIFF
--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -337,6 +337,45 @@ if VERSION >= (6, 0):
         'foreign_object.tests.ForeignObjectModelValidationTests.test_validate_constraints_success_case_single_query',
     ])
 
+# Django 6.1 specific exclusions - SQL Server limitations surfaced by 6.1's new
+# tests. Good candidates for incremental fixes / community contributions.
+if VERSION >= (6, 1):
+    EXCLUDED_TESTS.extend([
+        # SQL Server has no native boolean type (supports_comparing_boolean_expr=False),
+        # so a boolean annotation compiles to a CASE compared to a literal. 6.1 added
+        # assertions that such expressions omit the redundant "= True" comparison.
+        # TODO: strip the redundant boolean comparison in the compiler.
+        'lookup.tests.LookupTests.test_exact_booleanfield_annotation',
+
+        # SQL Server LIKE treats [ ] as a character-class wildcard; escaping a column
+        # reference (F()) used as a LIKE pattern doesn't cover the bracket case.
+        # TODO: escape []-wildcards for column-referencing __contains/__startswith.
+        'expressions.tests.ExpressionsTests.test_patterns_escape',
+
+        # JSON key __iexact=None semantics (no native JSON null handling on SQL Server);
+        # sibling to the existing JSONField exclusions.
+        'model_fields.test_jsonfield.TestQuerying.test_key_iexact_none',
+
+        # bulk_batch_size is capped for SQL Server's 2100-parameter limit, so the
+        # "unlimited" (no-fields) case doesn't match Django's expected large batch size.
+        'backends.base.test_operations.DatabaseOperationTests.test_bulk_batch_size_unlimited',
+
+        # New database-level ON DELETE models (DB_CASCADE/DB_SET_NULL/DB_SET_DEFAULT) are
+        # unsupported on SQL Server (supports_on_delete_db_*=False), so syncdb doesn't
+        # create their tables.
+        'migrations.test_commands.MigrateTests.test_migrate_syncdb_installed_truncated_db_model',
+
+        # SQL Server requires FK columns to match the referenced column's length/scale
+        # (error 1753); altering a PK's type transitively breaks the FK.
+        'migrations.test_operations.OperationTests.test_alter_field_reloads_state_on_transitive_attname_to_field_type_change',
+
+        # Deferrable unique constraints are unsupported on SQL Server
+        # (supports_deferrable_unique_constraints=False); sibling to the existing
+        # test_alter_field_unique_false_removes_deferred_sql exclusion.
+        'migrations.test_operations.OperationTests.test_alter_unique_together_deferred',
+        'migrations.test_operations.OperationTests.test_alter_unique_together_deferred_overlapping_columns',
+    ])
+
 # Django 5.2 specific exclusions
 # These are good candidates for community contributions - see GitHub issues
 if VERSION >= (5, 2):


### PR DESCRIPTION
[AB#46927](https://sqlclientdrivers.visualstudio.com/0103ffdb-aae3-4a4f-92ae-7c538078eca4/_workitems/edit/46927)

GitHub Issue: #551

adds a `VERSION >= (6, 1)` block to `EXCLUDED_TESTS` for 8 Django-suite tests that hit genuine SQL Server behaviors surfaced by 6.1's expanded suite. same mechanism we use for every prior Django version. each entry is commented with the reason and, where applicable, a `TODO` for the backend gaps we can close later.

verified against SQL Server 2022 + Django 6.1rc1:

- `test_exact_booleanfield_annotation` - boolean-expr annotation compiles to `= True` (SQL Server has no native boolean literal). compiler gap, fixable later.
- `test_patterns_escape` - `LIKE` `[ ]` escaping when the pattern is a column reference (`F()`). fixable later.
- `test_key_iexact_none` - JSON key `__iexact=None`. fixable later, same area as prior JSONField work.
- `test_bulk_batch_size_unlimited` - `1000 != 65537`; we cap for SQL Server's 2100-parameter limit (hard limit).
- `test_migrate_syncdb_installed_truncated_db_model` - the new DB-level ON DELETE models, unsupported on SQL Server (error 1785).
- `test_alter_field_reloads_state_on_transitive_attname_to_field_type_change` - FK column length/scale parity (error 1753, hard SQL Server rule).
- `test_alter_unique_together_deferred` (x2) - deferrable unique constraints, unsupported by SQL Server (hard limit).

these keep the full Django suite green on 6.1 via the `ExcludedTestSuiteRunner` (expected-failure) without masking any regression. part of Django 6.1 compatibility support, tracked in #551.
