### PR TITLE
CHORE: harden OneBranch artifact handoff + TSA bug template

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -9,6 +9,7 @@
   "repositoryName": "mssql-django",
   "codebaseName": "Django Backend for Microsoft SQL Server",
   "allTools": true,
+  "template": "MSDATA_RevolutionR",
   "includePathPatterns": "mssql/*, setup.py",
   "excludePathPatterns": "testapp/*, django/*, OneBranchPipelines/*"
 }

--- a/OneBranchPipelines/build-release-package-pipeline.yml
+++ b/OneBranchPipelines/build-release-package-pipeline.yml
@@ -85,7 +85,9 @@ extends:
               - imageOverride -equals Ubuntu22.04-AzurePipelines
 
             variables:
-              # OneBranch auto-publishes this directory as the 'drop' artifact.
+              # Wheel + sdist are staged under $(ob_outputDirectory)/dist and published
+              # explicitly as the 'drop_build_build' artifact (see PublishPipelineArtifact
+              # below) so the release pipelines consume a known artifact name + path.
               ob_outputDirectory: '$(Build.SourcesDirectory)/out'
 
             steps:
@@ -137,13 +139,17 @@ extends:
                     cd "$(Build.SourcesDirectory)"
                     python -m pip install --upgrade pip build
                     python -m build
-                    mkdir -p "$(Build.SourcesDirectory)/out"
-                    cp -v "$(Build.SourcesDirectory)"/dist/* "$(Build.SourcesDirectory)/out/"
+                    mkdir -p "$(Build.SourcesDirectory)/out/dist"
+                    cp -v "$(Build.SourcesDirectory)"/dist/* "$(Build.SourcesDirectory)/out/dist/"
                     echo "=== packaged artifacts ==="
-                    ls -la "$(Build.SourcesDirectory)/out"
+                    ls -la "$(Build.SourcesDirectory)/out/dist"
 
-              - task: ManifestGeneratorTask@0
-                displayName: 'Generate SBOM'
+              # Publish wheel + sdist as an explicitly-named artifact so the official/dummy
+              # release pipelines consume a known name + path ($(ob_outputDirectory)/dist).
+              # SBOM is generated automatically by the OneBranch Official template
+              # (globalSdl.sbom.enabled) - no explicit ManifestGeneratorTask needed.
+              - task: PublishPipelineArtifact@1
+                displayName: 'Publish drop_build_build'
                 inputs:
-                  BuildDropPath: '$(Build.SourcesDirectory)/out'
-                  PackageName: '$(PACKAGE_NAME)'
+                  targetPath: '$(ob_outputDirectory)'
+                  artifact: 'drop_build_build'

--- a/OneBranchPipelines/dummy-release-pipeline.yml
+++ b/OneBranchPipelines/dummy-release-pipeline.yml
@@ -69,7 +69,7 @@ extends:
                   targetType: 'inline'
                   script: |
                     set -euo pipefail
-                    DIST="$(Pipeline.Workspace)/buildPipeline/drop_build_build"
+                    DIST="$(Pipeline.Workspace)/buildPipeline/drop_build_build/dist"
                     echo "=== [TEST] artifact contents ==="
                     ls -la "$DIST"
 
@@ -98,7 +98,7 @@ extends:
                     Intent: 'PackageDistribution'
                     ContentType: 'Maven'   # placeholder - deliberately NOT PyPI
                     ContentSource: 'Folder'
-                    FolderLocation: '$(Pipeline.Workspace)/buildPipeline/drop_build_build'
+                    FolderLocation: '$(Pipeline.Workspace)/buildPipeline/drop_build_build/dist'
                     WaitForReleaseCompletion: true
                     Owners: '$(owner)'
                     Approvers: '$(approver)'

--- a/OneBranchPipelines/official-release-pipeline.yml
+++ b/OneBranchPipelines/official-release-pipeline.yml
@@ -75,7 +75,7 @@ extends:
                   targetType: 'inline'
                   script: |
                     set -euo pipefail
-                    DIST="$(Pipeline.Workspace)/buildPipeline/drop_build_build"
+                    DIST="$(Pipeline.Workspace)/buildPipeline/drop_build_build/dist"
                     echo "=== artifact contents ==="
                     ls -la "$DIST"
                     test -n "$(find "$DIST" -name '*.whl' -o -name '*.tar.gz')" \
@@ -118,7 +118,7 @@ extends:
                     Intent: 'PackageDistribution'
                     ContentType: 'PyPI'
                     ContentSource: 'Folder'
-                    FolderLocation: '$(Pipeline.Workspace)/buildPipeline/drop_build_build'
+                    FolderLocation: '$(Pipeline.Workspace)/buildPipeline/drop_build_build/dist'
                     WaitForReleaseCompletion: true
                     Owners: '$(owner)'
                     Approvers: '$(approver)'


### PR DESCRIPTION
Follow-up chore on the OneBranch pipeline series. Removes the artifact-handoff fragility and aligns to the mssql-python conventions.

## Changes
- **Build** — stage sdist/wheel under `$(ob_outputDirectory)/dist` and publish them as an explicitly-named `drop_build_build` artifact (`PublishPipelineArtifact@1`). Removes reliance on OneBranch auto-publish naming. Also drops the redundant `ManifestGeneratorTask` — the OneBranch Official template already generates the SBOM via `globalSdl.sbom`.
- **Official + Dummy** — point the artifact verify step and the ESRP `FolderLocation` at `drop_build_build/dist`, so the release pipelines consume the exact directory the build publishes (known name + path, no guessing).
- **tsaoptions.json** — add `"template": "MSDATA_RevolutionR"`, the `mssql-django` ADO project's existing TSA bug-template mapping, so the first Official build can onboard the TSA codebase cleanly.

No product code changes. Pipelines only.
