### PR TITLE
CHORE: gate PR validation on supported Django, run EOL versions on nightly

### DIFF
--- a/azure-pipelines-steps-linux.yml
+++ b/azure-pipelines-steps-linux.yml
@@ -1,0 +1,150 @@
+# Shared build/test steps for the Linux leg of the mssql-django PR-validation pipeline.
+# Included by azure-pipelines.yml from both the Linux_Core (every PR/CI run) and
+# Linux_Legacy (nightly/manual only) jobs so the step definitions stay in one place.
+# The python.version and tox.env variables are supplied per leg by each job's matrix.
+
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: "$(python.version)"
+    displayName: Use Python $(python.version)
+
+  - script: |
+      docker version
+      docker pull mcr.microsoft.com/mssql/server:2025-latest
+      docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=$(TestAppPassword)' -p 1433:1433 -d mcr.microsoft.com/mssql/server:2025-latest
+      curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+      curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+      
+      # Wait for SQL Server to be ready with increased timeout
+      echo "Waiting for SQL Server to start..."
+      
+      # Extended wait for the container to be running and SQL Server service to be listening
+      for i in {1..60}; do
+        if docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2025-latest) 2>&1 | grep -q "SQL Server is now ready for client connections"; then
+          echo "SQL Server service is ready after $i attempts ($(($i * 3)) seconds)"
+          break
+        fi
+        echo "Attempt $i: Waiting for SQL Server service to be ready, checking again in 3 seconds..."
+        sleep 3
+      done
+      
+      # Increased wait to ensure full initialization for database operations
+      echo "Waiting additional 60 seconds for full SQL Server initialization..."
+      sleep 60
+      
+      # Verify we can connect using a simple network test first
+      echo "Testing SQL Server connectivity..."
+      if ! timeout 30 bash -c 'until echo > /dev/tcp/localhost/1433; do sleep 1; done'; then
+        echo "Cannot connect to SQL Server on port 1433"
+        docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2025-latest)
+        exit 1
+      fi
+      
+      echo "SQL Server is ready and accepting connections"
+    displayName: Install SQL Server
+
+  - script: |
+      curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)/packages-microsoft-prod.deb
+      sudo dpkg -i packages-microsoft-prod.deb
+      rm packages-microsoft-prod.deb
+
+      # Add retry logic for handling dpkg lock
+      for i in {1..30}; do
+        echo "Attempt $i of 30 to update packages..."
+        if sudo apt-get update; then
+          break
+        fi
+        echo "Waiting for dpkg lock to be released..."
+        sleep 10
+      done
+      if ! sudo apt-get update; then
+        echo "Failed to update packages after 30 attempts. Exiting."
+        exit 1
+      fi
+
+      # Add retry logic for installing package
+      for i in {1..30}; do
+        echo "Attempt $i of 30 to install ODBC driver..."
+        if sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17; then
+          break
+        fi
+        echo "Waiting for dpkg lock to be released..."
+        sleep 10
+      done
+      # Exit with a non-zero status if installation fails after all retries
+      if ! sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17; then
+        echo "Failed to install ODBC driver after 30 attempts. Exiting."
+        exit 1
+      fi
+    displayName: Install ODBC Driver
+
+  - script: |
+      # Install mssql-tools to get sqlcmd
+      sudo ACCEPT_EULA=Y apt-get install -y mssql-tools
+      
+      # Wait for SQL Server authentication to be ready (retry loop)
+      echo "Waiting for SQL Server authentication to be ready..."
+      export PATH="$PATH:/opt/mssql-tools/bin"
+      
+      # Retry authentication until SQL Server finishes its internal upgrade process
+      for i in {1..30}; do
+        echo "Authentication attempt $i of 30..."
+        # Force IPv4 TCP to avoid potential localhost/IPv6 resolution issues on agents
+        if sqlcmd -S "tcp:127.0.0.1,1433" -U sa -P "$(TestAppPassword)" -Q "SELECT 1 AS test" -l 10 >/dev/null 2>&1; then
+          echo "✅ SQL Server authentication successful after $i attempts!"
+          break
+        else
+          if [ $i -eq 30 ]; then
+            echo "❌ SQL Server authentication FAILED after 30 attempts!"
+            echo "Final attempt with verbose output:"
+            sqlcmd -S "tcp:127.0.0.1,1433" -U sa -P "$(TestAppPassword)" -Q "SELECT 1 AS test" -l 10
+            echo ""
+            echo "Container logs:"
+            docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2025-latest)
+            exit 1
+          else
+            echo "Authentication failed (attempt $i), waiting 10 seconds before retry..."
+            echo "This is normal - SQL Server may still be upgrading internal databases..."
+            sleep 10
+          fi
+        fi
+      done
+      
+      echo "SQL Server is fully ready for authentication!"
+    displayName: Wait for SQL Server Authentication
+
+  - script: |
+      # Since pylibmc isn't supported for Python 3.12+ 
+      # We need to install libmemcached-dev to build it - dependency for Django test suite
+      # https://github.com/django/django/blob/1a744343999c9646912cee76ba0a2fa6ef5e6240/.github/workflows/schedule_tests.yml#L50
+      PYTHON_MINOR=$(python -c "import sys; print(sys.version_info.minor)")
+      if [[ "$PYTHON_MINOR" -ge 12 ]]; then
+        echo "Installing libmemcached-dev for Python 3.12+"
+        sudo apt-get install -y libmemcached-dev
+      fi
+    displayName: Install libmemcached for Python 3.12+
+
+  - script: |
+      python -m pip install --upgrade pip wheel setuptools
+      pip install tox
+      git clone https://github.com/django/django.git
+    displayName: Install Python requirements
+
+  - script: tox -e $(tox.env)
+    displayName: Run tox
+    env:
+      MSSQL_PASSWORD: $(TestAppPassword)
+      MSSQL_HOST: 127.0.0.1
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: 'django/coverage.xml'
+
+  - task: PublishTestResults@2
+    displayName: Publish test results via jUnit
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: 'django/result.xml'
+      testRunTitle: 'junit-$(Agent.OS)-$(Agent.OSArchitecture)-$(tox.env)'

