### PR TITLE
FEAT: Support Django 6.1 - enable in CI and packaging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,15 @@ jobs:
 
     strategy:
       matrix:
+        Python3.14 - Django 6.1:
+          python.version: '3.14'
+          tox.env: 'py314-django61'
+        Python3.13 - Django 6.1:
+          python.version: '3.13'
+          tox.env: 'py313-django61'
+        Python3.12 - Django 6.1:
+          python.version: '3.12'
+          tox.env: 'py312-django61'
         Python3.14 - Django 6.0:
           python.version: '3.14'
           tox.env: 'py314-django60'
@@ -172,6 +181,15 @@ jobs:
 
     strategy:
       matrix:
+        Python3.14 - Django 6.1:
+          python.version: '3.14'
+          tox.env: 'py314-django61'
+        Python3.13 - Django 6.1:
+          python.version: '3.13'
+          tox.env: 'py313-django61'
+        Python3.12 - Django 6.1:
+          python.version: '3.12'
+          tox.env: 'py312-django61'
         Python3.14 - Django 6.0:
           python.version: '3.14'
           tox.env: 'py314-django60'

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ CLASSIFIERS = [
     'Framework :: Django :: 5.1',
     'Framework :: Django :: 5.2',
     'Framework :: Django :: 6.0',
+    'Framework :: Django :: 6.1',
 ]
 
 this_directory = path.abspath(path.dirname(__file__))
@@ -47,7 +48,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['testapp', 'testapp.*']),
     install_requires=[
-        'django>=3.2,<6.1',
+        'django>=3.2,<6.2',
         'pyodbc>=3.0',
         'pytz',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
        {py310, py311, py312, py313}-django51
        {py310, py311, py312, py313}-django52
        {py312, py313, py314}-django60
+       {py312, py313, py314}-django61
 
 [testenv]
 allowlist_externals =
@@ -31,3 +32,4 @@ deps =
     django51: django>=5.1,<5.2
     django52: django>=5.2,<5.3
     django60: django>=6.0,<6.1
+    django61: django>=6.1,<6.2


### PR DESCRIPTION
[AB#46928](https://sqlclientdrivers.visualstudio.com/0103ffdb-aae3-4a4f-92ae-7c538078eca4/_workitems/edit/46928)

GitHub Issue: #551

capstone for Django 6.1 compatibility support. enables 6.1 (now GA) across CI and packaging, on top of the compatibility fixes already merged (#553, #555, #556, #557, #563).

- tox: new `py{312,313,314}-django61` env, `django>=6.1,<6.2` (resolves to 6.1 GA).
- CI: Django 6.1 matrix rows on both the Windows and Linux jobs (Python 3.12 / 3.13 / 3.14, matching 6.1's `requires-python >= 3.12`).
- packaging: `install_requires` cap lifted to `<6.2` so the tox package install doesn't downgrade Django off 6.1, plus the `Framework :: Django :: 6.1` classifier.

all existing Django versions (3.2 through 6.0) are retained. this is the PR whose CI actually exercises 6.1 end to end; the fix PRs before it were version-gated and inert on the pre-6.1 matrix.
