### PR TITLE
FEAT: Support Django 6.1 - fix remaining quote_name_unless_alias call site

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -599,7 +599,12 @@ class SQLCompiler(compiler.SQLCompiler):
                     order_by = []
                     if do_offset and supports_offset_clause:
                         meta = self.query.get_meta()
-                        qn = self.quote_name_unless_alias
+                        # Django 6.1 deprecated SQLCompiler.quote_name_unless_alias()
+                        # in favour of .quote_name(); the latter doesn't exist before 6.1.
+                        if django.VERSION >= (6, 1):
+                            qn = self.quote_name
+                        else:
+                            qn = self.quote_name_unless_alias
                         result.append(
                             'ORDER BY %s.%s ASC' % (
                                 qn(meta.db_table),

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -341,9 +341,10 @@ if VERSION >= (6, 0):
 # tests. Good candidates for incremental fixes / community contributions.
 if VERSION >= (6, 1):
     EXCLUDED_TESTS.extend([
-        # SQL Server has no native boolean type (supports_comparing_boolean_expr=False),
-        # so a boolean annotation compiles to a CASE compared to a literal. 6.1 added
-        # assertions that such expressions omit the redundant "= True" comparison.
+        # SQL Server has no boolean literal usable in a predicate
+        # (supports_comparing_boolean_expr=False), so a boolean annotation compiles
+        # to a CASE compared to a literal. 6.1 added assertions that such expressions
+        # omit the redundant "= True" comparison.
         # TODO: strip the redundant boolean comparison in the compiler.
         'lookup.tests.LookupTests.test_exact_booleanfield_annotation',
 

--- a/testapp/tests/test_compiler_offset.py
+++ b/testapp/tests/test_compiler_offset.py
@@ -14,6 +14,7 @@ Django's warnings-as-errors test run it broke every sliced/offset query.
 
 import warnings
 
+from django.db.models import Value
 from django.test import TestCase
 
 from testapp.models import Author
@@ -27,18 +28,35 @@ except ImportError:  # older Django versions
 class OffsetOrderingCompilerTests(TestCase):
     """The SQL Server offset ordering path avoids deprecated compiler APIs."""
 
-    def test_sliced_query_does_not_use_deprecated_quote_name(self):
-        Author.objects.bulk_create([Author(name="name%02d" % i) for i in range(6)])
-
+    def _assert_no_deprecated_quote_name(self, queryset):
         with warnings.catch_warnings():
             # Fail if the offset path emits the 6.1 deprecation (i.e. still calls
             # quote_name_unless_alias). Scoped to that specific category so
             # unrelated warnings don't affect the result.
             if RemovedInDjango70Warning is not None:
                 warnings.filterwarnings("error", category=RemovedInDjango70Warning)
-            # A sliced queryset compiles to OFFSET ... FETCH, which triggers the
-            # SQL Server offset ordering path in the compiler.
-            rows = list(Author.objects.order_by("name")[2:5])
+            return list(queryset)
+
+    def test_sliced_query_does_not_use_deprecated_quote_name(self):
+        Author.objects.bulk_create([Author(name="name%02d" % i) for i in range(6)])
+
+        # A sliced queryset compiles to OFFSET ... FETCH, which triggers the
+        # SQL Server offset ordering path in the compiler.
+        rows = self._assert_no_deprecated_quote_name(Author.objects.order_by("name")[2:5])
 
         # Correctness: OFFSET 2, next 3 rows.
         self.assertEqual([a.name for a in rows], ["name02", "name03", "name04"])
+
+    def test_sliced_query_with_constant_ordering_uses_pk_fallback(self):
+        # When the ORDER BY resolves to nothing (here an all-constant ordering),
+        # SQL Server still needs an ORDER BY to offset, so the compiler falls back
+        # to ORDER BY pk. That fallback is a separate quoting call site and must
+        # also avoid the deprecated quote_name_unless_alias on Django 6.1.
+        Author.objects.bulk_create([Author(name="name%02d" % i) for i in range(6)])
+
+        rows = self._assert_no_deprecated_quote_name(
+            Author.objects.order_by(Value(1))[2:5]
+        )
+
+        self.assertEqual(len(rows), 3)
+


### PR DESCRIPTION
[AB#46925](https://sqlclientdrivers.visualstudio.com/0103ffdb-aae3-4a4f-92ae-7c538078eca4/_workitems/edit/46925)

GitHub Issue: #551

follow-up to #555. that PR moved the offset order-by quoting off the 6.1-deprecated `quote_name_unless_alias`, but there is a second call site in the same method that it missed: the `ORDER BY pk` fallback used when a query's ordering resolves to empty (for example an all-constant `order_by` with a slice). Copilot flagged it on #555.

reproduced against SQL Server 2022 + Django 6.1rc1:

```python
list(Author.objects.order_by(Value(1))[2:5])
# RemovedInDjango70Warning: SQLCompiler.quote_name_unless_alias() is deprecated. Use .quote_name() instead.
```

on 6.1 this raises under warnings-as-errors, and on Django 7.0 it becomes an `AttributeError` once the method is removed.

changes:
- apply the same version-gated `quote_name` at the second call site.
- extend the offset regression test with the constant-`order_by` + slice case. fails without this fix (deprecation raised), passes with it.
- reword the boolean test-exclusion comment: SQL Server has a `BIT` type, so the limitation is boolean literals in predicates, not the absence of a boolean type (also raised by Copilot on #557).

part of Django 6.1 compatibility support, tracked in #551.