--- a/azure-pipelines-steps-windows.yml
+++ b/azure-pipelines-steps-windows.yml
@@ -1,0 +1,47 @@
+# Shared build/test steps for the Windows leg of the mssql-django PR-validation pipeline.
+# Included by azure-pipelines.yml from both the Windows_Core (every PR/CI run) and
+# Windows_Legacy (nightly/manual only) jobs so the step definitions stay in one place.
+# The python.version and tox.env variables are supplied per leg by each job's matrix.
+
+steps:
+  - task: CredScan@3
+    inputs:
+      toolMajorVersion: 'V2'
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: "$(python.version)"
+    displayName: Use Python $(python.version)
+
+  - powershell: |
+      $IP=Get-NetIPAddress -AddressFamily IPv4 -InterfaceIndex $(Get-NetConnectionProfile -IPv4Connectivity Internet | Select-Object -ExpandProperty InterfaceIndex) | Select-Object -ExpandProperty IPAddress
+
+      (Get-Content $pwd/testapp/settings.py).replace('localhost', $IP) | Set-Content $pwd/testapp/settings.py
+
+      Invoke-WebRequest https://download.microsoft.com/download/6/f/f/6ffefc73-39ab-4cc0-bb7c-4093d64c2669/en-US/17.10.5.1/x64/msodbcsql.msi -OutFile msodbcsql.msi
+      msiexec /quiet /passive /qn /i msodbcsql.msi IACCEPTMSODBCSQLLICENSETERMS=YES
+      Get-OdbcDriver
+    displayName: Install ODBC
+
+  - powershell: |
+      Import-Module "sqlps"
+      Invoke-Sqlcmd @"
+          EXEC xp_instance_regwrite N'HKEY_LOCAL_MACHINE', N'Software\Microsoft\MSSQLServer\MSSQLServer', N'LoginMode', REG_DWORD, 2
+          ALTER LOGIN [sa] ENABLE;
+          ALTER LOGIN [sa] WITH PASSWORD = '$(TestAppPassword)', CHECK_POLICY=OFF;
+      "@
+    displayName: Set up SQL Server
+
+  - powershell: |
+      Restart-Service -Name MSSQLSERVER -Force
+    displayName: Restart SQL Server
+
+  - powershell: |
+      python -m pip install --upgrade pip wheel setuptools
+      python -m pip install tox
+      git clone https://github.com/django/django.git
+
+      python -m tox -e $(tox.env)
+    displayName: Run tox
+    env:
+      MSSQL_PASSWORD: $(TestAppPassword)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,15 @@
+# PR-validation pipeline for mssql-django (runs on Azure DevOps, not GitHub Actions).
+#
+# The matrix is split into two tiers so pull requests stay fast without losing coverage:
+#   * Core jobs (Windows_Core / Linux_Core) run on every PR and CI build. They cover the
+#     Django versions still supported upstream today: 5.2 (LTS), 6.0.
+#   * Legacy jobs (Windows_Legacy / Linux_Legacy) cover end-of-life Django versions
+#     (3.2, 4.0, 4.1, 4.2, 5.0, 5.1). These only run on the nightly schedule (or a manual
+#     queue), so we keep full historical coverage without crowding every PR run.
+#
+# The per-leg build/test steps live in azure-pipelines-steps-windows.yml and
+# azure-pipelines-steps-linux.yml so the Core and Legacy jobs share one definition.
+
 trigger:
   - dev
 
