### PR TITLE
CHORE: escape single quotes in inspectdb --schema argument

### DIFF
--- a/mssql/management/commands/inspectdb.py
+++ b/mssql/management/commands/inspectdb.py
@@ -15,5 +15,9 @@ class Command(inspectdb_Command):
 
     def handle(self, *args, **options):
         if options["schema"]:
-            settings.SCHEMA_TO_INSPECT = "'" + options["schema"] + "'"
+            # Wrap the schema name as a T-SQL string literal, doubling any
+            # embedded single quotes so names like O'Brien are preserved
+            # verbatim instead of terminating the literal early.
+            escaped_schema = options["schema"].replace("'", "''")
+            settings.SCHEMA_TO_INSPECT = "'" + escaped_schema + "'"
         return super().handle(*args, **options)

--- a/testapp/tests/test_inspectdb.py
+++ b/testapp/tests/test_inspectdb.py
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the BSD license.
+#
+# Regression coverage for the inspectdb --schema argument handling: the value
+# is wrapped as a T-SQL string literal, so any embedded single quote must be
+# doubled to keep the schema name intact.
+
+from unittest import mock
+
+from django.conf import settings
+from django.core.management.commands.inspectdb import Command as DjangoInspectDBCommand
+from django.test import SimpleTestCase
+
+from mssql.management.commands.inspectdb import Command as MSSQLInspectDBCommand
+
+_SENTINEL = object()
+
+
+class InspectDBSchemaArgTests(SimpleTestCase):
+    def _resolve_schema_literal(self, schema):
+        # Preserve and restore the module-level setting the command mutates.
+        original = getattr(settings, "SCHEMA_TO_INSPECT", _SENTINEL)
+
+        def _restore():
+            if original is _SENTINEL:
+                if hasattr(settings, "SCHEMA_TO_INSPECT"):
+                    delattr(settings, "SCHEMA_TO_INSPECT")
+            else:
+                settings.SCHEMA_TO_INSPECT = original
+
+        self.addCleanup(_restore)
+
+        command = MSSQLInspectDBCommand()
+        # Stub out the parent handle() so no database introspection runs; we
+        # only care about the SCHEMA_TO_INSPECT value the override computes.
+        with mock.patch.object(DjangoInspectDBCommand, "handle", return_value=None):
+            command.handle(schema=schema)
+        return settings.SCHEMA_TO_INSPECT
+
+    def test_plain_schema_is_wrapped(self):
+        self.assertEqual(self._resolve_schema_literal("dbo"), "'dbo'")
+
+    def test_schema_with_apostrophe_is_kept_literal(self):
+        # Without doubling, the literal would terminate early and the trailing
+        # text would no longer be part of the schema name.
+        self.assertEqual(self._resolve_schema_literal("O'Brien"), "'O''Brien'")


### PR DESCRIPTION
### Summary
`inspectdb --schema <name>` wraps the provided value as a T-SQL string literal in `settings.SCHEMA_TO_INSPECT`. A single quote in the value (e.g. a schema named `O'Brien`) ended the literal early, so the resulting name no longer matched the intended schema. This doubles any embedded single quotes so the schema name is preserved verbatim.

### Changes
- `mssql/management/commands/inspectdb.py`: double embedded single quotes when building the schema literal.
- `testapp/tests/test_inspectdb.py`: regression test — an apostrophe-containing schema stays a literal name; a plain schema is unchanged.

The regression test patches the parent `handle`, so it is DB-free and runs without a live SQL Server.