### PR TITLE
AI: add AGENTS.md and path-scoped review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@ mssql/                  # Core backend implementation (~4400 lines)
         └── install_regex_clr.py  # CLR assembly for REGEXP_LIKE support
 
 testapp/               # Unit tests for the backend
-├── tests/             # 42 unit tests across 11 test files
+├── tests/             # 214 tests across 15 test files
 ├── settings.py        # Test configuration with EXCLUDED_TESTS
 └── models.py          # Test models
 
@@ -59,7 +59,7 @@ django/                # NOT in repo — cloned at runtime by test.sh for full t
 
 **mssql/features.py** - Declares what SQL Server supports/doesn't support. Check here first when a test fails to see if it's a known limitation.
 
-**testapp/settings.py** - Contains `EXCLUDED_TESTS` list for Django tests that cannot pass due to SQL Server limitations (not bugs). Includes version-gated exclusions (e.g., ~75 tests excluded for Django 6.0).
+**testapp/settings.py** - Contains `EXCLUDED_TESTS` list for Django tests that cannot pass due to SQL Server limitations (not bugs). Includes version-gated blocks (`if VERSION >= (X, Y):`) spanning Django 3.1 through 6.1.
 
 ## Coding Patterns
 
@@ -101,7 +101,7 @@ EXCLUDED_TESTS = [
 
 ## Testing
 
-### Run mssql-django unit tests (42 tests)
+### Run mssql-django unit tests (214 tests)
 ```bash
 python manage.py test testapp.tests
 ```
@@ -120,7 +120,7 @@ cd django && python tests/runtests.py --settings=testapp.settings <module>
 
 ## Version Compatibility
 
-- **Django**: 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0
+- **Django**: 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0, 6.1
 - **Python**: 3.8 – 3.14
 - **SQL Server**: 2017, 2019, 2022, 2025; Azure SQL DB / Managed Instance
 - **ODBC Driver**: 17 or 18 for SQL Server

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,12 @@
 
 mssql-django is a Django database backend for Microsoft SQL Server. It enables Django applications to use SQL Server as their database by translating Django's database abstraction layer to SQL Server's T-SQL dialect.
 
+## How these instructions are organized
+
+- **This file** is the repository-wide technical reference: SQL Server limitations, coding patterns, common errors, and testing commands.
+- **`AGENTS.md`** holds project facts, contribution conventions, and cross-cutting review judgment.
+- **`.github/instructions/*.instructions.md`** hold path-specific review checks, loaded automatically only when a matching file changes.
+
 ## Repository Structure
 
 ```
@@ -57,7 +63,7 @@ django/                # NOT in repo — cloned at runtime by test.sh for full t
 
 **mssql/functions.py** (~673 lines) - Uses the `as_microsoft` monkey-patching pattern (see Coding Patterns below). Also handles parameter limit splitting via temp tables for large IN clauses.
 
-**mssql/features.py** - Declares what SQL Server supports/doesn't support. Check here first when a test fails to see if it's a known limitation.
+**mssql/features.py** - Declares what SQL Server supports/doesn't support. Check here first when a test fails to see if it's a known limitation. On a new Django minor, diff Django's `BaseDatabaseFeatures` and override any newly added `supports_*` flags SQL Server can't honor.
 
 **testapp/settings.py** - Contains `EXCLUDED_TESTS` list for Django tests that cannot pass due to SQL Server limitations (not bugs). Includes version-gated blocks (`if VERSION >= (X, Y):`) spanning Django 3.1 through 6.1.
 
@@ -95,6 +101,7 @@ EXCLUDED_TESTS = [
     'app.test_module.TestClass.test_method',  # Brief reason
 ]
 ```
+State whether the reason is a permanent platform limitation or an unimplemented capability — the comment is documentation future maintainers rely on.
 
 ### Regex Support
 `python manage.py install_regex_clr <database>` installs a CLR assembly enabling `REGEXP_LIKE` support for regex-based Django tests.
@@ -149,13 +156,15 @@ echo "yes" | python tests/runtests.py --settings=testapp.settings <module>
 
 ## Development Workflow Rules
 
+For contribution conventions (branch, commit prefixes, history rules) and cross-cutting review judgment, see `AGENTS.md`.
+
 ### Git Hygiene
 - **Only commit files you intentionally changed.** Untracked files (e.g. `result.xml`, build artifacts) may exist in the workspace but not be in `.gitignore` — do not stage or commit them. Review `git diff` and `git status` before committing.
 - Do not modify `testapp/settings.py` database connection settings (ODBC driver version, passwords) as part of a PR — those are local dev environment changes.
 
 ### Fix Quality
-- **Find the root cause, not a workaround.** Don't parse or manipulate compiled SQL strings when Django provides a structured expression API to solve the problem at the right level. Work at the expression/node level (e.g. override `get_order_by()`, use `as_microsoft` pattern) rather than post-hoc string surgery on generated SQL.
-- Follow existing codebase patterns: the `as_microsoft` monkey-patching pattern in `functions.py`, the `_as_microsoft()` dispatch in `compiler.py`, and compiler method overrides are the standard extension points.
+- Follow the root-cause-over-workaround and node-level-fix principles in `AGENTS.md` (Review judgment).
+- Use the existing extension points: the `as_microsoft` monkey-patching pattern in `functions.py`, the `_as_microsoft()` dispatch in `compiler.py`, and compiler method overrides.
 
 ### Test Discipline
 - **All tests must be green before submitting.** If a test fails due to a SQL Server limitation (not a bug you introduced), add it to `EXCLUDED_TESTS` in `testapp/settings.py` with a comment explaining why.

--- a/.github/instructions/mssql-base.instructions.md
+++ b/.github/instructions/mssql-base.instructions.md
@@ -1,0 +1,43 @@
+---
+applyTo: "mssql/base.py"
+---
+# Review guidance: base.py
+
+`base.py` builds the `DatabaseWrapper`, the connection string, and cursor handling. It is
+one of only two driver-coupled files (with `introspection.py`) — everything else in
+`mssql/` is driver-agnostic. Connection-string changes have broad blast radius; review
+them carefully.
+
+## Connection-string defaults
+
+- **Any default the backend injects into the connection string needs a user opt-out.**
+  The established pattern (see #533, the `Authentication=` / `Trusted_Connection` fix) is:
+  if the user set the keyword explicitly in `extra_params`, skip our injection. Apply the
+  same pattern to any newly injected keyword; parse `extra_params` (case-insensitive) to
+  detect it.
+- **MARS is force-added on Windows for Microsoft drivers and cannot currently be turned
+  off**, which breaks backends that don't support it (e.g. Microsoft Fabric DWH). A fix
+  must (a) honor an explicit `MARS_Connection` in `extra_params`, and (b) keep the runtime
+  `supports_mars` feature flag consistent with the effective setting — the flag is derived
+  from the driver name, not from the actual connection string, so they can disagree. See #415.
+- **`extra_params` is appended verbatim.** A keyword the backend also sets can appear
+  twice; dedupe rather than emit duplicates.
+
+## Authentication shape
+
+- `USER` / `PASSWORD` become `UID` / `PWD`, which is **SQL Server authentication**. A
+  domain `username`/`password` pair is Windows auth (NTLM), which the Microsoft ODBC
+  driver does not support — passing a domain account as `USER` yields a confusing "login
+  failed" for a SQL login by that name. Windows auth is process identity via
+  `Trusted_Connection=yes` (added only when `USER` is empty). See #413, #428.
+
+## Server-property probes
+
+- Detection that runs `SERVERPROPERTY(...)` needs an **already-open connection**, so it
+  cannot gate connection-string construction (which happens before connect). Don't design
+  connect-time behavior around a value only available post-connect.
+
+## Testing
+
+- Connection-string builder tests are `SimpleTestCase` (no live DB) — fast to run and the
+  right home for connstring assertions.

--- a/.github/instructions/mssql-compiler.instructions.md
+++ b/.github/instructions/mssql-compiler.instructions.md
@@ -1,0 +1,37 @@
+---
+applyTo: "mssql/compiler.py"
+---
+# Review guidance: compiler.py
+
+`compiler.py` compiles Django queries into T-SQL: pagination emulation and ORDER BY
+handling are the sensitive areas. Keep changes here focused and node-level.
+
+## Deprecated Django API migration
+
+- **Sweep every call site in the file.** When a change moves off a deprecated Django API
+  (e.g. `quote_name_unless_alias`), grep the full symbol across the module — not just the
+  path the failing test exercised. The deprecated call typically still works: it warns on
+  the current Django and only breaks on a future major, so CI and correctness tests stay
+  green while a missed call site (such as the empty-ordering `ORDER BY pk` fallback)
+  lingers. See #555/#563.
+- **Make the deprecation itself the assertion.** When the query returns correct rows
+  either way and the only observable change is a `RemovedInDjangoXWarning`, scope a
+  warnings filter to that specific category and promote it to an error in the regression
+  test. That reproduces how the upstream warnings-as-errors suite surfaces the problem and
+  gives an otherwise-untestable fix real coverage. See #559.
+
+## Pagination and ORDER BY
+
+- SQL Server has no native `LIMIT/OFFSET`; pagination is emulated with `TOP` and
+  `OFFSET ... FETCH` / `ROW_NUMBER()`. Order-dependent changes need coverage on both the
+  offset and non-offset paths.
+- **ORDER BY must not list the same column twice** (SQL Server error 169), which composite
+  primary keys can trigger when Django emits a multi-column ordering as a single item.
+  Preserve the deduplication logic and handle both qualified (`[t].[c]`) and unqualified
+  (`[c]`) column references.
+
+## General
+
+- **Do not do string surgery on compiled SQL.** Solve at the expression/node level
+  (override the relevant compiler method, use the `as_microsoft` pattern) rather than
+  regex over generated SQL — the latter is blind to literals, aliases, and escaping.

--- a/.github/instructions/mssql-features.instructions.md
+++ b/.github/instructions/mssql-features.instructions.md
@@ -1,0 +1,39 @@
+---
+applyTo: "mssql/features.py"
+---
+# Review guidance: features.py
+
+`features.py` subclasses Django's `BaseDatabaseFeatures` and overrides the `supports_*`
+flags SQL Server can't honor. One correct flag both skips the inapplicable Django tests
+(`@skipUnlessDBFeature`) and makes runtime raise a clean `NotSupportedError` instead of
+emitting SQL the engine rejects.
+
+## First tool on a new Django minor
+
+- **Diff Django's `BaseDatabaseFeatures` between the old and new minor.** New minors add
+  `supports_*` flags that default to `True`; a backend that doesn't override them inherits
+  `True`, so Django assumes SQL Server can do the new thing, runs the new tests, and emits
+  SQL that fails. Override the new flags that SQL Server can't honor.
+- Some new-flag failures surface **at test-database creation**, before any test runs — so
+  a missed override can red the entire suite, not just one test. (Example: Django 6.1's
+  `supports_on_delete_db_cascade` / `_db_null` / `_db_default` left `True` makes the new
+  `delete` models create FK graphs SQL Server rejects with error 1785, multiple cascade
+  paths.) Bitwise-aggregate flags left `True` surface as ODBC error 195.
+
+## Correctness rules
+
+- **Overriding a flag the base class doesn't define yet is an inert no-op** (nothing reads
+  it on older Django), so a plain `= False` never needs version gating. Version-gate only
+  when the *reference itself* would fail on an older Django (e.g. importing a symbol that
+  doesn't exist yet). Follow the existing file: version gates guard imports, plain booleans
+  are unconditional.
+- **Turning a flag off declines the capability — it is not support.** If SQL Server can
+  actually do the thing with different SQL, that's real (higher-value) work, separate from
+  making the minor not break.
+
+## Comment discipline
+
+- State whether a `False` reflects a **permanent platform limitation** (a wall — e.g. the
+  1785 multi-cascade-path restriction) or an **unimplemented capability** (a gap that could
+  be emulated). Conflating the two turns "we haven't done it" into "it can't be done", and
+  that misclassification survives for years.

--- a/.github/instructions/mssql-functions.instructions.md
+++ b/.github/instructions/mssql-functions.instructions.md
@@ -1,0 +1,39 @@
+---
+applyTo: "mssql/functions.py"
+---
+# Review guidance: functions.py
+
+`functions.py` overrides Django SQL functions for SQL Server via the `as_microsoft`
+pattern, and handles the parameter-count limit.
+
+## Extension mechanism
+
+- **New function overrides must use the `as_microsoft` pattern** — define a
+  `sqlserver_<fn>` and monkey-patch it onto the Django expression class
+  (`Round.as_microsoft = sqlserver_round`). Don't special-case functions elsewhere or
+  post-process compiled SQL.
+
+## String and collation manipulation (historically fragile)
+
+- **`CONVERT(varchar, ...)` without a length truncates to 30 characters.** Any generated
+  `CONVERT`/`CAST` to a character type that carries an identifier (database name, object
+  name) must specify an explicit length, or long names are silently cut. See #423.
+- **Do not fabricate collations by string substitution.** Deriving a collation with
+  `.replace('_CI', '_CS')` (or similar) produces invalid collation names for suffixes like
+  `_CI_AI` or `_SC_UT`, and crashes when the collation is `NULL`. Guard for `NULL` and
+  don't synthesize collation names from substrings. See #420.
+- These live in a small, dense helper (`sqlserver_replace`); a change touching it should
+  check the whole helper, since multiple reported bugs share it.
+
+## Pattern lookups
+
+- **Escape `[` and `]` in pattern/`LIKE` operands.** SQL Server treats `[...]` as a
+  character class, so an unescaped `[J]` matches the single character `J`, not the literal
+  string `[J]` — a silent-wrong-results bug (correct rows, no error). Verify escaping is
+  applied when a pattern value can come from an `F()` expression or a column, not only from
+  a literal. See #573.
+
+## Parameter limit
+
+- SQL Server caps parameters per statement (~2100). Large `IN` clauses are split via temp
+  tables here — preserve that splitting when changing how multi-value lookups are compiled.

--- a/.github/instructions/mssql-introspection.instructions.md
+++ b/.github/instructions/mssql-introspection.instructions.md
@@ -1,0 +1,28 @@
+---
+applyTo: "mssql/introspection.py"
+---
+# Review guidance: introspection.py
+
+`introspection.py` maps SQL Server type codes to Django fields and introspects tables,
+columns, and relations. It is one of only two driver-coupled files (with `base.py`) — its
+type map depends on driver-exported constants.
+
+## Django-version return shapes
+
+- **Introspection return shapes change across Django minors — write version-aware tests.**
+  For example, `get_relations()` / foreign-key introspection gained a wider tuple on newer
+  Django. A change here must be tested against each supported Django version's expected
+  shape, using `django.VERSION` conditionals in one test rather than assuming a single
+  shape. See #556/#558.
+
+## Driver type constants
+
+- **Audit every `Database.SQL_*` type constant the map uses.** Driver builds differ in
+  which constants they export (e.g. `SQL_SS_TIME2` is not exported by every driver), so a
+  new type mapping should confirm the constant exists on all supported drivers, or provide
+  a fallback, rather than referencing it unconditionally.
+
+## Schema qualification
+
+- Introspection should behave correctly for tables in **non-default schemas**, not just
+  `dbo`. Test table/column/relation introspection with a schema-qualified `db_table`.

--- a/.github/instructions/mssql-operations.instructions.md
+++ b/.github/instructions/mssql-operations.instructions.md
@@ -1,0 +1,42 @@
+---
+applyTo: "mssql/operations.py"
+---
+# Review guidance: operations.py
+
+`operations.py` handles SQL Server quoting, parameter and type handling, and datetime
+adaptation. It is the highest-traffic bug surface in the backend — review changes here
+against the following checks.
+
+## Type dispatch
+
+- **Use `isinstance`, not exact-type identity.** `type(x) == int` (or `is int`)
+  silently rejects subclasses such as `IntegerChoices` / `IntEnum`, which reach the
+  parameter path through raw `GROUP BY` queries and then fall through to
+  `NotImplementedError`. Classify with `isinstance` (or read the enum's value). See #541.
+- **Integer range boundaries.** SQL Server `INT` is `-0x80000000 .. 0x7FFFFFFF`. When
+  classifying a value as `INT` vs `BIGINT`, verify the exact boundary values are not
+  misclassified.
+
+## SQL string manipulation
+
+- **Rewriting placeholders on raw SQL is unsafe by construction.** Any `%s`→`{}`-style
+  substitution is blind to string literals, comments, and escape sequences. A change to
+  placeholder handling must preserve `%%`-escaped literals; require a test covering
+  `GROUP BY` + an escaped `%%` literal + a real parameter in the same query. If the fix
+  only widens a regex, note that it is a band-aid over an unparsed-SQL approach. See #476/#537.
+- Prefer solving at Django's expression level over post-processing generated SQL.
+
+## Datetime adaptation
+
+- **Read and write paths must stay symmetric.** `convert_datetimefield_value` (read) and
+  `adapt_datetimefield_value` (write) must agree on timezone handling. A fix that touches
+  only one side creates a read/write asymmetry when a per-database `TIME_ZONE` is set
+  (aware values written as UTC but read back in the connection timezone, or vice versa).
+  Verify both paths, and test with `USE_TZ=True` plus an explicit non-UTC per-database
+  `TIME_ZONE`. See #371.
+
+## Identifier quoting
+
+- Identifiers are quoted with `[brackets]` via `quote_name()`. A change that routes more
+  call sites through quoting is a behavior change for every identifier — review its blast
+  radius, not just the reported case.

--- a/.github/instructions/mssql-schema.instructions.md
+++ b/.github/instructions/mssql-schema.instructions.md
@@ -1,0 +1,34 @@
+---
+applyTo: "mssql/schema.py"
+---
+# Review guidance: schema.py
+
+`schema.py` is the schema editor and the largest, most sensitive file in the backend. Its
+`_alter_field()` drops and recreates dependent constraints (foreign keys, indexes, unique
+constraints) around a column change. Keep changes here focused and well-tested.
+
+## `_alter_field` and cascading constraints
+
+- A change to field alteration must **recreate every constraint it drops**, in the right
+  order. When reviewing, confirm the set of constraints dropped equals the set recreated —
+  a missed recreation leaves the schema subtly wrong after a migration.
+
+## Schema-qualified tables (non-default schema)
+
+- **DDL must work for a `db_table` in a non-default schema, not just `dbo`.** A known open
+  case: adding a non-nullable column (with a default) to a model whose `db_table` uses an
+  explicit schema fails. Test the matrix explicitly: schema-qualified × nullable/non-nullable
+  × with/without default. See #402 (reproduced by more than one reporter).
+
+## Blast radius over label
+
+- **A change that reroutes identifier handling is an enhancement, review it as one.** If a
+  PR (even one labeled `FIX:`) routes every identifier through a new parser or changes a
+  default of a widely-called helper (e.g. `quote_name()` behavior, `get_table_list()`
+  defaults), the blast radius is the whole backend, with backward-compatibility and
+  SemVer implications. Assess it by what it changes, not by its stated intent. See #497.
+
+## General
+
+- Prefer Django's schema-editor hooks over hand-built DDL strings where they exist, and
+  keep DDL generation consistent with `operations.py` quoting (`[brackets]`).

--- a/.github/instructions/testapp.instructions.md
+++ b/.github/instructions/testapp.instructions.md
@@ -1,0 +1,44 @@
+---
+applyTo: "testapp/**"
+---
+# Review guidance: testapp/
+
+`testapp/` is the test project we own — the only place we add regression coverage for
+`mssql/*.py`. `testapp/settings.py` holds `EXCLUDED_TESTS`; `testapp/models.py` holds the
+test models.
+
+## Regression tests are mandatory
+
+- **Every `FIX:` and `FEAT:` ships a test here, in the same PR.** For a `FIX:`, the test
+  must fail on `dev` without the change and pass with it, and must assert the **exact
+  trigger combination** from the issue (e.g. GROUP BY + escaped `%%` + a real param), not a
+  simplified proxy. A one-dimensional test that doesn't reproduce the real combo isn't
+  coverage.
+- **Use the real fields in `testapp/models.py`** — don't invent model fields in a test.
+
+## The `USE_TZ` gap
+
+- `testapp` runs with `USE_TZ=False`, so the timezone / `datetimeoffset` path (a
+  `DateTimeField` becomes `datetimeoffset` only under `USE_TZ=True`) is exercised **only by
+  the upstream Django suite**, never by `testapp`. A timezone fix therefore can't be
+  regression-covered from `testapp` alone — say so explicitly in the PR body. That is the
+  one accepted "no testapp test" exception.
+
+## Version-aware tests
+
+- **Gate tests by `django.VERSION`, not by skipping.** A fix gated to a new Django minor is
+  inert on the legs CI runs today; a version-aware test still runs and asserts on the
+  current legs and automatically starts covering the new minor once it's enabled. See #558/#559.
+- **When the only observable change is a deprecation warning, make the warning the
+  assertion:** scope a filter to the specific `RemovedInDjangoXWarning` and promote it to an
+  error in the test. That mirrors Django's own warnings-as-errors suite and gives an
+  otherwise-untestable fix real coverage.
+
+## `EXCLUDED_TESTS` hygiene
+
+- Exclusions are version-gated blocks (`if VERSION >= (X, Y):`). Add an exclusion only for a
+  genuine SQL Server limitation, not a bug you introduced.
+- **The comment is documentation.** State whether the reason is a permanent platform
+  limitation or an unimplemented capability — a wrong reason there becomes received wisdom.
+- **`@expectedFailure` / `@skip` (or an exclusion) means the bug is NOT fixed** — it
+  documents a known failure while keeping CI green. Never read "a test exists" as "fixed".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md — mssql-django
+
+Repository context for automated agents and code review. This file holds durable
+project facts and review judgment. SQL Server limitations, the `as_microsoft`
+extension pattern, and the `EXCLUDED_TESTS` mechanism are documented in
+`.github/copilot-instructions.md`; this file does not repeat them.
+
+## What this project is
+
+`mssql-django` is a Django database backend for Microsoft SQL Server. It translates
+Django's database abstraction layer into T-SQL. The backend lives entirely under
+`mssql/`; `testapp/` is the test project we own.
+
+## Project facts
+
+- **Default branch:** `dev` (not `main`). Open pull requests against `dev`.
+- **Version:** declared in `setup.py` (`version='X.Y.Z'`). Supported range is the
+  `install_requires` cap (`django>=3.2,<6.2`) plus the `Framework :: Django :: X.Y`
+  classifiers.
+- **Supported matrix:** Django 3.2 – 6.1, Python 3.8 – 3.14, SQL Server 2017 – 2025 /
+  Azure SQL, ODBC Driver 17 or 18.
+- **Tests:** `python manage.py test testapp --noinput` runs the suite we own. A live
+  SQL Server is required; connection settings come from environment variables read in
+  `testapp/settings.py` (`MSSQL_HOST`, `MSSQL_PASSWORD`, ...). The full upstream Django
+  suite is driven by `test.sh` (clones Django, runs `runtests.py` against SQL Server).
+
+## Module map (`mssql/`)
+
+| File | Responsibility |
+|------|----------------|
+| `schema.py` | Schema editor; `_alter_field` constraint drop/recreate. Largest, most sensitive file. |
+| `compiler.py` | SQL query compilation: pagination (OFFSET/FETCH, TOP), ORDER BY handling. |
+| `operations.py` | SQL Server operations: quoting, parameter/type handling, datetime adaptation. |
+| `functions.py` | Function overrides via the `as_microsoft` pattern; parameter-limit splitting. |
+| `base.py` | `DatabaseWrapper`, connection-string construction, cursor handling. |
+| `features.py` | Capability flags (`supports_*`) declaring what SQL Server can and can't do. |
+| `introspection.py` | Type-code → Django field mapping; table/relation introspection. |
+| `creation.py` | Test-database creation and teardown. |
+
+`base.py` and `introspection.py` are the only DBAPI/driver-coupled files; everything
+else in `mssql/` is driver-agnostic.
+
+## Commit and PR conventions
+
+- **Title prefix (uppercase, colon):** `FEAT:`, `FIX:`, `CHORE:`, `DOCS:`, `REFACTOR:`,
+  `RELEASE:`, `AI:` (AI-initiative changes).
+- Reference issues in the body: `Closes #<N>` or `Issue: #<N>`.
+- **Every `FIX:` and `FEAT:` ships a regression test in the same PR**, added under
+  `testapp/tests/`. For a `FIX:`, the test must fail on `dev` without the change and
+  pass with it, asserting the exact trigger combination from the issue. The only
+  exception is a change that genuinely cannot be covered from `testapp` (e.g. a path
+  exercised only under `USE_TZ=True`, which `testapp` does not run) — state that
+  explicitly in the PR body.
+
+## History rules
+
+- No force-push (not even `--force-with-lease`) and no rebase of already-pushed
+  branches. Resolve conflicts with `git merge origin/dev`, then a normal push.
+
+## Review judgment (apply across all files)
+
+- **Fix the root cause, not the symptom.** Solve problems at Django's structured
+  expression/node level (e.g. override `get_order_by()`, use the `as_microsoft`
+  pattern). Do not post-process compiled SQL strings with regex or `str.format`.
+- **Fixing one input shape is not fixing the bug class.** If a change narrows a crash
+  for one input, check whether the same failure mode survives on adjacent inputs. A
+  narrow fix can be worth shipping, but call it out as narrow.
+- **Classify a change by its blast radius, not its label.** A PR labeled `FIX:` that
+  reroutes a hot-path helper (e.g. every identifier through a new parser) or changes a
+  default is an enhancement with backward-compatibility implications. Review it as such.
+- **Silent-wrong-results outrank crashes.** A change that can return incorrect rows with
+  no error deserves more scrutiny than one that raises — the crash gets reported, the
+  wrong `filter()` ships into someone's business logic.
+- **Migrating off a deprecated Django API requires a whole-file sweep.** A deprecated
+  call often still works (warns on the current Django, breaks on a future major), so CI
+  and correctness tests stay green while a missed second call site lingers. Grep the
+  full symbol across the file, not just the path the failing test walked.
+- **Test-exclusion comments are documentation.** State whether an exclusion is a
+  permanent platform limitation or an unimplemented capability — a wrong reason there
+  becomes received wisdom for years. `@expectedFailure` / `@skip` documents a known
+  failure; it does not mean the bug is fixed.


### PR DESCRIPTION
Adds repository context so GitHub Copilot code review reviews mssql-django with the backend's actual conventions and known failure modes, instead of generic advice. First step of the AI-assisted review initiative.

> Stacked on #577 (DOCS refresh). Base will be retargeted to `dev` once #577 merges; until then the diff here is scoped to just this change.

## What's added
- **`AGENTS.md`** — durable project facts (default branch `dev`, version/support matrix, module map, commit/PR prefix grammar, history rules) plus cross-cutting review judgment (root-cause over workaround, classify by blast radius, silent-wrong-results severity, whole-file sweep when migrating off a deprecated API, exclusion comments as documentation).
- **`.github/instructions/*.instructions.md`** — path-scoped review guidance loaded only when a matching file changes. One per backend area (schema, compiler, operations, functions, base, features, introspection) plus `testapp/`. Each encodes checks drawn from real prior issues/PRs (e.g. `isinstance` vs exact-type dispatch, ORDER BY dedup, MARS connection-string opt-out, feature-flag overrides on a new Django minor, mandatory regression tests under `testapp/tests/`).
- **`.github/copilot-instructions.md`** — small dedup edits: a header describing the three-file split and pointers to `AGENTS.md`, so nothing is stated twice.

Documentation/configuration only. No backend code, no workflow, no test changes.