@@ -15,7 +27,8 @@ schedules:
   always: true
 
 jobs:
-  - job: Windows
+  - job: Windows_Core
+    displayName: Windows (supported Django)
     pool:
       name: Django-1ES-pool
       demands:
@@ -33,7 +46,6 @@ jobs:
         Python3.12 - Django 6.0:
           python.version: '3.12'
           tox.env: 'py312-django60'
-
         Python3.13 - Django 5.2:
           python.version: '3.13'
           tox.env: 'py313-django52'
@@ -47,6 +59,20 @@ jobs:
           python.version: '3.10'
           tox.env: 'py310-django52'
 
+    steps:
+      - template: azure-pipelines-steps-windows.yml
+
+  - job: Windows_Legacy
+    displayName: Windows (EOL Django, nightly)
+    condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
+    pool:
+      name: Django-1ES-pool
+      demands:
+      - imageOverride -equals JDBC-MMS2025-SQL2025
+    timeoutInMinutes: 120
+
+    strategy:
+      matrix:
         Python3.13 - Django 5.1:
           python.version: '3.13'
           tox.env: 'py313-django51'
@@ -59,7 +85,6 @@ jobs:
         Python3.10 - Django 5.1:
           python.version: '3.10'
           tox.env: 'py310-django51'
-
         Python3.12 - Django 5.0:
           python.version: '3.12'
           tox.env: 'py312-django50'
@@ -69,7 +94,6 @@ jobs:
         Python3.10 - Django 5.0:
           python.version: '3.10'
           tox.env: 'py310-django50'
-
         Python3.11 - Django 4.2:
           python.version: '3.11'
           tox.env: 'py311-django42'
@@ -82,7 +106,6 @@ jobs:
         Python 3.8 - Django 4.2:
           python.version: '3.8'
           tox.env: 'py38-django42'
-
         Python3.11 - Django 4.1:
           python.version: '3.11'
           tox.env: 'py311-django41'
@@ -95,7 +118,6 @@ jobs:
         Python 3.8 - Django 4.1:
           python.version: '3.8'
           tox.env: 'py38-django41'
-
         Python3.11 - Django 4.0:
           python.version: '3.11'
           tox.env: 'py311-django40'
@@ -108,7 +130,6 @@ jobs:
         Python 3.8 - Django 4.0:
           python.version: '3.8'
           tox.env: 'py38-django40'
-
         Python3.11 - Django 3.2:
           python.version: '3.11'
           tox.env: 'py311-django32'
@@ -119,51 +140,11 @@ jobs:
           python.version: '3.8'
           tox.env: 'py38-django32'
 
-
     steps:
