### PR TITLE
FIX: escape '[' wildcard in F() expression pattern lookups

### DIFF
--- a/mssql/base.py
+++ b/mssql/base.py
@@ -181,7 +181,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     #
     # Note: we use str.format() here for readability as '%' is used as a wildcard for
     # the LIKE operator.
-    pattern_esc = r"REPLACE(REPLACE(REPLACE({}, '\', '[\]'), '%%', '[%%]'), '_', '[_]')"
+    pattern_esc = r"REPLACE(REPLACE(REPLACE(REPLACE({}, '[', '[[]'), '\', '[\]'), '%%', '[%%]'), '_', '[_]')"
     pattern_ops = {
         'contains': "LIKE '%%' + {} + '%%'",
         'icontains': "LIKE '%%' + UPPER({}) + '%%'",

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -348,11 +348,6 @@ if VERSION >= (6, 1):
         # TODO: strip the redundant boolean comparison in the compiler.
         'lookup.tests.LookupTests.test_exact_booleanfield_annotation',
 
-        # SQL Server LIKE treats [ ] as a character-class wildcard; escaping a column
-        # reference (F()) used as a LIKE pattern doesn't cover the bracket case.
-        # TODO: escape []-wildcards for column-referencing __contains/__startswith.
-        'expressions.tests.ExpressionsTests.test_patterns_escape',
-
         # JSON key __iexact=None semantics (no native JSON null handling on SQL Server);
         # sibling to the existing JSONField exclusions.
         'model_fields.test_jsonfield.TestQuerying.test_key_iexact_none',

--- a/testapp/tests/test_expressions.py
+++ b/testapp/tests/test_expressions.py
@@ -14,7 +14,7 @@ from django.db.models.aggregates import Count, Sum
 if VERSION >= (6, 0):
     from django.db.models import StringAgg
 
-from ..models import Author, Book, Comment, Post, Editor, ModelWithNullableFieldsOfDifferentTypes, Publisher
+from ..models import Author, Book, Comment, Post, Editor, ModelWithNullableFieldsOfDifferentTypes, Publisher, TestNullableUniqueTogetherModel
 
 
 DJANGO3 = VERSION[0] >= 3
@@ -214,6 +214,29 @@ class TestStringAggOrderingRegression(TestCase):
 
         self.assertEqual(values, ['Alpha'])
         self.assertNotIn('WITHIN GROUP', ctx[0]['sql'])
+
+
+class TestPatternLookupExpressionEscaping(TestCase):
+    """
+    Regression tests for https://github.com/microsoft/mssql-django/issues/573
+
+    Pattern lookups (contains/startswith/endswith) whose search term comes
+    from a column reference (F()) must escape SQL Server's '[' character-class
+    wildcard, matching the escaping already applied to literal patterns.
+    """
+
+    def setUp(self):
+        TestNullableUniqueTogetherModel.objects.create(a="Johnny", b="[J]ohnny", c="1")
+        self.john = TestNullableUniqueTogetherModel.objects.create(a="Johnny", b="John", c="2")
+        self.bracketed = TestNullableUniqueTogetherModel.objects.create(a="[J]ohnny", b="[J]ohnny", c="3")
+
+    def test_contains_with_f_expression_escapes_brackets(self):
+        qs = TestNullableUniqueTogetherModel.objects.filter(a__contains=F("b"))
+        self.assertCountEqual(qs, [self.john, self.bracketed])
+
+    def test_startswith_with_f_expression_escapes_brackets(self):
+        qs = TestNullableUniqueTogetherModel.objects.filter(a__startswith=F("b"))
+        self.assertCountEqual(qs, [self.john, self.bracketed])
 
 
 class TestSubtractTemporals(TestCase):


### PR DESCRIPTION
Adds bracket escaping to `DatabaseWrapper.pattern_esc`, which is applied to `__contains`, `__startswith`, `__endswith` and their case-insensitive variants when the search term comes from an `F()` expression (column reference).

`[` is the SQL Server LIKE character-class wildcard. Before this change, values containing `[` were matched as a character class, so a row like `firstname='[J]ohnny'` matched `firstname__contains=F("lastname")` where `lastname='[J]ohnny'` — silently wrong results. `]` outside a character class is already literal in SQL Server LIKE and needs no escaping.

```python
# before
pattern_esc = r"REPLACE(REPLACE(REPLACE({}, '\', '[\]'), '%%', '[%%]'), '_', '[_]')"

# after
pattern_esc = r"REPLACE(REPLACE(REPLACE(REPLACE({}, '[', '[[]'), '\', '[\]'), '%%', '[%%]'), '_', '[_]')"
```

Mirrors the existing literal-term escaping in `DatabaseOperations.prep_for_like_query`, which already escapes `[` as `[[]`.

Adds regression tests for `__contains` and `__startswith` with an `F()` expression, and removes the `expressions.tests.ExpressionsTests.test_patterns_escape` exclusion from the test settings (it now passes).

Tested with:

```
python manage.py test testapp.tests.test_expressions.TestPatternLookupExpressionEscaping --noinput
python django/tests/runtests.py --settings=testapp.settings --noinput expressions.tests.ExpressionsTests.test_patterns_escape
```

Fixes #573