### PR TITLE
RELEASE: 1.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='mssql-django',
-    version='1.7.4',
+    version='1.8.0',
     description='Django backend for Microsoft SQL Server',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Bump version to 1.8.0 for the Django 6.1 compatibility release.

All Django 6.1 backend support and CI enablement is already merged to `dev` (features, compiler, introspection, test exclusions, regression tests, and the CI/packaging capstone). This PR is the version bump only.

GitHub Issue: #551