-      - task: CredScan@3
-        inputs:
-          toolMajorVersion: 'V2'
+      - template: azure-pipelines-steps-windows.yml
 
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: "$(python.version)"
-        displayName: Use Python $(python.version)
-
-      - powershell: |
-          $IP=Get-NetIPAddress -AddressFamily IPv4 -InterfaceIndex $(Get-NetConnectionProfile -IPv4Connectivity Internet | Select-Object -ExpandProperty InterfaceIndex) | Select-Object -ExpandProperty IPAddress
-
-          (Get-Content $pwd/testapp/settings.py).replace('localhost', $IP) | Set-Content $pwd/testapp/settings.py
-
-          Invoke-WebRequest https://download.microsoft.com/download/6/f/f/6ffefc73-39ab-4cc0-bb7c-4093d64c2669/en-US/17.10.5.1/x64/msodbcsql.msi -OutFile msodbcsql.msi
-          msiexec /quiet /passive /qn /i msodbcsql.msi IACCEPTMSODBCSQLLICENSETERMS=YES
-          Get-OdbcDriver
-        displayName: Install ODBC
-
-      - powershell: |
-          Import-Module "sqlps"
-          Invoke-Sqlcmd @"
-              EXEC xp_instance_regwrite N'HKEY_LOCAL_MACHINE', N'Software\Microsoft\MSSQLServer\MSSQLServer', N'LoginMode', REG_DWORD, 2
-              ALTER LOGIN [sa] ENABLE;
-              ALTER LOGIN [sa] WITH PASSWORD = '$(TestAppPassword)', CHECK_POLICY=OFF;
-          "@
-        displayName: Set up SQL Server
-
-      - powershell: |
-          Restart-Service -Name MSSQLSERVER -Force
-        displayName: Restart SQL Server
-
-      - powershell: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install tox
-          git clone https://github.com/django/django.git
-
-          python -m tox -e $(tox.env)
-        displayName: Run tox
-        env:
-          MSSQL_PASSWORD: $(TestAppPassword)
-
-  - job: Linux
+  - job: Linux_Core
+    displayName: Linux (supported Django)
     pool:
       name: Django-1ES-pool
       demands:
@@ -181,7 +162,6 @@ jobs:
         Python3.12 - Django 6.0:
           python.version: '3.12'
           tox.env: 'py312-django60'
-
         Python3.13 - Django 5.2:
           python.version: '3.13'
           tox.env: 'py313-django52'
@@ -195,6 +175,20 @@ jobs:
           python.version: '3.10'
           tox.env: 'py310-django52'
 
+    steps:
+      - template: azure-pipelines-steps-linux.yml
+
+  - job: Linux_Legacy
+    displayName: Linux (EOL Django, nightly)
+    condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))
+    pool:
+      name: Django-1ES-pool
+      demands:
+      - imageOverride -equals Ubuntu22.04-AzurePipelines
+    timeoutInMinutes: 120
+
+    strategy:
+      matrix:
         Python3.13 - Django 5.1:
           python.version: '3.13'
           tox.env: 'py313-django51'
@@ -207,7 +201,6 @@ jobs:
         Python3.10 - Django 5.1:
           python.version: '3.10'
           tox.env: 'py310-django51'
-
         Python3.12 - Django 5.0:
           python.version: '3.12'
           tox.env: 'py312-django50'
@@ -217,7 +210,6 @@ jobs:
         Python3.10 - Django 5.0:
           python.version: '3.10'
           tox.env: 'py310-django50'
-
         Python3.11 - Django 4.2:
           python.version: '3.11'
           tox.env: 'py311-django42'
@@ -230,7 +222,6 @@ jobs:
         Python 3.8 - Django 4.2:
           python.version: '3.8'
           tox.env: 'py38-django42'
-
         Python3.11 - Django 4.1:
           python.version: '3.11'
           tox.env: 'py311-django41'
@@ -243,7 +234,6 @@ jobs:
         Python 3.8 - Django 4.1:
           python.version: '3.8'
           tox.env: 'py38-django41'
-
         Python3.11 - Django 4.0:
           python.version: '3.11'
           tox.env: 'py311-django40'
