### PR TITLE
RELEASE: 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This project is the continuation and evolution of earlier community efforts, and
 
 | Component | Supported Versions |
 |---|---|
-| Django | 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0 |
-| Python | 3.8 – 3.14 (Django 6.0 requires 3.12+) |
+| Django | 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0, 6.1 |
+| Python | 3.8 – 3.14 (Django 6.0 and 6.1 require 3.12+) |
 | SQL Server | 2016, 2017, 2019, 2022, 2025 |
 | Azure SQL | Database, Managed Instance, SQL Database in Microsoft Fabric |
 | ODBC Driver | Microsoft ODBC Driver 17 or 18 for SQL Server |
@@ -114,6 +114,7 @@ The following limitations apply when using SQL Server with Django:
 | Django 5.1 | Minor limitations with composite primary key inspection via `inspectdb` |
 | Django 5.2 | Tuple lookups require Django 5.2.4+ for full support. Some JSONField bulk/CASE WHEN update edge cases. See [test exclusions](https://github.com/microsoft/mssql-django/blob/dev/testapp/settings.py) for details. |
 | Django 6.0 | Requires Python 3.12+. All 5.2 limitations apply. Backend handles all 6.0 API changes transparently. |
+| Django 6.1 | Requires Python 3.12+. All 6.0 limitations apply. Two 6.1 additions are unavailable: database-level referential actions (`DB_CASCADE`, `DB_SET_NULL`, `DB_SET_DEFAULT`) are not supported because SQL Server disallows multiple cascade paths to the same table, so using one raises a Django system check (`fields.E324`) that points you to the standard Django-level `on_delete`; and bitwise aggregates (`BitAnd`, `BitOr`, `BitXor`) are not implemented by this backend and raise `NotSupportedError`. See [test exclusions](https://github.com/microsoft/mssql-django/blob/dev/testapp/settings.py) for details. |
 
 JSONField lookups have additional limitations — see the [JSONField wiki page](https://github.com/microsoft/mssql-django/wiki/JSONField).
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='mssql-django',
-    version='1.7.4',
+    version='1.8.0',
     description='Django backend for Microsoft SQL Server',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# mssql-django 1.8.0

This release adds support for **Django 6.1**.

Django 6.1 introduced backend changes that required updates to the SQL Server backend. This release makes mssql-django compatible with Django 6.1 while continuing to support Django 3.2 through 6.0. No changes are required in your project beyond upgrading, unless you use one of the newly declined 6.1 features noted under Limitations.

## Supported versions

| Component | Supported |
| --- | --- |
| Django | 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0, 6.1 |
| Python | 3.8 - 3.14 (Django 6.0 and 6.1 require Python 3.12+) |
| SQL Server | 2016, 2017, 2019, 2022, 2025 |
| Azure SQL | Database, Managed Instance, SQL Database in Microsoft Fabric |

## What changed for Django 6.1

- **Query compiler**: Django 6.1 deprecated `quote_name_unless_alias`. The backend now uses `SQLCompiler.quote_name` on Django 6.1+, so sliced and offset queries compile without deprecation warnings.
- **Foreign key introspection**: Django 6.1 changed the shape of `get_relations()` to include the database-level ON DELETE rule. The backend now returns the expected structure, so `inspectdb` and related introspection work correctly.
- **Feature flags**: The backend declines the two Django 6.1 capabilities that SQL Server does not provide (see Limitations), so the affected Django test cases are skipped rather than failing.

## Limitations on Django 6.1

Two features added in Django 6.1 are not available on the SQL Server backend:

- **Database-level referential actions** (`DB_CASCADE`, `DB_SET_NULL`, `DB_SET_DEFAULT`). SQL Server disallows multiple cascade paths to the same table, so these are not supported. Using one raises a Django system check (`fields.E324`) that points you to the standard Django-level `on_delete`.
- **Bitwise aggregates** (`BitAnd`, `BitOr`, `BitXor`). SQL Server has no native bitwise aggregate function, so these raise `NotSupportedError`.

Full details are documented in the README, and the specific skipped tests are listed in `testapp/settings.py`.

## Upgrading

```
pip install --upgrade mssql-django
```

## Notes

- This PR is the version bump (1.7.4 to 1.8.0) only. All Django 6.1 backend support is already merged to `dev`.
- Documentation for the 6.1 changes is in the companion docs PR.

[AB#44002](https://sqlclientdrivers.visualstudio.com/0103ffdb-aae3-4a4f-92ae-7c538078eca4/_workitems/edit/44002)

GitHub Issue: #551