@@ -256,7 +246,6 @@ jobs:
         Python 3.8 - Django 4.0:
           python.version: '3.8'
           tox.env: 'py38-django40'
-
         Python3.11 - Django 3.2:
           python.version: '3.11'
           tox.env: 'py311-django32'
@@ -268,147 +257,4 @@ jobs:
           tox.env: 'py38-django32'
 
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: "$(python.version)"
-        displayName: Use Python $(python.version)
-
-      - script: |
-          docker version
-          docker pull mcr.microsoft.com/mssql/server:2025-latest
-          docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=$(TestAppPassword)' -p 1433:1433 -d mcr.microsoft.com/mssql/server:2025-latest
-          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
-          
-          # Wait for SQL Server to be ready with increased timeout
-          echo "Waiting for SQL Server to start..."
-          
-          # Extended wait for the container to be running and SQL Server service to be listening
-          for i in {1..60}; do
-            if docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2025-latest) 2>&1 | grep -q "SQL Server is now ready for client connections"; then
-              echo "SQL Server service is ready after $i attempts ($(($i * 3)) seconds)"
-              break
-            fi
-            echo "Attempt $i: Waiting for SQL Server service to be ready, checking again in 3 seconds..."
-            sleep 3
-          done
-          
-          # Increased wait to ensure full initialization for database operations
-          echo "Waiting additional 60 seconds for full SQL Server initialization..."
-          sleep 60
-          
-          # Verify we can connect using a simple network test first
-          echo "Testing SQL Server connectivity..."
-          if ! timeout 30 bash -c 'until echo > /dev/tcp/localhost/1433; do sleep 1; done'; then
-            echo "Cannot connect to SQL Server on port 1433"
-            docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2025-latest)
-            exit 1
-          fi
-          
-          echo "SQL Server is ready and accepting connections"
-        displayName: Install SQL Server
-
-      - script: |
-          curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)/packages-microsoft-prod.deb
-          sudo dpkg -i packages-microsoft-prod.deb
-          rm packages-microsoft-prod.deb
-
-          # Add retry logic for handling dpkg lock
-          for i in {1..30}; do
-            echo "Attempt $i of 30 to update packages..."
-            if sudo apt-get update; then
-              break
-            fi
-            echo "Waiting for dpkg lock to be released..."
-            sleep 10
-          done
-          if ! sudo apt-get update; then
-            echo "Failed to update packages after 30 attempts. Exiting."
-            exit 1
-          fi
-
-          # Add retry logic for installing package
-          for i in {1..30}; do
-            echo "Attempt $i of 30 to install ODBC driver..."
-            if sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17; then
-              break
-            fi
-            echo "Waiting for dpkg lock to be released..."
-            sleep 10
-          done
-          # Exit with a non-zero status if installation fails after all retries
-          if ! sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17; then
-            echo "Failed to install ODBC driver after 30 attempts. Exiting."
-            exit 1
-          fi
-        displayName: Install ODBC Driver
-
-      - script: |
-          # Install mssql-tools to get sqlcmd
-          sudo ACCEPT_EULA=Y apt-get install -y mssql-tools
-          
-          # Wait for SQL Server authentication to be ready (retry loop)
-          echo "Waiting for SQL Server authentication to be ready..."
-          export PATH="$PATH:/opt/mssql-tools/bin"
-          
-          # Retry authentication until SQL Server finishes its internal upgrade process
-          for i in {1..30}; do
-            echo "Authentication attempt $i of 30..."
-            # Force IPv4 TCP to avoid potential localhost/IPv6 resolution issues on agents
-            if sqlcmd -S "tcp:127.0.0.1,1433" -U sa -P "$(TestAppPassword)" -Q "SELECT 1 AS test" -l 10 >/dev/null 2>&1; then
-              echo "✅ SQL Server authentication successful after $i attempts!"
-              break
-            else
-              if [ $i -eq 30 ]; then
-                echo "❌ SQL Server authentication FAILED after 30 attempts!"
-                echo "Final attempt with verbose output:"
-                sqlcmd -S "tcp:127.0.0.1,1433" -U sa -P "$(TestAppPassword)" -Q "SELECT 1 AS test" -l 10
-                echo ""
-                echo "Container logs:"
-                docker logs $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2025-latest)
-                exit 1
-              else
-                echo "Authentication failed (attempt $i), waiting 10 seconds before retry..."
-                echo "This is normal - SQL Server may still be upgrading internal databases..."
-                sleep 10
-              fi
-            fi
-          done
-          
-          echo "SQL Server is fully ready for authentication!"
-        displayName: Wait for SQL Server Authentication
-
-      - script: |
-          # Since pylibmc isn't supported for Python 3.12+ 
-          # We need to install libmemcached-dev to build it - dependency for Django test suite
-          # https://github.com/django/django/blob/1a744343999c9646912cee76ba0a2fa6ef5e6240/.github/workflows/schedule_tests.yml#L50
-          PYTHON_MINOR=$(python -c "import sys; print(sys.version_info.minor)")
-          if [[ "$PYTHON_MINOR" -ge 12 ]]; then
-            echo "Installing libmemcached-dev for Python 3.12+"
-            sudo apt-get install -y libmemcached-dev
-          fi
-        displayName: Install libmemcached for Python 3.12+
-
-      - script: |
-          python -m pip install --upgrade pip wheel setuptools
-          pip install tox
-          git clone https://github.com/django/django.git
-        displayName: Install Python requirements
-
-      - script: tox -e $(tox.env)
-        displayName: Run tox
-        env:
-          MSSQL_PASSWORD: $(TestAppPassword)
-          MSSQL_HOST: 127.0.0.1
-
-      - task: PublishCodeCoverageResults@1
-        inputs:
-          codeCoverageTool: 'Cobertura'
-          summaryFileLocation: 'django/coverage.xml'
-
-      - task: PublishTestResults@2
-        displayName: Publish test results via jUnit
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: 'django/result.xml'
-          testRunTitle: 'junit-$(Agent.OS)-$(Agent.OSArchitecture)-$(tox.env)'
+      - template: azure-pipelines-steps-linux.yml


### PR DESCRIPTION
## What

Splits the PR-validation matrix into two tiers:

- **Core** (`Windows_Core` / `Linux_Core`) runs on every PR and CI build. It covers the Django versions still supported upstream today: 5.2 (LTS) and 6.0.
- **Legacy** (`Windows_Legacy` / `Linux_Legacy`) covers the end of life versions 3.2, 4.0, 4.1, 4.2, 5.0 and 5.1. These run only on the nightly schedule (or a manual queue), gated with `condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual'))`.

The per-leg build/test steps move into `azure-pipelines-steps-windows.yml` and `azure-pipelines-steps-linux.yml` so the Core and Legacy jobs share one step definition instead of duplicating ~150 lines of setup shell.

## Why

The matrix had grown to 29 legs per OS (58 total) on every PR, and more than half of that is Django versions that are end of life upstream. Gating PRs on the currently supported set keeps the fast feedback lean while the nightly still exercises the full history.

Support status as of today (per endoflife.date):

| Django | EOL (incl. security) | Tier |
|---|---|---|
| 6.0 | 2027-04-30 | Core |
| 5.2 (LTS) | 2028-04-30 | Core |
| 5.1 | 2025-12-03 | Legacy (EOL) |
| 5.0 | 2025-04-02 | Legacy (EOL) |
| 4.2 (LTS) | 2026-04-07 | Legacy (EOL) |
| 4.1, 4.0, 3.2 | <= 2023 | Legacy (EOL) |

## Coverage is not dropped

This changes *when* the old versions run, not *whether*. `setup.py` and `tox.ini` are untouched, so we still declare and test Django 3.2 through 6.0. The full matrix runs nightly (`always: true`) and on manual queue.

## Legs per run

| | Per OS | Total (Win + Linux) |
|---|---|---|
| Before, every PR | 29 | 58 |
| After, per PR (Core) | 7 | 14 |
| After, nightly (Core + Legacy) | 29 | 58 |

Django 6.1 is not on `dev` yet; it joins the Core tier via #564, taking Core to 10 legs per OS (20 total).
