### PR TITLE
Restore `Meta.indexes` after `RenameField` and `AlterField`

### DIFF
--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -959,10 +959,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     index_fields = [model._meta.get_field(field_name) for field_name, _ in index.fields_orders]
                     index_columns_list = [field.column for field in index_fields]
                 except FieldDoesNotExist:
-                    # A field name in index.fields is stale (from a preceding RenameField).
+                    # A field name in index.fields_orders is stale (from a preceding RenameField).
                     # Resolve columns individually, falling back to new_field.column.
                     index_columns_list = []
-                    for field_name in index.fields_orders:
+                    for field_name, _ in index.fields_orders:
                         try:
                             index_columns_list.append(model._meta.get_field(field_name).column)
                         except FieldDoesNotExist:

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -19,6 +19,7 @@ from django.db.backends.ddl_references import (
     Table,
 )
 from django import VERSION as django_version
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models import NOT_PROVIDED, Index, UniqueConstraint
 from django.db.models.fields import AutoField, BigAutoField
 from django.db.models.fields.related import ForeignKey
@@ -427,7 +428,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         #      indexes from Meta.indexes are not restored. The _delete_indexes() method
         #      fails with FieldDoesNotExist because it looks up the index field by the
         #      old field name, but RenameField has already updated the model state.
-        #      Tests (marked @expectedFailure):
+        #      Tests:
         #        - test_index_from_meta_indexes_retained_after_rename_and_type_change
         #        - test_index_from_meta_indexes_retained_after_rename_and_nullability_change
         #
@@ -785,8 +786,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         #   - Only if type changed OR nullability changed
         #   - Only if column was NOT renamed (rename is handled separately)
         # Test:
-        #   - test_index_from_meta_indexes_retained_after_rename_and_type_change (@expectedFailure)
-        #   - test_index_from_meta_indexes_retained_after_rename_and_nullability_change (@expectedFailure)
+        #   - test_index_from_meta_indexes_retained_after_rename_and_type_change
+        #   - test_index_from_meta_indexes_retained_after_rename_and_nullability_change
         #
 
         # Restore indexes & unique constraints deleted above, SQL Server requires explicit restoration
@@ -950,12 +951,25 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # For other changes, only restore indexes involving the altered field.
             # --------------------------------------------------------------------------------
             for index in model._meta.indexes:
-                # Get the field objects for this index
-                index_fields = [model._meta.get_field(field_name) for field_name, _ in index.fields_orders]
-                index_columns_list = [field.column for field in index_fields]
+                # Get the column names for this index, resolving stale field names
+                # that may remain after a RenameField updated the model state but
+                # not the Index.fields list.
+                # See https://github.com/microsoft/mssql-django/issues/499
+                try:
+                    index_fields = [model._meta.get_field(field_name) for field_name, _ in index.fields_orders]
+                    index_columns_list = [field.column for field in index_fields]
+                except FieldDoesNotExist:
+                    # A field name in index.fields is stale (from a preceding RenameField).
+                    # Resolve columns individually, falling back to new_field.column.
+                    index_columns_list = []
+                    for field_name in index.fields_orders:
+                        try:
+                            index_columns_list.append(model._meta.get_field(field_name).column)
+                        except FieldDoesNotExist:
+                            index_columns_list.append(new_field.column)
 
                 # Restore if: AutoField change (all indexes dropped) OR field is in this index
-                if is_autofield_change or old_field.column in index_columns_list:
+                if is_autofield_change or old_field.column in index_columns_list or new_field.column in index_columns_list:
                     indexes_to_restore.append(index)  # Store the Index object, not field list
 
             # --------------------------------------------------------------------------------
@@ -964,13 +978,52 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # Restore Index objects using index.create_sql() to preserve explicit names
             # and attributes.
             #
+            # If an index has stale field names (from a preceding RenameField that
+            # updated the model state but not Index.fields), clone the index with
+            # corrected field names so that create_sql() can resolve them.
+            # See https://github.com/microsoft/mssql-django/issues/499
+            #
             # Deduplication: Skip if already in deferred_sql or post_actions
             # (which contains other_actions from _alter_column_type_sql).
             # This prevents duplicate index creation if the same index
             # was already scheduled elsewhere.
             # --------------------------------------------------------------------------------
             for index in indexes_to_restore:
-                create_index_sql_statement = index.create_sql(model, self)
+                # Fix stale field names in index.fields before calling create_sql()
+                restored_index = index
+                has_stale_fields = False
+                for field_name in index.fields:
+                    try:
+                        model._meta.get_field(field_name)
+                    except FieldDoesNotExist:
+                        has_stale_fields = True
+                        break
+                if has_stale_fields:
+                    # Build corrected field names preserving ordering prefixes.
+                    # index.fields stores raw strings like ['-a', 'b'] where '-'
+                    # means descending.  We need to replace just the name part
+                    # while keeping the prefix, because Index.__init__ derives
+                    # fields_orders (used by create_sql) from the raw strings.
+                    corrected_fields = []
+                    for raw_field in index.fields:
+                        # Strip optional '-' prefix to get the bare field name
+                        if raw_field.startswith('-'):
+                            prefix = '-'
+                            bare_name = raw_field[1:]
+                        else:
+                            prefix = ''
+                            bare_name = raw_field
+                        try:
+                            model._meta.get_field(bare_name)
+                            corrected_fields.append(raw_field)
+                        except FieldDoesNotExist:
+                            corrected_fields.append(prefix + new_field.name)
+                    # Reconstruct via deconstruct() so fields_orders is correct
+                    _, args, kwargs = index.deconstruct()
+                    kwargs['fields'] = corrected_fields
+                    restored_index = index.__class__(*args, **kwargs)
+
+                create_index_sql_statement = restored_index.create_sql(model, self)
                 if create_index_sql_statement and (str(create_index_sql_statement)
                         not in [str(sql) for sql in self.deferred_sql] + [str(statement[0]) for statement in post_actions]
                         ):
@@ -1092,6 +1145,23 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             return
         index_columns = []
         index_names = []
+
+        # After a RenameField + AlterField in the same migration, the model state
+        # has the new field name but Index.fields / index_together / unique_together
+        # may still reference the old field name (Django's rename_field() updates
+        # index_together and unique_together but NOT Meta.indexes). Additionally,
+        # sp_rename has already executed so the DB column uses new_field.column.
+        # This helper resolves a field name to its DB column, falling back to
+        # new_field.column when the field name is stale (FieldDoesNotExist).
+        # See https://github.com/microsoft/mssql-django/issues/499
+        def _resolve_column(field_name):
+            try:
+                return model._meta.get_field(field_name).column
+            except FieldDoesNotExist:
+                # The field was renamed by a preceding RenameField; the old name
+                # is stale. Use new_field.column since sp_rename has already run.
+                return new_field.column
+
         if old_field.db_index and new_field.db_index:
             index_columns.append([old_field.column])
         elif old_field.null != new_field.null:
@@ -1101,19 +1171,19 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
            # Iterate over each set of field names defined in index_together  
            for fields in model._meta.index_together:
               # Get the actual column names for each field in the set
-              columns = [model._meta.get_field(field).column for field in fields]
+              columns = [_resolve_column(field) for field in fields]
               # If the old field's column is among these columns, add to index_columns for later index deletion
-              if old_field.column in columns:
+              if old_field.column in columns or new_field.column in columns:
                  index_columns.append(columns)
 
         for index in model._meta.indexes:
-            columns = [model._meta.get_field(field_name).column for field_name, _ in index.fields_orders]
-            if old_field.column in columns:
+            columns = [_resolve_column(field) for field, _ in index.fields_orders]
+            if old_field.column in columns or new_field.column in columns:
                 index_columns.append(columns)
 
         for fields in model._meta.unique_together:
-            columns = [model._meta.get_field(field).column for field in fields]
-            if old_field.column in columns:
+            columns = [_resolve_column(field) for field in fields]
+            if old_field.column in columns or new_field.column in columns:
                 index_columns.append(columns)
         if index_columns:
             # remove duplicates first

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -2,7 +2,9 @@
 # Licensed under the BSD license.
 
 import binascii
+import copy
 import datetime
+
 
 from collections import defaultdict
 
@@ -423,16 +425,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         #
         #
         # KNOWN BUGS/LIMITATIONS:
-        #   1. Rename + alter in same migration: When a field is renamed (via RenameField)
-        #      AND has a type or nullability change (via AlterField) in the same migration,
-        #      indexes from Meta.indexes are not restored. The _delete_indexes() method
-        #      fails with FieldDoesNotExist because it looks up the index field by the
-        #      old field name, but RenameField has already updated the model state.
-        #      Tests:
-        #        - test_index_from_meta_indexes_retained_after_rename_and_type_change
-        #        - test_index_from_meta_indexes_retained_after_rename_and_nullability_change
-        #
-        #   2. unique_together + unique=True: When a field has BOTH unique=True AND
+
+        #   1. unique_together + unique=True: When a field has BOTH unique=True AND
         #      participates in unique_together, only the single-field unique constraint
         #      is restored after field alteration. The unique_together constraint is NOT
         #      restored because the restoration code is in an 'else' block that only
@@ -518,6 +512,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 )
                 for fk_name in rel_fk_names:
                     self.execute(self._delete_constraint_sql(self.sql_delete_fk, new_rel.related_model, fk_name))
+        meta_index_replacements = self._get_meta_index_replacements(model)
+
         # If working with an AutoField or BigAutoField drop all indexes on the related table
         # This is needed when doing ALTER column statements on IDENTITY fields
         # https://stackoverflow.com/questions/33429775/sql-server-alter-table-alter-column-giving-set-option-error
@@ -639,7 +635,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # Drop unique constraint, SQL Server requires explicit deletion
             self._delete_unique_constraints(model, old_field, new_field, strict)
             # Drop indexes, SQL Server requires explicit deletion
-            self._delete_indexes(model, old_field, new_field)
+            self._delete_indexes(
+                model, old_field, new_field,
+                meta_index_replacements=meta_index_replacements,
+            )
+
         # db_default change?
         if django_version >= (5,0):
             if new_field.db_default is not NOT_PROVIDED:
@@ -691,7 +691,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 # Drop unique constraint, SQL Server requires explicit deletion
                 self._delete_unique_constraints(model, old_field, new_field, strict)
                 # Drop indexes, SQL Server requires explicit deletion
-                self._delete_indexes(model, old_field, new_field)
+                self._delete_indexes(
+                    model, old_field, new_field,
+                    meta_index_replacements=meta_index_replacements,
+                )
+
 
         # ================================================================================
         # 3. Column alteration
@@ -951,83 +955,43 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # For other changes, only restore indexes involving the altered field.
             # --------------------------------------------------------------------------------
             for index in model._meta.indexes:
-                # Get the column names for this index, resolving stale field names
-                # that may remain after a RenameField updated the model state but
-                # not the Index.fields list.
-                # See https://github.com/microsoft/mssql-django/issues/499
+                replacements = meta_index_replacements.get(index.name)
                 try:
-                    index_fields = [model._meta.get_field(field_name) for field_name, _ in index.fields_orders]
-                    index_columns_list = [field.column for field in index_fields]
-                except FieldDoesNotExist:
-                    # A field name in index.fields_orders is stale (from a preceding RenameField).
-                    # Resolve columns individually, falling back to new_field.column.
-                    index_columns_list = []
-                    for field_name, _ in index.fields_orders:
-                        try:
-                            index_columns_list.append(model._meta.get_field(field_name).column)
-                        except FieldDoesNotExist:
-                            index_columns_list.append(new_field.column)
+                    index_fields = [
+                        model._meta.get_field(replacements.get(field_name, field_name))
+                        for field_name, _ in index.fields_orders
+                    ]
+                    included_fields = [
+                        model._meta.get_field(replacements.get(field_name, field_name))
+                        for field_name in index.include
+                    ]
+                    condition_fields = [
+                        model._meta.get_field(replacements.get(field_name, field_name))
+                        for field_name in self._get_condition_field_names(index.condition)
+                    ]
+                except (AttributeError, FieldDoesNotExist):
+                    # An unresolved reference isn't evidence that it names the field
+                    # currently being altered. Its index was already removed or has
+                    # never existed, so never recreate it with a different field.
+                    continue
 
-                # Restore if: AutoField change (all indexes dropped) OR field is in this index
+                index_columns_list = [
+                    field.column for field in index_fields + included_fields + condition_fields
+                ]
                 if is_autofield_change or old_field.column in index_columns_list or new_field.column in index_columns_list:
-                    indexes_to_restore.append(index)  # Store the Index object, not field list
+                    indexes_to_restore.append((index, replacements))
 
-            # --------------------------------------------------------------------------------
-            # Execute restoration: Meta.indexes
-            # --------------------------------------------------------------------------------
-            # Restore Index objects using index.create_sql() to preserve explicit names
-            # and attributes.
-            #
-            # If an index has stale field names (from a preceding RenameField that
-            # updated the model state but not Index.fields), clone the index with
-            # corrected field names so that create_sql() can resolve them.
-            # See https://github.com/microsoft/mssql-django/issues/499
-            #
-            # Deduplication: Skip if already in deferred_sql or post_actions
-            # (which contains other_actions from _alter_column_type_sql).
-            # This prevents duplicate index creation if the same index
-            # was already scheduled elsewhere.
-            # --------------------------------------------------------------------------------
-            for index in indexes_to_restore:
-                # Fix stale field names in index.fields before calling create_sql()
-                restored_index = index
-                has_stale_fields = False
-                for field_name in index.fields:
-                    try:
-                        model._meta.get_field(field_name)
-                    except FieldDoesNotExist:
-                        has_stale_fields = True
-                        break
-                if has_stale_fields:
-                    # Build corrected field names preserving ordering prefixes.
-                    # index.fields stores raw strings like ['-a', 'b'] where '-'
-                    # means descending.  We need to replace just the name part
-                    # while keeping the prefix, because Index.__init__ derives
-                    # fields_orders (used by create_sql) from the raw strings.
-                    corrected_fields = []
-                    for raw_field in index.fields:
-                        # Strip optional '-' prefix to get the bare field name
-                        if raw_field.startswith('-'):
-                            prefix = '-'
-                            bare_name = raw_field[1:]
-                        else:
-                            prefix = ''
-                            bare_name = raw_field
-                        try:
-                            model._meta.get_field(bare_name)
-                            corrected_fields.append(raw_field)
-                        except FieldDoesNotExist:
-                            corrected_fields.append(prefix + new_field.name)
-                    # Reconstruct via deconstruct() so fields_orders is correct
-                    _, args, kwargs = index.deconstruct()
-                    kwargs['fields'] = corrected_fields
-                    restored_index = index.__class__(*args, **kwargs)
-
+            # Restore Index objects using index.create_sql() to preserve explicit
+            # names and attributes. Stale references are repaired only when the
+            # existing physical index supplied an unambiguous replacement.
+            for index, replacements in indexes_to_restore:
+                restored_index = self._clone_index_with_replacements(index, replacements)
                 create_index_sql_statement = restored_index.create_sql(model, self)
                 if create_index_sql_statement and (str(create_index_sql_statement)
                         not in [str(sql) for sql in self.deferred_sql] + [str(statement[0]) for statement in post_actions]
                         ):
                     self.execute(create_index_sql_statement)
+
 
         # Type alteration on primary key? Then we need to alter the column
         # referring to us.
@@ -1135,68 +1099,160 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if self.connection.features.connection_persists_old_columns:
             self.connection.close()
 
-    def _delete_indexes(self, model, old_field, new_field):
+    def _get_index_metadata(self, model, index_name):
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT ic.is_included_column, c.name, i.filter_definition
+                FROM sys.indexes AS i
+                INNER JOIN sys.index_columns AS ic
+                    ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+                INNER JOIN sys.columns AS c
+                    ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+                WHERE i.object_id = OBJECT_ID(%s) AND i.name = %s
+                ORDER BY ic.key_ordinal, ic.index_column_id
+                """,
+                [model._meta.db_table, index_name],
+            )
+            return cursor.fetchall()
+
+    def _get_condition_field_names(self, condition):
+        if condition is None:
+            return []
+        field_names = []
+        for child in condition.children:
+            if hasattr(child, 'children'):
+                field_names.extend(self._get_condition_field_names(child))
+            else:
+                field_names.append(child[0].split('__', 1)[0])
+        return field_names
+
+    def _get_meta_index_replacements(self, model):
+        fields_by_column = {field.column: field for field in model._meta.fields}
+        replacements = {}
+        for index in model._meta.indexes:
+            field_names = [field_name for field_name, _ in index.fields_orders]
+            include_names = list(index.include)
+            condition_names = self._get_condition_field_names(index.condition)
+            reference_names = field_names + include_names + condition_names
+            if all(name in model._meta._forward_fields_map for name in reference_names):
+                continue
+
+            metadata = self._get_index_metadata(model, index.name)
+            if not metadata:
+                continue
+            key_columns = [column for included, column, _ in metadata if not included]
+            included_columns = [column for included, column, _ in metadata if included]
+            if len(field_names) != len(key_columns) or len(include_names) != len(included_columns):
+                continue
+
+            index_replacements = {}
+            for name, column in zip(field_names + include_names, key_columns + included_columns):
+                try:
+                    field = model._meta.get_field(name)
+                except FieldDoesNotExist:
+                    field = fields_by_column.get(column)
+                    if field is None:
+                        break
+                    index_replacements[name] = field.name
+                else:
+                    if field.column != column:
+                        break
+            else:
+                filter_definition = metadata[0][2]
+                condition_columns = {
+                    column for column in fields_by_column
+                    if f"[{column.replace(']', ']]')}]" in (filter_definition or '')
+                }
+                for name in condition_names:
+                    try:
+                        condition_columns.remove(model._meta.get_field(name).column)
+                    except FieldDoesNotExist:
+                        if name not in index_replacements and len(condition_columns) == 1:
+                            index_replacements[name] = fields_by_column[condition_columns.pop()].name
+                if all(name in index_replacements or name in model._meta._forward_fields_map for name in reference_names):
+                    replacements[index.name] = index_replacements
+        return replacements
+
+    def _clone_index_with_replacements(self, index, replacements):
+        if not replacements:
+            return index
+        _, args, kwargs = index.deconstruct()
+        kwargs['fields'] = [
+            ('-' if field_name.startswith('-') else '') + replacements.get(field_name.lstrip('-'), field_name.lstrip('-'))
+            for field_name in index.fields
+        ]
+        if index.include:
+            kwargs['include'] = [replacements.get(field_name, field_name) for field_name in index.include]
+        if index.condition:
+            condition = copy.deepcopy(index.condition)
+            self._replace_condition_field_names(condition, replacements)
+            kwargs['condition'] = condition
+        return index.__class__(*args, **kwargs)
+
+    def _replace_condition_field_names(self, condition, replacements):
+        for index, child in enumerate(condition.children):
+            if hasattr(child, 'children'):
+                self._replace_condition_field_names(child, replacements)
+            else:
+                field_name, lookup = child[0].split('__', 1) if '__' in child[0] else (child[0], '')
+                if field_name in replacements:
+                    condition.children[index] = (
+                        replacements[field_name] + ('__' + lookup if lookup else ''), child[1]
+                    )
+
+    def _delete_indexes(self, model, old_field, new_field, meta_index_replacements=None):
         if (
             django_version >= (4, 2)
             and isinstance(new_field, ForeignKey)
             and type(new_field.db_comment) != type(None)
             and "fk_on_delete_keep_index" in new_field.db_comment
         ):
-            return
+            return []
+        if isinstance(old_field, (AutoField, BigAutoField)) or isinstance(new_field, (AutoField, BigAutoField)):
+            return []
+
+        meta_index_replacements = meta_index_replacements or {}
         index_columns = []
         index_names = []
-
-        # After a RenameField + AlterField in the same migration, the model state
-        # has the new field name but Index.fields / index_together / unique_together
-        # may still reference the old field name (Django's rename_field() updates
-        # index_together and unique_together but NOT Meta.indexes). Additionally,
-        # sp_rename has already executed so the DB column uses new_field.column.
-        # This helper resolves a field name to its DB column, falling back to
-        # new_field.column when the field name is stale (FieldDoesNotExist).
-        # See https://github.com/microsoft/mssql-django/issues/499
-        def _resolve_column(field_name):
-            try:
-                return model._meta.get_field(field_name).column
-            except FieldDoesNotExist:
-                # The field was renamed by a preceding RenameField; the old name
-                # is stale. Use new_field.column since sp_rename has already run.
-                return new_field.column
-
         if old_field.db_index and new_field.db_index:
             index_columns.append([old_field.column])
         elif old_field.null != new_field.null:
             index_columns.append([old_field.column])
-        # Handle index_together for only django version < 5.1    
-        if django_version < (5, 1):  
-           # Iterate over each set of field names defined in index_together  
-           for fields in model._meta.index_together:
-              # Get the actual column names for each field in the set
-              columns = [_resolve_column(field) for field in fields]
-              # If the old field's column is among these columns, add to index_columns for later index deletion
-              if old_field.column in columns or new_field.column in columns:
-                 index_columns.append(columns)
+        if django_version < (5, 1):
+            for fields in model._meta.index_together:
+                columns = [model._meta.get_field(field).column for field in fields]
+                if old_field.column in columns or new_field.column in columns:
+                    index_columns.append(columns)
 
         for index in model._meta.indexes:
-            columns = [_resolve_column(field) for field, _ in index.fields_orders]
-            if old_field.column in columns or new_field.column in columns:
-                index_columns.append(columns)
+            replacements = meta_index_replacements.get(index.name, {})
+            try:
+                fields = [
+                    model._meta.get_field(replacements.get(field_name, field_name))
+                    for field_name, _ in index.fields_orders
+                ]
+                fields += [
+                    model._meta.get_field(replacements.get(field_name, field_name))
+                    for field_name in index.include
+                ]
+                fields += [
+                    model._meta.get_field(replacements.get(field_name, field_name))
+                    for field_name in self._get_condition_field_names(index.condition)
+                ]
+            except FieldDoesNotExist:
+                continue
+            if old_field.column in [field.column for field in fields] or new_field.column in [field.column for field in fields]:
+                index_names.append(index.name)
 
         for fields in model._meta.unique_together:
-            columns = [_resolve_column(field) for field in fields]
+            columns = [model._meta.get_field(field).column for field in fields]
             if old_field.column in columns or new_field.column in columns:
                 index_columns.append(columns)
-        if index_columns:
-            # remove duplicates first
-            temp = []
-            for columns in index_columns:
-                if columns not in temp:
-                    temp.append(columns)
-            index_columns = temp
-
-            for columns in index_columns:
-                index_names = self._constraint_names(model, columns, index=True)
-                for index_name in index_names:
-                    self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))
+        for columns in {tuple(columns) for columns in index_columns}:
+            index_names.extend(self._constraint_names(model, columns, index=True))
+        for index_name in set(index_names):
+            self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))
         return index_names
 
     def _delete_unique_constraints(self, model, old_field, new_field, strict=False):

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -593,21 +593,36 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 self._db_table_constraint_names(model._meta.db_table, index=True)
             )
             for index in model._meta.indexes:
-                if (
-                    index.name in existing_index_names
-                    and old_field.name in self._get_condition_field_names(index.condition)
-                ):
-                    restored_index = self._clone_index_with_replacements(
-                        index, {old_field.name: new_field.name}
+                if index.name not in existing_index_names:
+                    continue
+                base_replacements = meta_index_replacements.get(index.name)
+                if base_replacements is None:
+                    continue
+                condition_names = {
+                    base_replacements.get(name, name)
+                    for name in self._get_condition_field_names(index.condition)
+                }
+                if old_field.name not in condition_names:
+                    continue
+                replacements = {
+                    stale_name: (
+                        new_field.name if field_name == old_field.name else field_name
                     )
+                    for stale_name, field_name in base_replacements.items()
+                }
+                replacements.setdefault(old_field.name, new_field.name)
+                restored_index = self._clone_index_with_replacements(index, replacements)
+                try:
                     statement = restored_index.create_sql(new_field.model, self)
-                    if statement:
-                        meta_indexes_to_restore.append(statement)
-                        self.execute(
-                            self._delete_constraint_sql(
-                                self.sql_delete_index, model, index.name
-                            )
+                except (AttributeError, FieldDoesNotExist):
+                    continue
+                if statement:
+                    meta_indexes_to_restore.append(statement)
+                    self.execute(
+                        self._delete_constraint_sql(
+                            self.sql_delete_index, model, index.name
                         )
+                    )
 
             self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
             # Restore index(es) now the column has been renamed

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -407,7 +407,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         """
         if old_field.name != new_field.name:
             self._rename_meta_index_references(
-                new_field.model, old_field.name, new_field.name
+                getattr(new_field, 'model', model), old_field.name, new_field.name
             )
         super().alter_field(model, old_field, new_field, strict=strict)
 
@@ -466,7 +466,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if (old_is_auto and not new_is_auto) or (not old_is_auto and new_is_auto):
             raise NotImplementedError("the backend doesn't support altering from %s to %s." %
                 (old_field.get_internal_type(), new_field.get_internal_type()))
-        meta_model = new_field.model
+        meta_model = getattr(new_field, 'model', model)
 
 
         meta_index_replacements = self._get_meta_index_replacements(model)

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -61,6 +61,35 @@ def _clone_index_with_replacements(index, replacements):
     return index.__class__(*args, **kwargs)
 
 
+def _clone_constraint_with_replacements(constraint, replacements):
+    """Clone a structured Meta.constraints UniqueConstraint with renamed
+    field references.
+
+    Mirrors _clone_index_with_replacements(): Django does not update
+    Meta.constraints references on ProjectState.rename_field() /
+    RenameField.state_forwards(), so a renamed field left in a preserved
+    UniqueConstraint.condition/fields/include raises FieldError when a
+    later migration operation renders it.
+    """
+    if not replacements or not isinstance(constraint, UniqueConstraint):
+        return constraint
+    _, args, kwargs = constraint.deconstruct()
+    kwargs['fields'] = tuple(
+        replacements.get(field_name, field_name)
+        for field_name in constraint.fields
+    )
+    if constraint.include:
+        kwargs['include'] = tuple(
+            replacements.get(field_name, field_name)
+            for field_name in constraint.include
+        )
+    if constraint.condition:
+        condition = copy.deepcopy(constraint.condition)
+        _replace_condition_field_names(condition, replacements)
+        kwargs['condition'] = condition
+    return constraint.__class__(*args, **kwargs)
+
+
 def _replace_condition_field_names(condition, replacements):
     """Rewrite lookup roots and nested F() references in a copied Q tree.
 
@@ -95,16 +124,33 @@ def _replace_expression_field_names(expression, replacements):
     return expression
 
 
-def _replace_meta_index_field_names(model_state, old_name, new_name):
-    """Replace renamed field references in structured Meta.indexes state."""
-    indexes = model_state.options.get('indexes')
+def _replace_options_field_names(options, old_name, new_name):
+    """Rewrite renamed field references in a Meta options mapping's
+    structured indexes/constraints (shared by ModelState.options and a raw
+    migration operation's .options dict)."""
+    indexes = options.get('indexes')
     if indexes is not None:
-        # ModelState.clone() shallow-copies options, so replace the list to protect
-        # the preserved state used by a migration operation.
-        model_state.options['indexes'] = [
+        options['indexes'] = [
             _clone_index_with_replacements(index, {old_name: new_name})
             for index in indexes
         ]
+    constraints = options.get('constraints')
+    if constraints is not None:
+        options['constraints'] = [
+            _clone_constraint_with_replacements(constraint, {old_name: new_name})
+            for constraint in constraints
+        ]
+
+
+def _replace_meta_index_field_names(model_state, old_name, new_name):
+    """Replace renamed field references in structured Meta.indexes/
+    .constraints state.
+
+    ModelState.clone() shallow-copies options, so _replace_options_field_names()
+    replaces each affected list rather than mutating it, to protect the
+    preserved state used by a migration operation.
+    """
+    _replace_options_field_names(model_state.options, old_name, new_name)
 
 
 def _rename_field_with_meta_indexes(self, app_label, model_name, old_name, new_name):
@@ -768,11 +814,41 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                         )
                     )
 
+            # A filtered UniqueConstraint (Meta.constraints) whose condition
+            # references the renamed field is not caught by the unique-index
+            # drop above (that only matches by physical key column), so SQL
+            # Server would otherwise refuse the rename with "index is
+            # dependent on column". Mirror the Meta.indexes handling above.
+            meta_constraints_to_restore = []
+            for constraint in model._meta.constraints:
+                if not isinstance(constraint, UniqueConstraint) or not constraint.condition:
+                    continue
+                if constraint.name not in existing_index_names:
+                    continue
+                reference_names = (
+                    list(constraint.fields) + list(constraint.include)
+                    + self._get_condition_field_names(constraint.condition)
+                )
+                if old_field.name not in reference_names:
+                    continue
+                restored_constraint = _clone_constraint_with_replacements(
+                    constraint, {old_field.name: new_field.name}
+                )
+                statement = restored_constraint.create_sql(meta_model, self)
+                if statement:
+                    meta_constraints_to_restore.append(statement)
+                    self.execute(
+                        self._delete_constraint_sql(
+                            self.sql_delete_index, model, constraint.name
+                        )
+                    )
             self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
             # Restore index(es) now the column has been renamed
             if sql_restore_index:
                 self.execute(sql_restore_index.replace(f'[{old_field.column}]', f'[{new_field.column}]'))
             for statement in meta_indexes_to_restore:
+                self.execute(statement)
+            for statement in meta_constraints_to_restore:
                 self.execute(statement)
             # Rename all deferred references to the renamed column.
             for sql in self.deferred_sql:

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -91,6 +91,11 @@ def _clone_constraint_with_replacements(constraint, replacements):
     return constraint.__class__(*args, **kwargs)
 
 
+def _split_field_lookup(name):
+    """Split a lookup/transform path into its root field name and suffix."""
+    return name.split('__', 1) if '__' in name else (name, '')
+
+
 def _replace_condition_field_names(condition, replacements):
     """Rewrite lookup roots and nested F() references in a copied Q tree.
 
@@ -100,9 +105,7 @@ def _replace_condition_field_names(condition, replacements):
         if hasattr(child, 'children'):
             _replace_condition_field_names(child, replacements)
         elif isinstance(child, tuple):
-            field_name, lookup = (
-                child[0].split('__', 1) if '__' in child[0] else (child[0], '')
-            )
+            field_name, lookup = _split_field_lookup(child[0])
             condition.children[index] = (
                 replacements.get(field_name, field_name) + ('__' + lookup if lookup else ''),
                 _replace_expression_field_names(child[1], replacements),
@@ -114,9 +117,20 @@ def _replace_condition_field_names(condition, replacements):
 
 
 def _replace_expression_field_names(expression, replacements):
-    """Rewrite F() references in a copied condition expression tree."""
+    """Rewrite F() references in a copied condition expression tree.
+
+    Recurses into list/tuple RHS values (e.g. `a__in=(F('b'),)`) and strips
+    a lookup/transform suffix before replacing only the root of an F() path
+    (e.g. `F('a__year')` renaming `a`, not the literal string `'a__year'`).
+    """
     if isinstance(expression, F):
-        return F(replacements.get(expression.name, expression.name))
+        root, suffix = _split_field_lookup(expression.name)
+        return F(replacements.get(root, root) + ('__' + suffix if suffix else ''))
+    if isinstance(expression, (list, tuple)):
+        return type(expression)(
+            _replace_expression_field_names(item, replacements)
+            for item in expression
+        )
     if hasattr(expression, 'get_source_expressions'):
         expression.set_source_expressions([
             _replace_expression_field_names(source_expression, replacements)
@@ -1418,7 +1432,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def _get_expression_field_names(self, expression):
         """Return field names referenced recursively by an expression tree."""
         if isinstance(expression, F):
-            return [expression.name]
+            return [expression.name.split('__', 1)[0]]
+        if isinstance(expression, (list, tuple)):
+            return [
+                field_name
+                for item in expression
+                for field_name in self._get_expression_field_names(item)
+            ]
         if hasattr(expression, 'get_source_expressions'):
             return [
                 field_name

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -24,6 +24,7 @@ from django.db.backends.ddl_references import (
 from django import VERSION as django_version
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import F, NOT_PROVIDED, Index, UniqueConstraint
+from django.db.migrations.operations.fields import RenameField
 from django.db.models.fields import AutoField, BigAutoField
 from django.db.models.fields.related import ForeignKey
 from django.db.models.sql import Query
@@ -94,6 +95,18 @@ def _replace_expression_field_names(expression, replacements):
     return expression
 
 
+def _replace_meta_index_field_names(model_state, old_name, new_name):
+    """Replace renamed field references in structured Meta.indexes state."""
+    indexes = model_state.options.get('indexes')
+    if indexes is not None:
+        # ModelState.clone() shallow-copies options, so replace the list to protect
+        # the preserved state used by a migration operation.
+        model_state.options['indexes'] = [
+            _clone_index_with_replacements(index, {old_name: new_name})
+            for index in indexes
+        ]
+
+
 def _rename_field_with_meta_indexes(self, app_label, model_name, old_name, new_name):
     """Keep structured Meta.indexes state consistent with Django field renames.
 
@@ -103,27 +116,31 @@ def _rename_field_with_meta_indexes(self, app_label, model_name, old_name, new_n
     MigrationExecutor builds state.
     """
     model_state = self.models[(app_label, model_name)]
-    if old_name not in model_state.fields:
-        return ProjectState._mssql_original_rename_field(
-            self, app_label, model_name, old_name, new_name
-        )
-    indexes = model_state.options.get('indexes')
-    if indexes is not None:
-        # ModelState.clone() shallow-copies options, so replace the list to protect
-        # the preserved state used by a migration operation.
-        model_state.options['indexes'] = [
-            _clone_index_with_replacements(index, {old_name: new_name})
-            for index in indexes
-        ]
+    if old_name in model_state.fields:
+        _replace_meta_index_field_names(model_state, old_name, new_name)
     return ProjectState._mssql_original_rename_field(
         self, app_label, model_name, old_name, new_name
     )
 
 
-# The private ProjectState sentinel prevents a module reload from stacking wrappers.
+def _rename_field_state_forwards_with_meta_indexes(self, app_label, state):
+    """Keep Django 3.2 Meta.indexes state consistent with field renames."""
+    model_state = state.models[(app_label, self.model_name_lower)]
+    if self.old_name in model_state.fields:
+        _replace_meta_index_field_names(model_state, self.old_name, self.new_name)
+    return RenameField._mssql_original_state_forwards(self, app_label, state)
+
+
+# The private sentinels prevent a module reload from stacking wrappers.
 if django_version >= (4, 0) and not hasattr(ProjectState, '_mssql_original_rename_field'):
     ProjectState._mssql_original_rename_field = ProjectState.rename_field
     ProjectState.rename_field = _rename_field_with_meta_indexes
+
+if (3, 2) <= django_version < (4, 0) and not hasattr(
+    RenameField, '_mssql_original_state_forwards'
+):
+    RenameField._mssql_original_state_forwards = RenameField.state_forwards
+    RenameField.state_forwards = _rename_field_state_forwards_with_meta_indexes
 
 
 # Import CompositePrimaryKey only if Django version is 5.2 or higher

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -1553,6 +1553,14 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         its deferred CREATE INDEX statement runs at schema_editor context
         exit, and would otherwise be recreated here too, colliding with that
         still-pending statement once it finally executes.
+
+        When the drop came from the AutoField/BigAutoField path, every index
+        and unique constraint on the table was unconditionally dropped, not
+        just Meta.indexes - also restore db_index=True columns,
+        index_together (Django < 5.1), unique_together, and Meta.constraints
+        UniqueConstraint objects, the same way the non-renamed "column
+        alteration cleanup" path restores them for a plain (non-renamed)
+        AutoField/BigAutoField change.
         """
         if not dropped_index_names:
             return
@@ -1566,6 +1574,48 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 index, {old_field.name: new_field.name}
             )
             statement = restored_index.create_sql(model, self)
+            if statement:
+                self.execute(statement)
+
+        is_autofield_change = (
+            isinstance(old_field, (AutoField, BigAutoField)) or
+            isinstance(new_field, (AutoField, BigAutoField))
+        )
+        if not is_autofield_change:
+            return
+
+        index_columns = []
+        for field in model._meta.fields:
+            if field.db_index:
+                index_columns.append([field])
+        if django_version < (5, 1):
+            for fields in model._meta.index_together:
+                index_columns.append([model._meta.get_field(f) for f in fields])
+        for columns in index_columns:
+            create_index_sql_statement = self._create_index_sql(model, columns)
+            if str(create_index_sql_statement) not in [str(sql) for sql in self.deferred_sql]:
+                self.execute(create_index_sql_statement)
+
+        for field_names in model._meta.unique_together:
+            columns = [model._meta.get_field(f).column for f in field_names]
+            fields = [model._meta.get_field(f) for f in field_names]
+            condition = ' AND '.join(["[%s] IS NOT NULL" % col for col in columns])
+            if django_version >= (4, 0):
+                self.execute(self._create_unique_sql(model, fields, condition=condition))
+            else:
+                self.execute(self._create_unique_sql(model, columns, condition=condition))
+
+        for constraint in model._meta.constraints:
+            if (
+                not isinstance(constraint, UniqueConstraint)
+                or constraint.name not in dropped_index_names
+                or constraint.name in existing_index_names
+            ):
+                continue
+            restored_constraint = _clone_constraint_with_replacements(
+                constraint, {old_field.name: new_field.name}
+            )
+            statement = restored_constraint.create_sql(model, self)
             if statement:
                 self.execute(statement)
 

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -1176,6 +1176,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 field_names.extend(self._get_condition_field_names(child))
             elif isinstance(child, tuple):
                 field_names.append(child[0].split('__', 1)[0])
+                field_names.extend(self._get_expression_field_names(child[1]))
             else:
                 field_names.extend(self._get_expression_field_names(child))
         return field_names
@@ -1248,10 +1249,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 self._replace_condition_field_names(child, replacements)
             elif isinstance(child, tuple):
                 field_name, lookup = child[0].split('__', 1) if '__' in child[0] else (child[0], '')
-                if field_name in replacements:
-                    condition.children[index] = (
-                        replacements[field_name] + ('__' + lookup if lookup else ''), child[1]
-                    )
+                condition.children[index] = (
+                    replacements.get(field_name, field_name) + ('__' + lookup if lookup else ''),
+                    self._replace_expression_field_names(child[1], replacements),
+                )
             else:
                 condition.children[index] = self._replace_expression_field_names(
                     child, replacements

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -1912,13 +1912,32 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             opclasses=opclasses, condition=condition,
         )
 
-    def _create_deferred_unique_constraint_sql(self, model, constraint):
-        """Create a conditional unique constraint as a deferred filtered index."""
-        if constraint.condition.connector != AND:
+    def _validate_unique_constraint_condition(self, condition, constraint_name):
+        """Recursively verify a conditional UniqueConstraint's Q tree only uses
+        AND connectors with no negation, the only predicate shape SQL Server
+        supports in a filtered index. A root-only check lets a nested OR
+        (`Q(a=1) & (Q(b=2) | Q(c=3))`) or a negated Q (`~Q(a=1)`, which still
+        reports connector == AND at the root) through, producing a filtered-index
+        predicate SQL Server rejects with a raw syntax error instead of this
+        NotImplementedError.
+        """
+        if condition.negated:
+            raise NotImplementedError(
+                "The backend does not support negated conditions on unique constraint %s." %
+                constraint_name
+            )
+        if condition.connector != AND:
             raise NotImplementedError(
                 "The backend does not support %s conditions on unique constraint %s." %
-                (constraint.condition.connector, constraint.name)
+                (condition.connector, constraint_name)
             )
+        for child in condition.children:
+            if hasattr(child, 'children'):
+                self._validate_unique_constraint_condition(child, constraint_name)
+
+    def _create_deferred_unique_constraint_sql(self, model, constraint):
+        """Create a conditional unique constraint as a deferred filtered index."""
+        self._validate_unique_constraint_condition(constraint.condition, constraint.name)
         condition = IndexCondition(model, constraint.condition, self)
         kwargs = {
             'name': constraint.name,
@@ -2239,9 +2258,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 self.deferred_sql.remove(sql)
 
     def add_constraint(self, model, constraint):
-        if isinstance(constraint, UniqueConstraint) and constraint.condition and constraint.condition.connector != AND:
-            raise NotImplementedError("The backend does not support %s conditions on unique constraint %s." %
-                                      (constraint.condition.connector, constraint.name))
+        if isinstance(constraint, UniqueConstraint) and constraint.condition:
+            self._validate_unique_constraint_condition(constraint.condition, constraint.name)
         super().add_constraint(model, constraint)
 
     if django_version >= (4, 2):

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -780,6 +780,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         for t in (AutoField, BigAutoField):
             if isinstance(old_field, t) or isinstance(new_field, t):
                 index_names = self._constraint_names(model, index=True)
+                dropped_meta_index_names.update(index_names)
                 for index_name in index_names:
                     self.execute(
                         self._delete_constraint_sql(self.sql_delete_index, model, index_name)
@@ -1512,15 +1513,21 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return replacements
 
     def _restore_missing_meta_indexes(self, model, old_field, new_field, dropped_index_names):
-        """Recreate a named Meta.indexes entry referencing the renamed field
-        that was dropped from the table earlier in this _alter_field() call.
+        """Recreate a named Meta.indexes entry that was dropped from the
+        table earlier in this _alter_field() call.
 
         The rename-restoration block above only recreates a Meta.indexes entry
         whose filtered `condition` references the renamed field; a combined
         column rename and type/nullability change drops a plain (non-
         conditional) Meta.indexes entry via _delete_indexes() without
         recreating it, because the later "column alteration cleanup"
-        restoration is skipped whenever the column was renamed.
+        restoration is skipped whenever the column was renamed. The
+        AutoField/BigAutoField "drop all indexes" path above drops every
+        index on the table regardless of which field it references, for the
+        same reason - so a dropped index here is not necessarily one that
+        references the renamed field at all; _clone_index_with_replacements()
+        is a no-op for names it doesn't contain, so restoring unconditionally
+        is safe.
 
         Restricting to `dropped_index_names` (rather than any index simply
         absent from the catalog) is required: an index declared inline via
@@ -1536,13 +1543,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         )
         for index in model._meta.indexes:
             if index.name not in dropped_index_names or index.name in existing_index_names:
-                continue
-            reference_names = (
-                [field_name for field_name, _ in index.fields_orders]
-                + list(index.include)
-                + self._get_condition_field_names(index.condition)
-            )
-            if old_field.name not in reference_names:
                 continue
             restored_index = _clone_index_with_replacements(
                 index, {old_field.name: new_field.name}

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -22,7 +22,7 @@ from django.db.backends.ddl_references import (
 )
 from django import VERSION as django_version
 from django.core.exceptions import FieldDoesNotExist
-from django.db.models import NOT_PROVIDED, Index, UniqueConstraint
+from django.db.models import F, NOT_PROVIDED, Index, UniqueConstraint
 from django.db.models.fields import AutoField, BigAutoField
 from django.db.models.fields.related import ForeignKey
 from django.db.models.sql.where import AND
@@ -52,6 +52,14 @@ class Statement(DjStatement):
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
+    def _rename_statement_column_references(self, statement, table, old_column, new_column):
+        statement.rename_column_references(table, old_column, new_column)
+        condition = statement.parts.get('condition')
+        if condition:
+            statement.parts['condition'] = condition.replace(
+                f'[{old_column}]', f'[{new_column}]'
+            )
+
 
     _sql_check_constraint = " CONSTRAINT %(name)s CHECK (%(check)s)"
     _sql_select_default_constraint_name = "SELECT" \
@@ -594,14 +602,40 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     index_name, model._meta.db_table, columns_to_recreate_index, filter_definition)
                 self.execute(self._db_table_delete_constraint_sql(
                     self.sql_delete_index, model._meta.db_table, index_name))
+
+            meta_indexes_to_restore = []
+            existing_index_names = set(
+                self._db_table_constraint_names(model._meta.db_table, index=True)
+            )
+            for index in model._meta.indexes:
+                if (
+                    index.name in existing_index_names
+                    and old_field.name in self._get_condition_field_names(index.condition)
+                ):
+                    statement = index.create_sql(model, self)
+                    if statement:
+                        meta_indexes_to_restore.append(statement)
+                        self.execute(
+                            self._delete_constraint_sql(
+                                self.sql_delete_index, model, index.name
+                            )
+                        )
+
             self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
             # Restore index(es) now the column has been renamed
             if sql_restore_index:
                 self.execute(sql_restore_index.replace(f'[{old_field.column}]', f'[{new_field.column}]'))
+            for statement in meta_indexes_to_restore:
+                self._rename_statement_column_references(
+                    statement, model._meta.db_table, old_field.column, new_field.column
+                )
+                self.execute(statement)
             # Rename all references to the renamed column.
             for sql in self.deferred_sql:
                 if isinstance(sql, DjStatement):
-                    sql.rename_column_references(model._meta.db_table, old_field.column, new_field.column)
+                    self._rename_statement_column_references(
+                        sql, model._meta.db_table, old_field.column, new_field.column
+                    )
 
         # ===============================================================================
         # 2. Column alter preparation
@@ -955,7 +989,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # For other changes, only restore indexes involving the altered field.
             # --------------------------------------------------------------------------------
             for index in model._meta.indexes:
-                replacements = meta_index_replacements.get(index.name)
+                replacements = meta_index_replacements.get(index.name, {})
                 try:
                     index_fields = [
                         model._meta.get_field(replacements.get(field_name, field_name))
@@ -1116,6 +1150,17 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             )
             return cursor.fetchall()
 
+    def _get_expression_field_names(self, expression):
+        if isinstance(expression, F):
+            return [expression.name]
+        if hasattr(expression, 'get_source_expressions'):
+            return [
+                field_name
+                for source_expression in expression.get_source_expressions()
+                for field_name in self._get_expression_field_names(source_expression)
+            ]
+        return []
+
     def _get_condition_field_names(self, condition):
         if condition is None:
             return []
@@ -1123,8 +1168,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         for child in condition.children:
             if hasattr(child, 'children'):
                 field_names.extend(self._get_condition_field_names(child))
-            else:
+            elif isinstance(child, tuple):
                 field_names.append(child[0].split('__', 1)[0])
+            else:
+                field_names.extend(self._get_expression_field_names(child))
         return field_names
 
     def _get_meta_index_replacements(self, model):
@@ -1194,12 +1241,26 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         for index, child in enumerate(condition.children):
             if hasattr(child, 'children'):
                 self._replace_condition_field_names(child, replacements)
-            else:
+            elif isinstance(child, tuple):
                 field_name, lookup = child[0].split('__', 1) if '__' in child[0] else (child[0], '')
                 if field_name in replacements:
                     condition.children[index] = (
                         replacements[field_name] + ('__' + lookup if lookup else ''), child[1]
                     )
+            else:
+                condition.children[index] = self._replace_expression_field_names(
+                    child, replacements
+                )
+
+    def _replace_expression_field_names(self, expression, replacements):
+        if isinstance(expression, F):
+            return F(replacements.get(expression.name, expression.name))
+        if hasattr(expression, 'get_source_expressions'):
+            expression.set_source_expressions([
+                self._replace_expression_field_names(source_expression, replacements)
+                for source_expression in expression.get_source_expressions()
+            ])
+        return expression
 
     def _delete_indexes(self, model, old_field, new_field, meta_index_replacements=None):
         if (
@@ -1251,7 +1312,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 index_columns.append(columns)
         for columns in {tuple(columns) for columns in index_columns}:
             index_names.extend(self._constraint_names(model, columns, index=True))
-        for index_name in set(index_names):
+        existing_index_names = set(
+            self._db_table_constraint_names(model._meta.db_table, index=True)
+        )
+        for index_name in set(index_names) & existing_index_names:
             self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))
         return index_names
 
@@ -1262,7 +1326,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # afterwards then that is handled separately in _alter_field
         if old_field.unique and new_field.unique:
             unique_columns.append([old_field.column])
-
         # Also consider unique_together because, although this is implemented with a filtered unique INDEX now, we
         # need to handle the possibility that we're acting on a database previously created by an older version of
         # this backend, where unique_together used to be implemented with a CONSTRAINT

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -850,7 +850,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     old_field.name: new_field.name,
                 }
                 restored_index = _clone_index_with_replacements(index, replacements)
-                statement = restored_index.create_sql(new_field.model, self)
+                statement = restored_index.create_sql(meta_model, self)
                 if statement:
                     meta_indexes_to_restore.append(statement)
                     self.execute(

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -42,24 +42,9 @@ class Statement(DjStatement):
     def __eq__(self, other):
         return self.template == other.template and str(self.parts['name']) == str(other.parts['name'])
 
-    def rename_column_references(self, table, old_column, new_column):
-        for part in self.parts.values():
-            if hasattr(part, 'rename_column_references'):
-                part.rename_column_references(table, old_column, new_column)
-            condition = self.parts['condition']
-            if condition:
-                self.parts['condition'] = condition.replace(f'[{old_column}]', f'[{new_column}]')
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
-    def _rename_statement_column_references(self, statement, table, old_column, new_column):
-        statement.rename_column_references(table, old_column, new_column)
-        condition = statement.parts.get('condition')
-        if condition:
-            statement.parts['condition'] = condition.replace(
-                f'[{old_column}]', f'[{new_column}]'
-            )
-
 
     _sql_check_constraint = " CONSTRAINT %(name)s CHECK (%(check)s)"
     _sql_select_default_constraint_name = "SELECT" \
@@ -612,7 +597,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     index.name in existing_index_names
                     and old_field.name in self._get_condition_field_names(index.condition)
                 ):
-                    statement = index.create_sql(model, self)
+                    restored_index = self._clone_index_with_replacements(
+                        index, {old_field.name: new_field.name}
+                    )
+                    statement = restored_index.create_sql(new_field.model, self)
                     if statement:
                         meta_indexes_to_restore.append(statement)
                         self.execute(
@@ -626,15 +614,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             if sql_restore_index:
                 self.execute(sql_restore_index.replace(f'[{old_field.column}]', f'[{new_field.column}]'))
             for statement in meta_indexes_to_restore:
-                self._rename_statement_column_references(
-                    statement, model._meta.db_table, old_field.column, new_field.column
-                )
                 self.execute(statement)
             # Rename all references to the renamed column.
             for sql in self.deferred_sql:
                 if isinstance(sql, DjStatement):
-                    self._rename_statement_column_references(
-                        sql, model._meta.db_table, old_field.column, new_field.column
+                    sql.rename_column_references(
+                        model._meta.db_table, old_field.column, new_field.column
                     )
 
         # ===============================================================================

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -121,7 +121,7 @@ def _rename_field_with_meta_indexes(self, app_label, model_name, old_name, new_n
 
 
 # The private ProjectState sentinel prevents a module reload from stacking wrappers.
-if not hasattr(ProjectState, '_mssql_original_rename_field'):
+if django_version >= (4, 0) and not hasattr(ProjectState, '_mssql_original_rename_field'):
     ProjectState._mssql_original_rename_field = ProjectState.rename_field
     ProjectState.rename_field = _rename_field_with_meta_indexes
 
@@ -1642,7 +1642,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     table=self.quote_name(table) if isinstance(table, str) else table,
                     name=name,
                     columns=columns,
-                    condition=' WHERE ' + condition,
+                    condition=(
+                        condition
+                        if isinstance(condition, NullableColumns)
+                        else ' WHERE ' + condition
+                    ),
                     **statement_args,
                     include=include,
                 ) if self.connection.features.supports_partial_indexes else None

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -1137,6 +1137,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             self.connection.close()
 
     def _get_index_metadata(self, model, index_name):
+        """Return key/include columns and the filter definition for a physical index."""
         with self.connection.cursor() as cursor:
             cursor.execute(
                 """
@@ -1154,6 +1155,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             return cursor.fetchall()
 
     def _get_expression_field_names(self, expression):
+        """Return field names referenced recursively by an expression tree."""
         if isinstance(expression, F):
             return [expression.name]
         if hasattr(expression, 'get_source_expressions'):
@@ -1165,6 +1167,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return []
 
     def _get_condition_field_names(self, condition):
+        """Return lookup and expression field names referenced by a Q condition."""
         if condition is None:
             return []
         field_names = []
@@ -1178,6 +1181,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return field_names
 
     def _get_meta_index_replacements(self, model):
+        """Map each reconciled Meta index to its unambiguous stale field replacements."""
         fields_by_column = {field.column: field for field in model._meta.fields}
         replacements = {}
         for index in model._meta.indexes:
@@ -1221,6 +1225,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return replacements
 
     def _clone_index_with_replacements(self, index, replacements):
+        """Clone an Index while replacing field names in keys, includes, and conditions."""
         if not replacements:
             return index
         _, args, kwargs = index.deconstruct()
@@ -1237,6 +1242,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return index.__class__(*args, **kwargs)
 
     def _replace_condition_field_names(self, condition, replacements):
+        """Mutate a Q condition tree to replace referenced lookup and expression fields."""
         for index, child in enumerate(condition.children):
             if hasattr(child, 'children'):
                 self._replace_condition_field_names(child, replacements)
@@ -1252,6 +1258,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 )
 
     def _replace_expression_field_names(self, expression, replacements):
+        """Mutate an expression tree to replace F() field references."""
         if isinstance(expression, F):
             return F(replacements.get(expression.name, expression.name))
         if hasattr(expression, 'get_source_expressions'):

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -43,6 +43,16 @@ class Statement(DjStatement):
         return self.template == other.template and str(self.parts['name']) == str(other.parts['name'])
 
 
+class NullableColumns(Columns):
+    """Reference nullable unique-index columns in deferred schema SQL."""
+
+    def __str__(self):
+        return ' WHERE ' + ' AND '.join(
+            '%s IS NOT NULL' % self.quote_name(column) for column in self.columns
+        )
+
+
+
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
@@ -1522,15 +1532,20 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             include = self._index_include_sql(model, include)
 
             if condition:
+                condition = (
+                    condition
+                    if isinstance(condition, NullableColumns)
+                    else ' WHERE ' + condition
+                )
                 return Statement(
                     self.sql_create_unique_index,
                     table=self.quote_name(table),
                     name=name,
                     columns=columns,
-                    condition=' WHERE ' + condition,
+                    condition=condition,
                     **statement_args,
                     include=include,
-                    nulls_distinct=''
+                    nulls_distinct='',
                 ) if self.connection.features.supports_partial_indexes else None
             else:
                 return Statement(
@@ -1686,7 +1701,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         for field_names in model._meta.unique_together:
             fields = [model._meta.get_field(field) for field in field_names]
             columns = [model._meta.get_field(field).column for field in field_names]
-            condition = ' AND '.join(["[%s] IS NOT NULL" % col for col in columns])
+            condition = NullableColumns(
+                model._meta.db_table, columns, self.quote_name
+            )
             if django_version >= (4, 0):
                 self.deferred_sql.append(self._create_unique_sql(model, fields, condition=condition))
             else:

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -616,6 +616,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             for statement in meta_indexes_to_restore:
                 self.execute(statement)
             # Rename all references to the renamed column.
+            # Deferred Statement conditions are already-rendered SQL. Rewriting them
+            # would mutate string literals; filtered Meta.indexes in this path remain
+            # unsupported. See test_deferred_filtered_meta_index_after_field_rename.
             for sql in self.deferred_sql:
                 if isinstance(sql, DjStatement):
                     sql.rename_column_references(

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -16,6 +16,7 @@ from django.db.backends.base.schema import (
 )
 from django.db.backends.ddl_references import (
     Columns,
+    Expressions,
     IndexName,
     Statement as DjStatement,
     Table,
@@ -25,6 +26,7 @@ from django.core.exceptions import FieldDoesNotExist
 from django.db.models import F, NOT_PROVIDED, Index, UniqueConstraint
 from django.db.models.fields import AutoField, BigAutoField
 from django.db.models.fields.related import ForeignKey
+from django.db.models.sql import Query
 from django.db.models.sql.where import AND
 from django.db.transaction import TransactionManagementError
 from django.utils.encoding import force_str
@@ -124,9 +126,6 @@ if not hasattr(ProjectState, '_mssql_original_rename_field'):
     ProjectState.rename_field = _rename_field_with_meta_indexes
 
 
-if django_version >= (4, 0):
-    from django.db.models.sql import Query
-    from django.db.backends.ddl_references import Expressions
 # Import CompositePrimaryKey only if Django version is 5.2 or higher
 if django_version >= (5, 2):    
     from django.db.models.fields.composite import CompositePrimaryKey
@@ -145,6 +144,20 @@ class NullableColumns(Columns):
         return ' WHERE ' + ' AND '.join(
             '%s IS NOT NULL' % self.quote_name(column) for column in self.columns
         )
+
+class IndexCondition(Expressions):
+    """Reference a filtered Meta.index condition in deferred schema SQL."""
+
+    def __init__(self, model, condition, schema_editor):
+        query = Query(model=model, alias_cols=False)
+        where = query.build_where(condition)
+        compiler = query.get_compiler(connection=schema_editor.connection)
+        super().__init__(
+            model._meta.db_table, where, compiler, schema_editor.quote_value
+        )
+
+    def __str__(self):
+        return ' WHERE ' + super().__str__()
 
 
 
@@ -391,6 +404,17 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 sql = self._create_unique_sql(model, columns, condition=condition)
                 self.execute(sql)
 
+    def _create_deferred_meta_index_sql(self, model, index):
+        if index.condition is None:
+            return index.create_sql(model, self)
+        condition = index.condition
+        index = index.clone()
+        index.condition = None
+        statement = index.create_sql(model, self)
+        if statement is not None:
+            statement.parts['condition'] = IndexCondition(model, condition, self)
+        return statement
+
     def _model_indexes_sql(self, model):
         """
         Return a list of all index SQL statements (field indexes,
@@ -431,9 +455,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 not index.contains_expressions or
                 self.connection.features.supports_expression_indexes
             ):
-                output.append(index.create_sql(model, self))
+                sql = self._create_deferred_meta_index_sql(model, index)
+                if sql:
+                    output.append(sql)
             else:
-                output.append(index.create_sql(model, self))
+                sql = self._create_deferred_meta_index_sql(model, index)
+                if sql:
+                    output.append(sql)
         return output
 
     def _db_table_constraint_names(self, db_table, column_names=None, column_match_any=False,
@@ -727,10 +755,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 self.execute(sql_restore_index.replace(f'[{old_field.column}]', f'[{new_field.column}]'))
             for statement in meta_indexes_to_restore:
                 self.execute(statement)
-            # Rename all references to the renamed column.
-            # Deferred Statement conditions are already-rendered SQL. Rewriting them
-            # would mutate string literals; filtered Meta.indexes in this path remain
-            # unsupported. See test_deferred_filtered_meta_index_after_field_rename.
+            # Rename all deferred references to the renamed column.
             for sql in self.deferred_sql:
                 if isinstance(sql, DjStatement):
                     sql.rename_column_references(

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -398,6 +398,29 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             params = ()
         return f"GENERATED ALWAYS AS ({expression_sql}) {persistency_sql}", params
 
+    def alter_field(self, model, old_field, new_field, strict=False):
+        """Persist structured Meta.indexes references through field renames.
+
+        RenameField updates ModelState fields but not its indexes option. Rewrite
+        the rendered destination model's original index definitions before the
+        base editor can short-circuit a logical rename or emit physical DDL.
+        """
+        if old_field.name != new_field.name:
+            self._rename_meta_index_references(
+                new_field.model, old_field.name, new_field.name
+            )
+        super().alter_field(model, old_field, new_field, strict=strict)
+
+    def _rename_meta_index_references(self, model, old_name, new_name):
+        """Update migration-state Meta indexes for a logical field rename."""
+        indexes = model._meta.original_attrs.get('indexes')
+        if indexes is None:
+            return
+        indexes[:] = [
+            self._clone_index_with_replacements(index, {old_name: new_name})
+            for index in indexes
+        ]
+
     def _alter_field(self, model, old_field, new_field, old_type, new_type,
                      old_db_params, new_db_params, strict=False):
         """Actually perform a "physical" (non-ManyToMany) field update."""
@@ -443,6 +466,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if (old_is_auto and not new_is_auto) or (not old_is_auto and new_is_auto):
             raise NotImplementedError("the backend doesn't support altering from %s to %s." %
                 (old_field.get_internal_type(), new_field.get_internal_type()))
+        meta_model = new_field.model
+
+
+        meta_index_replacements = self._get_meta_index_replacements(model)
 
         # Drop any FK constraints, we'll remake them later
         fks_dropped = set()
@@ -505,10 +532,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 )
                 for fk_name in rel_fk_names:
                     self.execute(self._delete_constraint_sql(self.sql_delete_fk, new_rel.related_model, fk_name))
-        catalog_meta_index_replacements = self._get_meta_index_replacements(model)
-        meta_index_replacements = self._merge_meta_index_replacements(
-            catalog_meta_index_replacements
-        )
 
         # If working with an AutoField or BigAutoField drop all indexes on the related table
         # This is needed when doing ALTER column statements on IDENTITY fields
@@ -565,12 +588,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 self.execute(self._delete_constraint_sql(self.sql_delete_check, model, constraint_name))
         # Have they renamed the column?
         if old_field.column != new_field.column:
-            self._record_meta_index_rename_replacements(
-                model, old_field, new_field, meta_index_replacements
-            )
-            meta_index_replacements = self._merge_meta_index_replacements(
-                catalog_meta_index_replacements
-            )
             sql_restore_index = ''
             # Drop any unique indexes which include the column to be renamed
             index_names = self._db_table_constraint_names(
@@ -604,22 +621,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             for index in model._meta.indexes:
                 if index.name not in existing_index_names:
                     continue
-                base_replacements = meta_index_replacements.get(index.name)
-                if base_replacements is None:
-                    continue
-                condition_names = {
-                    base_replacements.get(name, name)
-                    for name in self._get_condition_field_names(index.condition)
-                }
-                if new_field.name not in condition_names:
+                base_replacements = meta_index_replacements.get(index.name, {})
+                if old_field.name not in self._get_condition_field_names(index.condition):
                     continue
                 replacements = {
-                    stale_name: (
-                        new_field.name if field_name == old_field.name else field_name
-                    )
-                    for stale_name, field_name in base_replacements.items()
+                    **base_replacements,
+                    old_field.name: new_field.name,
                 }
-                replacements.setdefault(old_field.name, new_field.name)
                 restored_index = self._clone_index_with_replacements(index, replacements)
                 statement = restored_index.create_sql(new_field.model, self)
                 if statement:
@@ -679,7 +687,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             self._delete_unique_constraints(model, old_field, new_field, strict)
             # Drop indexes, SQL Server requires explicit deletion
             self._delete_indexes(
-                model, old_field, new_field,
+                meta_model, old_field, new_field,
                 meta_index_replacements=meta_index_replacements,
             )
 
@@ -735,7 +743,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 self._delete_unique_constraints(model, old_field, new_field, strict)
                 # Drop indexes, SQL Server requires explicit deletion
                 self._delete_indexes(
-                    model, old_field, new_field,
+                    meta_model, old_field, new_field,
                     meta_index_replacements=meta_index_replacements,
                 )
 
@@ -997,7 +1005,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # For AutoField changes, restore ALL Meta.indexes.
             # For other changes, only restore indexes involving the altered field.
             # --------------------------------------------------------------------------------
-            for index in model._meta.indexes:
+            for index in meta_model._meta.indexes:
                 if index.name not in meta_index_replacements:
                     continue
                 replacements = meta_index_replacements.get(index.name, {})
@@ -1008,7 +1016,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 for field_name in reference_names:
                     try:
                         fields.append(
-                            model._meta.get_field(
+                            meta_model._meta.get_field(
                                 replacements.get(field_name, field_name)
                             )
                         )
@@ -1035,7 +1043,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # existing physical index supplied an unambiguous replacement.
             for index, replacements in indexes_to_restore:
                 restored_index = self._clone_index_with_replacements(index, replacements)
-                create_index_sql_statement = restored_index.create_sql(model, self)
+                create_index_sql_statement = restored_index.create_sql(meta_model, self)
                 if create_index_sql_statement and (str(create_index_sql_statement)
                         not in [str(sql) for sql in self.deferred_sql] + [str(statement[0]) for statement in post_actions]
                         ):
@@ -1220,48 +1228,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 replacements[index.name] = index_replacements
         return replacements
 
-    def _merge_meta_index_replacements(self, catalog_replacements):
-        """Merge catalog reconciliation with structured field rename history."""
-        rename_replacements = getattr(self, '_meta_index_rename_replacements', {})
-        replacements = {}
-        for index_name, index_replacements in catalog_replacements.items():
-            rename_replacements_for_index = rename_replacements.get(index_name, {})
-            if any(
-                rename_replacements_for_index[name] != replacement
-                for name, replacement in index_replacements.items()
-                if name in rename_replacements_for_index
-            ):
-                continue
-            replacements[index_name] = {
-                **rename_replacements_for_index,
-                **index_replacements,
-            }
-        return replacements
-
-    def _record_meta_index_rename_replacements(
-        self, model, old_field, new_field, meta_index_replacements
-    ):
-        """Record structured references changed by a Meta.indexes field rename."""
-        for index in model._meta.indexes:
-            replacements = meta_index_replacements.get(index.name)
-            if replacements is None:
-                continue
-            field_names = [field_name for field_name, _ in index.fields_orders]
-            field_names += list(index.include)
-            field_names += self._get_condition_field_names(index.condition)
-            if old_field.name not in {
-                replacements.get(field_name, field_name) for field_name in field_names
-            }:
-                continue
-            if not hasattr(self, '_meta_index_rename_replacements'):
-                self._meta_index_rename_replacements = {}
-            index_replacements = self._meta_index_rename_replacements.setdefault(
-                index.name, {}
-            )
-            for field_name, replacement in list(index_replacements.items()):
-                if replacement == old_field.name:
-                    index_replacements[field_name] = new_field.name
-            index_replacements.setdefault(old_field.name, new_field.name)
 
     def _clone_index_with_replacements(self, index, replacements):
         """Clone an Index while replacing field names in keys, includes, and conditions."""

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -505,7 +505,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 )
                 for fk_name in rel_fk_names:
                     self.execute(self._delete_constraint_sql(self.sql_delete_fk, new_rel.related_model, fk_name))
-        meta_index_replacements = self._get_meta_index_replacements(model)
+        catalog_meta_index_replacements = self._get_meta_index_replacements(model)
+        meta_index_replacements = self._merge_meta_index_replacements(
+            catalog_meta_index_replacements
+        )
 
         # If working with an AutoField or BigAutoField drop all indexes on the related table
         # This is needed when doing ALTER column statements on IDENTITY fields
@@ -562,6 +565,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 self.execute(self._delete_constraint_sql(self.sql_delete_check, model, constraint_name))
         # Have they renamed the column?
         if old_field.column != new_field.column:
+            self._record_meta_index_rename_replacements(
+                model, old_field, new_field, meta_index_replacements
+            )
+            meta_index_replacements = self._merge_meta_index_replacements(
+                catalog_meta_index_replacements
+            )
             sql_restore_index = ''
             # Drop any unique indexes which include the column to be renamed
             index_names = self._db_table_constraint_names(
@@ -602,7 +611,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     base_replacements.get(name, name)
                     for name in self._get_condition_field_names(index.condition)
                 }
-                if old_field.name not in condition_names:
+                if new_field.name not in condition_names:
                     continue
                 replacements = {
                     stale_name: (
@@ -612,10 +621,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 }
                 replacements.setdefault(old_field.name, new_field.name)
                 restored_index = self._clone_index_with_replacements(index, replacements)
-                try:
-                    statement = restored_index.create_sql(new_field.model, self)
-                except (AttributeError, FieldDoesNotExist):
-                    continue
+                statement = restored_index.create_sql(new_field.model, self)
                 if statement:
                     meta_indexes_to_restore.append(statement)
                     self.execute(
@@ -992,25 +998,31 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # For other changes, only restore indexes involving the altered field.
             # --------------------------------------------------------------------------------
             for index in model._meta.indexes:
-                replacements = meta_index_replacements.get(index.name, {})
-                try:
-                    index_fields = [
-                        model._meta.get_field(replacements.get(field_name, field_name))
-                        for field_name, _ in index.fields_orders
-                    ]
-                    included_fields = [
-                        model._meta.get_field(replacements.get(field_name, field_name))
-                        for field_name in index.include
-                    ]
-                    condition_fields = [
-                        model._meta.get_field(replacements.get(field_name, field_name))
-                        for field_name in self._get_condition_field_names(index.condition)
-                    ]
-                except (AttributeError, FieldDoesNotExist):
-                    # An unresolved reference isn't evidence that it names the field
-                    # currently being altered. Its index was already removed or has
-                    # never existed, so never recreate it with a different field.
+                if index.name not in meta_index_replacements:
                     continue
+                replacements = meta_index_replacements.get(index.name, {})
+                reference_names = [
+                    field_name for field_name, _ in index.fields_orders
+                ] + list(index.include) + self._get_condition_field_names(index.condition)
+                fields = []
+                for field_name in reference_names:
+                    try:
+                        fields.append(
+                            model._meta.get_field(
+                                replacements.get(field_name, field_name)
+                            )
+                        )
+                    except FieldDoesNotExist as exc:
+                        raise FieldDoesNotExist(
+                            "Meta index '%s' references unresolved field '%s'." % (
+                                index.name, field_name
+                            )
+                        ) from exc
+                index_fields = fields[:len(index.fields_orders)]
+                included_fields = fields[
+                    len(index.fields_orders):len(index.fields_orders) + len(index.include)
+                ]
+                condition_fields = fields[len(index.fields_orders) + len(index.include):]
 
                 index_columns_list = [
                     field.column for field in index_fields + included_fields + condition_fields
@@ -1137,11 +1149,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             self.connection.close()
 
     def _get_index_metadata(self, model, index_name):
-        """Return key/include columns and the filter definition for a physical index."""
+        """Return key and INCLUDE columns for a physical index."""
         with self.connection.cursor() as cursor:
             cursor.execute(
                 """
-                SELECT ic.is_included_column, c.name, i.filter_definition
+                SELECT ic.is_included_column, c.name
                 FROM sys.indexes AS i
                 INNER JOIN sys.index_columns AS ic
                     ON i.object_id = ic.object_id AND i.index_id = ic.index_id
@@ -1188,13 +1200,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         for index in model._meta.indexes:
             field_names = [field_name for field_name, _ in index.fields_orders]
             include_names = list(index.include)
-            condition_names = self._get_condition_field_names(index.condition)
-            reference_names = field_names + include_names + condition_names
             metadata = self._get_index_metadata(model, index.name)
             if not metadata:
                 continue
-            key_columns = [column for included, column, _ in metadata if not included]
-            included_columns = [column for included, column, _ in metadata if included]
+            key_columns = [column for included, column in metadata if not included]
+            included_columns = [column for included, column in metadata if included]
             if len(field_names) != len(key_columns) or len(include_names) != len(included_columns):
                 continue
 
@@ -1207,23 +1217,51 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                         break
                     index_replacements[name] = field.name
             else:
-                filter_definition = metadata[0][2]
-                condition_columns = {
-                    column for column in fields_by_column
-                    if f"[{column.replace(']', ']]')}]" in (filter_definition or '')
-                }
-                for name in condition_names:
-                    field = model._meta._forward_fields_map.get(
-                        index_replacements.get(name, name)
-                    )
-                    if field is not None and field.column in condition_columns:
-                        condition_columns.remove(field.column)
-                    elif len(condition_columns) == 1:
-                        field = fields_by_column[condition_columns.pop()]
-                        index_replacements[name] = field.name
-                if all(name in index_replacements or name in model._meta._forward_fields_map for name in reference_names):
-                    replacements[index.name] = index_replacements
+                replacements[index.name] = index_replacements
         return replacements
+
+    def _merge_meta_index_replacements(self, catalog_replacements):
+        """Merge catalog reconciliation with structured field rename history."""
+        rename_replacements = getattr(self, '_meta_index_rename_replacements', {})
+        replacements = {}
+        for index_name, index_replacements in catalog_replacements.items():
+            rename_replacements_for_index = rename_replacements.get(index_name, {})
+            if any(
+                rename_replacements_for_index[name] != replacement
+                for name, replacement in index_replacements.items()
+                if name in rename_replacements_for_index
+            ):
+                continue
+            replacements[index_name] = {
+                **rename_replacements_for_index,
+                **index_replacements,
+            }
+        return replacements
+
+    def _record_meta_index_rename_replacements(
+        self, model, old_field, new_field, meta_index_replacements
+    ):
+        """Record structured references changed by a Meta.indexes field rename."""
+        for index in model._meta.indexes:
+            replacements = meta_index_replacements.get(index.name)
+            if replacements is None:
+                continue
+            field_names = [field_name for field_name, _ in index.fields_orders]
+            field_names += list(index.include)
+            field_names += self._get_condition_field_names(index.condition)
+            if old_field.name not in {
+                replacements.get(field_name, field_name) for field_name in field_names
+            }:
+                continue
+            if not hasattr(self, '_meta_index_rename_replacements'):
+                self._meta_index_rename_replacements = {}
+            index_replacements = self._meta_index_rename_replacements.setdefault(
+                index.name, {}
+            )
+            for field_name, replacement in list(index_replacements.items()):
+                if replacement == old_field.name:
+                    index_replacements[field_name] = new_field.name
+            index_replacements.setdefault(old_field.name, new_field.name)
 
     def _clone_index_with_replacements(self, index, replacements):
         """Clone an Index while replacing field names in keys, includes, and conditions."""
@@ -1293,23 +1331,30 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 if old_field.column in columns or new_field.column in columns:
                     index_columns.append(columns)
 
+        existing_index_names = set(
+            self._db_table_constraint_names(model._meta.db_table, index=True)
+        )
         for index in model._meta.indexes:
-            replacements = meta_index_replacements.get(index.name, {})
-            try:
-                fields = [
-                    model._meta.get_field(replacements.get(field_name, field_name))
-                    for field_name, _ in index.fields_orders
-                ]
-                fields += [
-                    model._meta.get_field(replacements.get(field_name, field_name))
-                    for field_name in index.include
-                ]
-                fields += [
-                    model._meta.get_field(replacements.get(field_name, field_name))
-                    for field_name in self._get_condition_field_names(index.condition)
-                ]
-            except FieldDoesNotExist:
+            if index.name not in existing_index_names:
                 continue
+            replacements = meta_index_replacements.get(index.name, {})
+            reference_names = [
+                field_name for field_name, _ in index.fields_orders
+            ] + list(index.include) + self._get_condition_field_names(index.condition)
+            fields = []
+            for field_name in reference_names:
+                try:
+                    fields.append(
+                        model._meta.get_field(
+                            replacements.get(field_name, field_name)
+                        )
+                    )
+                except FieldDoesNotExist as exc:
+                    raise FieldDoesNotExist(
+                        "Meta index '%s' references unresolved field '%s'." % (
+                            index.name, field_name
+                        )
+                    ) from exc
             if old_field.column in [field.column for field in fields] or new_field.column in [field.column for field in fields]:
                 index_names.append(index.name)
 
@@ -1319,9 +1364,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 index_columns.append(columns)
         for columns in {tuple(columns) for columns in index_columns}:
             index_names.extend(self._constraint_names(model, columns, index=True))
-        existing_index_names = set(
-            self._db_table_constraint_names(model._meta.db_table, index=True)
-        )
         for index_name in set(index_names) & existing_index_names:
             self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))
         return index_names

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -691,6 +691,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
 
         meta_index_replacements = self._get_meta_index_replacements(model)
+        # Names actually dropped by _delete_indexes() below, as opposed to an
+        # index merely not yet created (e.g. still queued in deferred_sql
+        # from a CreateModel(options={'indexes': [...]}) in the same
+        # migration) - _restore_missing_meta_indexes() must only recreate the
+        # former, or it races the still-pending deferred CREATE INDEX and
+        # collides with it once the schema editor context exits.
+        dropped_meta_index_names = set()
 
         # Drop any FK constraints, we'll remake them later
         fks_dropped = set()
@@ -934,10 +941,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # Drop unique constraint, SQL Server requires explicit deletion
             self._delete_unique_constraints(model, old_field, new_field, strict)
             # Drop indexes, SQL Server requires explicit deletion
-            self._delete_indexes(
+            dropped_meta_index_names.update(self._delete_indexes(
                 meta_model, old_field, new_field,
                 meta_index_replacements=meta_index_replacements,
-            )
+            ))
 
         # db_default change?
         if django_version >= (5,0):
@@ -990,10 +997,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 # Drop unique constraint, SQL Server requires explicit deletion
                 self._delete_unique_constraints(model, old_field, new_field, strict)
                 # Drop indexes, SQL Server requires explicit deletion
-                self._delete_indexes(
+                dropped_meta_index_names.update(self._delete_indexes(
                     meta_model, old_field, new_field,
                     meta_index_replacements=meta_index_replacements,
-                )
+                ))
 
 
         # ================================================================================
@@ -1405,7 +1412,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # because the "column alteration cleanup" restoration block is skipped
         # whenever the column was renamed (see comment there).
         if old_field.column != new_field.column:
-            self._restore_missing_meta_indexes(meta_model, old_field, new_field)
+            self._restore_missing_meta_indexes(
+                meta_model, old_field, new_field, dropped_meta_index_names
+            )
 
         # Reset connection if required
         if self.connection.features.connection_persists_old_columns:
@@ -1489,9 +1498,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 replacements[index.name] = index_replacements
         return replacements
 
-    def _restore_missing_meta_indexes(self, model, old_field, new_field):
+    def _restore_missing_meta_indexes(self, model, old_field, new_field, dropped_index_names):
         """Recreate a named Meta.indexes entry referencing the renamed field
-        that is missing from the table after this _alter_field() call.
+        that was dropped from the table earlier in this _alter_field() call.
 
         The rename-restoration block above only recreates a Meta.indexes entry
         whose filtered `condition` references the renamed field; a combined
@@ -1499,12 +1508,21 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         conditional) Meta.indexes entry via _delete_indexes() without
         recreating it, because the later "column alteration cleanup"
         restoration is skipped whenever the column was renamed.
+
+        Restricting to `dropped_index_names` (rather than any index simply
+        absent from the catalog) is required: an index declared inline via
+        CreateModel(options={'indexes': [...]}) is legitimately absent until
+        its deferred CREATE INDEX statement runs at schema_editor context
+        exit, and would otherwise be recreated here too, colliding with that
+        still-pending statement once it finally executes.
         """
+        if not dropped_index_names:
+            return
         existing_index_names = set(
             self._db_table_constraint_names(model._meta.db_table, index=True)
         )
         for index in model._meta.indexes:
-            if index.name in existing_index_names:
+            if index.name not in dropped_index_names or index.name in existing_index_names:
                 continue
             reference_names = (
                 [field_name for field_name, _ in index.fields_orders]

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -1182,9 +1182,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             include_names = list(index.include)
             condition_names = self._get_condition_field_names(index.condition)
             reference_names = field_names + include_names + condition_names
-            if all(name in model._meta._forward_fields_map for name in reference_names):
-                continue
-
             metadata = self._get_index_metadata(model, index.name)
             if not metadata:
                 continue
@@ -1195,16 +1192,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
             index_replacements = {}
             for name, column in zip(field_names + include_names, key_columns + included_columns):
-                try:
-                    field = model._meta.get_field(name)
-                except FieldDoesNotExist:
+                field = model._meta._forward_fields_map.get(name)
+                if field is None or field.column != column:
                     field = fields_by_column.get(column)
                     if field is None:
                         break
                     index_replacements[name] = field.name
-                else:
-                    if field.column != column:
-                        break
             else:
                 filter_definition = metadata[0][2]
                 condition_columns = {
@@ -1212,11 +1205,14 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     if f"[{column.replace(']', ']]')}]" in (filter_definition or '')
                 }
                 for name in condition_names:
-                    try:
-                        condition_columns.remove(model._meta.get_field(name).column)
-                    except FieldDoesNotExist:
-                        if name not in index_replacements and len(condition_columns) == 1:
-                            index_replacements[name] = fields_by_column[condition_columns.pop()].name
+                    field = model._meta._forward_fields_map.get(
+                        index_replacements.get(name, name)
+                    )
+                    if field is not None and field.column in condition_columns:
+                        condition_columns.remove(field.column)
+                    elif len(condition_columns) == 1:
+                        field = fields_by_column[condition_columns.pop()]
+                        index_replacements[name] = field.name
                 if all(name in index_replacements or name in model._meta._forward_fields_map for name in reference_names):
                     replacements[index.name] = index_replacements
         return replacements

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -1279,6 +1279,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             }
             self.execute(sql, params)
 
+        # A combined column rename with a type/nullability change drops a plain
+        # Meta.indexes entry via _delete_indexes() above without recreating it,
+        # because the "column alteration cleanup" restoration block is skipped
+        # whenever the column was renamed (see comment there).
+        if old_field.column != new_field.column:
+            self._restore_missing_meta_indexes(meta_model, old_field, new_field)
+
         # Reset connection if required
         if self.connection.features.connection_persists_old_columns:
             self.connection.close()
@@ -1355,7 +1362,36 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 replacements[index.name] = index_replacements
         return replacements
 
+    def _restore_missing_meta_indexes(self, model, old_field, new_field):
+        """Recreate a named Meta.indexes entry referencing the renamed field
+        that is missing from the table after this _alter_field() call.
 
+        The rename-restoration block above only recreates a Meta.indexes entry
+        whose filtered `condition` references the renamed field; a combined
+        column rename and type/nullability change drops a plain (non-
+        conditional) Meta.indexes entry via _delete_indexes() without
+        recreating it, because the later "column alteration cleanup"
+        restoration is skipped whenever the column was renamed.
+        """
+        existing_index_names = set(
+            self._db_table_constraint_names(model._meta.db_table, index=True)
+        )
+        for index in model._meta.indexes:
+            if index.name in existing_index_names:
+                continue
+            reference_names = (
+                [field_name for field_name, _ in index.fields_orders]
+                + list(index.include)
+                + self._get_condition_field_names(index.condition)
+            )
+            if old_field.name not in reference_names:
+                continue
+            restored_index = _clone_index_with_replacements(
+                index, {old_field.name: new_field.name}
+            )
+            statement = restored_index.create_sql(model, self)
+            if statement:
+                self.execute(statement)
 
     def _delete_indexes(self, model, old_field, new_field, meta_index_replacements=None):
         if (

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -831,10 +831,29 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # Have they renamed the column?
         if old_field.column != new_field.column:
             sql_restore_index = ''
+            # Identify Meta.constraints (UniqueConstraint) referencing the
+            # renamed field before the generic unique-index drop below runs,
+            # so the structured restoration further down - which alone knows
+            # about INCLUDE columns and preserves them via
+            # _clone_constraint_with_replacements() - has exclusive
+            # responsibility for dropping and recreating them. Left to the
+            # generic path (which rebuilds from an unfiltered
+            # sys.index_columns listing that doesn't distinguish key from
+            # INCLUDE columns), a covering constraint's INCLUDE column would
+            # be silently promoted into the unique key.
+            meta_constraint_names_to_protect = {
+                constraint.name
+                for constraint in model._meta.constraints
+                if isinstance(constraint, UniqueConstraint)
+                and old_field.name in (
+                    list(constraint.fields) + list(constraint.include)
+                    + self._get_condition_field_names(constraint.condition)
+                )
+            }
             # Drop any unique indexes which include the column to be renamed
             index_names = self._db_table_constraint_names(
                 db_table=model._meta.db_table, column_names=[old_field.column], column_match_any=True,
-                index=True, unique=True,
+                index=True, unique=True, exclude=meta_constraint_names_to_protect,
             )
             for index_name in index_names:
                 # Before dropping figure out how to recreate it afterwards
@@ -880,22 +899,21 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                         )
                     )
 
-            # A filtered UniqueConstraint (Meta.constraints) whose condition
-            # references the renamed field is not caught by the unique-index
-            # drop above (that only matches by physical key column), so SQL
-            # Server would otherwise refuse the rename with "index is
-            # dependent on column". Mirror the Meta.indexes handling above.
+            # A UniqueConstraint (Meta.constraints) whose fields/include/
+            # condition reference the renamed field is protected from the
+            # generic unique-index drop above (see
+            # meta_constraint_names_to_protect), so it is still physically
+            # present here; recreate it through create_sql() - which
+            # preserves INCLUDE columns, unlike the generic path's raw
+            # sys.index_columns-based rebuild - rather than leaving it for
+            # the generic path to (incorrectly) handle.
             meta_constraints_to_restore = []
             for constraint in model._meta.constraints:
-                if not isinstance(constraint, UniqueConstraint) or not constraint.condition:
-                    continue
-                if constraint.name not in existing_index_names:
-                    continue
-                reference_names = (
-                    list(constraint.fields) + list(constraint.include)
-                    + self._get_condition_field_names(constraint.condition)
-                )
-                if old_field.name not in reference_names:
+                if (
+                    not isinstance(constraint, UniqueConstraint)
+                    or constraint.name not in meta_constraint_names_to_protect
+                    or constraint.name not in existing_index_names
+                ):
                     continue
                 restored_constraint = _clone_constraint_with_replacements(
                     constraint, {old_field.name: new_field.name}

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -96,6 +96,19 @@ def _split_field_lookup(name):
     return name.split('__', 1) if '__' in name else (name, '')
 
 
+def _resolve_pk_alias(model, field_name):
+    """Resolve the 'pk' query alias to the model's actual primary key field
+    name.
+
+    Django's Q()/F() lookups accept 'pk' as an alias for the primary key
+    (e.g. `Q(pk__gt=0)` in an Index/UniqueConstraint condition), but
+    `Options.get_field()` does not recognize it and raises
+    FieldDoesNotExist. Any reference-name resolution derived from a
+    condition must resolve this alias first.
+    """
+    return model._meta.pk.name if field_name == 'pk' else field_name
+
+
 def _replace_condition_field_names(condition, replacements):
     """Rewrite lookup roots and nested F() references in a copied Q tree.
 
@@ -1272,7 +1285,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     try:
                         fields.append(
                             meta_model._meta.get_field(
-                                replacements.get(field_name, field_name)
+                                _resolve_pk_alias(meta_model, replacements.get(field_name, field_name))
                             )
                         )
                     except FieldDoesNotExist as exc:
@@ -1577,7 +1590,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 try:
                     fields.append(
                         model._meta.get_field(
-                            replacements.get(field_name, field_name)
+                            _resolve_pk_alias(model, replacements.get(field_name, field_name))
                         )
                     )
                 except FieldDoesNotExist as exc:

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -28,6 +28,101 @@ from django.db.models.fields.related import ForeignKey
 from django.db.models.sql.where import AND
 from django.db.transaction import TransactionManagementError
 from django.utils.encoding import force_str
+from django.db.migrations.state import ProjectState
+
+
+def _clone_index_with_replacements(index, replacements):
+    """Clone a structured Meta.indexes definition with renamed field references.
+
+    Django stores indexes as structured Index and Q objects in migration state.
+    Cloning from deconstruct() preserves index options without changing the
+    historical definition retained by a preserved project state.
+    """
+    if not replacements:
+        return index
+    _, args, kwargs = index.deconstruct()
+    kwargs['fields'] = [
+        ('-' if field_name.startswith('-') else '') + replacements.get(
+            field_name.lstrip('-'), field_name.lstrip('-')
+        )
+        for field_name in index.fields
+    ]
+    if index.include:
+        kwargs['include'] = [
+            replacements.get(field_name, field_name) for field_name in index.include
+        ]
+    if index.condition:
+        condition = copy.deepcopy(index.condition)
+        _replace_condition_field_names(condition, replacements)
+        kwargs['condition'] = condition
+    return index.__class__(*args, **kwargs)
+
+
+def _replace_condition_field_names(condition, replacements):
+    """Rewrite lookup roots and nested F() references in a copied Q tree.
+
+    Only field references are replaced; literal condition values are retained.
+    """
+    for index, child in enumerate(condition.children):
+        if hasattr(child, 'children'):
+            _replace_condition_field_names(child, replacements)
+        elif isinstance(child, tuple):
+            field_name, lookup = (
+                child[0].split('__', 1) if '__' in child[0] else (child[0], '')
+            )
+            condition.children[index] = (
+                replacements.get(field_name, field_name) + ('__' + lookup if lookup else ''),
+                _replace_expression_field_names(child[1], replacements),
+            )
+        else:
+            condition.children[index] = _replace_expression_field_names(
+                child, replacements
+            )
+
+
+def _replace_expression_field_names(expression, replacements):
+    """Rewrite F() references in a copied condition expression tree."""
+    if isinstance(expression, F):
+        return F(replacements.get(expression.name, expression.name))
+    if hasattr(expression, 'get_source_expressions'):
+        expression.set_source_expressions([
+            _replace_expression_field_names(source_expression, replacements)
+            for source_expression in expression.get_source_expressions()
+        ])
+    return expression
+
+
+def _rename_field_with_meta_indexes(self, app_label, model_name, old_name, new_name):
+    """Keep structured Meta.indexes state consistent with Django field renames.
+
+    Django's rename_field() updates fields but not ModelState.options['indexes'].
+    RenameField.database_forwards() is too late to make reconstructed state
+    durable, and mssql imports this module while initializing its backend before
+    MigrationExecutor builds state.
+    """
+    model_state = self.models[(app_label, model_name)]
+    if old_name not in model_state.fields:
+        return ProjectState._mssql_original_rename_field(
+            self, app_label, model_name, old_name, new_name
+        )
+    indexes = model_state.options.get('indexes')
+    if indexes is not None:
+        # ModelState.clone() shallow-copies options, so replace the list to protect
+        # the preserved state used by a migration operation.
+        model_state.options['indexes'] = [
+            _clone_index_with_replacements(index, {old_name: new_name})
+            for index in indexes
+        ]
+    return ProjectState._mssql_original_rename_field(
+        self, app_label, model_name, old_name, new_name
+    )
+
+
+# The private ProjectState sentinel prevents a module reload from stacking wrappers.
+if not hasattr(ProjectState, '_mssql_original_rename_field'):
+    ProjectState._mssql_original_rename_field = ProjectState.rename_field
+    ProjectState.rename_field = _rename_field_with_meta_indexes
+
 
 if django_version >= (4, 0):
     from django.db.models.sql import Query
@@ -408,28 +503,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             params = ()
         return f"GENERATED ALWAYS AS ({expression_sql}) {persistency_sql}", params
 
-    def alter_field(self, model, old_field, new_field, strict=False):
-        """Persist structured Meta.indexes references through field renames.
-
-        RenameField updates ModelState fields but not its indexes option. Rewrite
-        the rendered destination model's original index definitions before the
-        base editor can short-circuit a logical rename or emit physical DDL.
-        """
-        if old_field.name != new_field.name:
-            self._rename_meta_index_references(
-                getattr(new_field, 'model', model), old_field.name, new_field.name
-            )
-        super().alter_field(model, old_field, new_field, strict=strict)
-
-    def _rename_meta_index_references(self, model, old_name, new_name):
-        """Update migration-state Meta indexes for a logical field rename."""
-        indexes = model._meta.original_attrs.get('indexes')
-        if indexes is None:
-            return
-        indexes[:] = [
-            self._clone_index_with_replacements(index, {old_name: new_name})
-            for index in indexes
-        ]
 
     def _alter_field(self, model, old_field, new_field, old_type, new_type,
                      old_db_params, new_db_params, strict=False):
@@ -638,7 +711,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     **base_replacements,
                     old_field.name: new_field.name,
                 }
-                restored_index = self._clone_index_with_replacements(index, replacements)
+                restored_index = _clone_index_with_replacements(index, replacements)
                 statement = restored_index.create_sql(new_field.model, self)
                 if statement:
                     meta_indexes_to_restore.append(statement)
@@ -1052,7 +1125,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # names and attributes. Stale references are repaired only when the
             # existing physical index supplied an unambiguous replacement.
             for index, replacements in indexes_to_restore:
-                restored_index = self._clone_index_with_replacements(index, replacements)
+                restored_index = _clone_index_with_replacements(index, replacements)
                 create_index_sql_statement = restored_index.create_sql(meta_model, self)
                 if create_index_sql_statement and (str(create_index_sql_statement)
                         not in [str(sql) for sql in self.deferred_sql] + [str(statement[0]) for statement in post_actions]
@@ -1239,49 +1312,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return replacements
 
 
-    def _clone_index_with_replacements(self, index, replacements):
-        """Clone an Index while replacing field names in keys, includes, and conditions."""
-        if not replacements:
-            return index
-        _, args, kwargs = index.deconstruct()
-        kwargs['fields'] = [
-            ('-' if field_name.startswith('-') else '') + replacements.get(field_name.lstrip('-'), field_name.lstrip('-'))
-            for field_name in index.fields
-        ]
-        if index.include:
-            kwargs['include'] = [replacements.get(field_name, field_name) for field_name in index.include]
-        if index.condition:
-            condition = copy.deepcopy(index.condition)
-            self._replace_condition_field_names(condition, replacements)
-            kwargs['condition'] = condition
-        return index.__class__(*args, **kwargs)
-
-    def _replace_condition_field_names(self, condition, replacements):
-        """Mutate a Q condition tree to replace referenced lookup and expression fields."""
-        for index, child in enumerate(condition.children):
-            if hasattr(child, 'children'):
-                self._replace_condition_field_names(child, replacements)
-            elif isinstance(child, tuple):
-                field_name, lookup = child[0].split('__', 1) if '__' in child[0] else (child[0], '')
-                condition.children[index] = (
-                    replacements.get(field_name, field_name) + ('__' + lookup if lookup else ''),
-                    self._replace_expression_field_names(child[1], replacements),
-                )
-            else:
-                condition.children[index] = self._replace_expression_field_names(
-                    child, replacements
-                )
-
-    def _replace_expression_field_names(self, expression, replacements):
-        """Mutate an expression tree to replace F() field references."""
-        if isinstance(expression, F):
-            return F(replacements.get(expression.name, expression.name))
-        if hasattr(expression, 'get_source_expressions'):
-            expression.set_source_expressions([
-                self._replace_expression_field_names(source_expression, replacements)
-                for source_expression in expression.get_source_expressions()
-            ])
-        return expression
 
     def _delete_indexes(self, model, old_field, new_field, meta_index_replacements=None):
         if (

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -25,6 +25,7 @@ from django import VERSION as django_version
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import F, NOT_PROVIDED, Index, UniqueConstraint
 from django.db.migrations.operations.fields import RenameField
+from django.db.migrations.operations.models import CreateModel
 from django.db.models.fields import AutoField, BigAutoField
 from django.db.models.fields.related import ForeignKey
 from django.db.models.sql import Query
@@ -187,6 +188,36 @@ if (3, 2) <= django_version < (4, 0) and not hasattr(
 ):
     RenameField._mssql_original_state_forwards = RenameField.state_forwards
     RenameField.state_forwards = _rename_field_state_forwards_with_meta_indexes
+
+
+def _create_model_reduce_with_meta_indexes(self, operation, app_label):
+    """Keep structured Meta.indexes/.constraints consistent when the
+    migration optimizer folds a RenameField into this CreateModel.
+
+    CreateModel.reduce() rewrites only unique_together/index_together when
+    absorbing a RenameField (see Django's migrations/operations/models.py);
+    an optimizer pass that performs this fold (e.g. squashmigrations, or
+    autodetector-side optimization within one makemigrations run) leaves a
+    structured Index/UniqueConstraint predicate referencing the pre-rename
+    field name.
+    """
+    result = CreateModel._mssql_original_reduce(self, operation, app_label)
+    if (
+        isinstance(operation, RenameField)
+        and self.name_lower == operation.model_name_lower
+        and isinstance(result, list)
+        and len(result) == 1
+        and isinstance(result[0], CreateModel)
+    ):
+        _replace_options_field_names(
+            result[0].options, operation.old_name, operation.new_name
+        )
+    return result
+
+
+if not hasattr(CreateModel, '_mssql_original_reduce'):
+    CreateModel._mssql_original_reduce = CreateModel.reduce
+    CreateModel.reduce = _create_model_reduce_with_meta_indexes
 
 
 # Import CompositePrimaryKey only if Django version is 5.2 or higher

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -1914,6 +1914,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def _create_deferred_unique_constraint_sql(self, model, constraint):
         """Create a conditional unique constraint as a deferred filtered index."""
+        if constraint.condition.connector != AND:
+            raise NotImplementedError(
+                "The backend does not support %s conditions on unique constraint %s." %
+                (constraint.condition.connector, constraint.name)
+            )
         condition = IndexCondition(model, constraint.condition, self)
         kwargs = {
             'name': constraint.name,

--- a/mssql/schema.py
+++ b/mssql/schema.py
@@ -144,8 +144,10 @@ if (3, 2) <= django_version < (4, 0) and not hasattr(
 
 
 # Import CompositePrimaryKey only if Django version is 5.2 or higher
-if django_version >= (5, 2):    
+if django_version >= (5, 2):
     from django.db.models.fields.composite import CompositePrimaryKey
+
+
 class Statement(DjStatement):
     def __hash__(self):
         return hash((self.template, str(self.parts['name'])))
@@ -163,7 +165,7 @@ class NullableColumns(Columns):
         )
 
 class IndexCondition(Expressions):
-    """Reference a filtered Meta.index condition in deferred schema SQL."""
+    """Reference any filtered-index predicate in deferred schema SQL."""
 
     def __init__(self, model, condition, schema_editor):
         query = Query(model=model, alias_cols=False)
@@ -1606,7 +1608,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             if condition:
                 condition = (
                     condition
-                    if isinstance(condition, NullableColumns)
+                    if isinstance(condition, (NullableColumns, IndexCondition))
                     else ' WHERE ' + condition
                 )
                 return Statement(
@@ -1661,7 +1663,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     columns=columns,
                     condition=(
                         condition
-                        if isinstance(condition, NullableColumns)
+                        if isinstance(condition, (NullableColumns, IndexCondition))
                         else ' WHERE ' + condition
                     ),
                     **statement_args,
@@ -1697,6 +1699,34 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             db_tablespace=db_tablespace, col_suffixes=col_suffixes, sql=sql,
             opclasses=opclasses, condition=condition,
         )
+
+    def _create_deferred_unique_constraint_sql(self, model, constraint):
+        """Create a conditional unique constraint as a deferred filtered index."""
+        condition = IndexCondition(model, constraint.condition, self)
+        kwargs = {
+            'name': constraint.name,
+            'condition': condition,
+            'deferrable': constraint.deferrable,
+            'include': [
+                model._meta.get_field(field_name).column
+                for field_name in constraint.include
+            ],
+            'opclasses': constraint.opclasses,
+        }
+        if hasattr(constraint, '_get_index_expressions'):
+            kwargs['expressions'] = constraint._get_index_expressions(model, self)
+        if hasattr(constraint, 'nulls_distinct'):
+            kwargs['nulls_distinct'] = constraint.nulls_distinct
+        if django_version >= (4, 0):
+            fields = [
+                model._meta.get_field(field_name) for field_name in constraint.fields
+            ]
+        else:
+            fields = [
+                model._meta.get_field(field_name).column
+                for field_name in constraint.fields
+            ]
+        return self._create_unique_sql(model, fields, **kwargs)
 
     def create_model(self, model):
         """
@@ -1785,7 +1815,14 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             else:
                 self.deferred_sql.append(self._create_unique_sql(model, columns, condition=condition))
 
-        constraints = [constraint.constraint_sql(model, self) for constraint in model._meta.constraints]
+        constraints = []
+        for constraint in model._meta.constraints:
+            if isinstance(constraint, UniqueConstraint) and constraint.condition is not None:
+                statement = self._create_deferred_unique_constraint_sql(model, constraint)
+                if statement is not None:
+                    self.deferred_sql.append(statement)
+            else:
+                constraints.append(constraint.constraint_sql(model, self))
          # If a composite primary key SQL clause was generated, insert it at the beginning of the constraints list
         if composite_pk_sql:
           constraints.insert(0, composite_pk_sql)

--- a/testapp/tests/test_constraints.py
+++ b/testapp/tests/test_constraints.py
@@ -262,3 +262,64 @@ class TestUniqueConstraints(TransactionTestCase):
                     NotImplementedError, "does not support OR conditions"
                 ):
                     return migration.apply(ProjectState(), editor)
+
+    def test_unsupportable_unique_constraint_via_create_model(self):
+        """
+        add_constraint() raises NotImplementedError for a conditional
+        UniqueConstraint with a top-level OR (see
+        test_unsupportable_unique_constraint above), but a constraint
+        declared inline via CreateModel(options={'constraints': [...]})
+        never reaches add_constraint() - create_model() calls
+        _create_deferred_unique_constraint_sql() directly. That path must
+        raise the same NotImplementedError instead of compiling an
+        unsupported OR predicate into a filtered index and letting SQL
+        Server fail with a raw syntax error.
+        """
+        # Only execute tests when running against SQL Server
+        connection = connections['default']
+        if isinstance(connection, DatabaseWrapper):
+
+            class TestMigration(migrations.Migration):
+                initial = True
+
+                operations = [
+                    migrations.CreateModel(
+                        name='TestUnsupportableUniqueConstraintCreateModel',
+                        fields=[
+                            (
+                                'id',
+                                models.AutoField(
+                                    auto_created=True,
+                                    primary_key=True,
+                                    serialize=False,
+                                    verbose_name='ID',
+                                ),
+                            ),
+                            ('_type', models.CharField(max_length=50)),
+                            ('status', models.CharField(max_length=50)),
+                        ],
+                        options={
+                            'constraints': [
+                                models.UniqueConstraint(
+                                    condition=models.Q(
+                                        ('status', 'in_progress'),
+                                        ('status', 'needs_changes'),
+                                        _connector='OR',
+                                    ),
+                                    fields=('_type',),
+                                    name='or_constraint_create_model',
+                                ),
+                            ],
+                        },
+                    ),
+                ]
+
+            migration = TestMigration(
+                name='test_unsupportable_unique_constraint_create_model', app_label='testapp'
+            )
+
+            with connection.schema_editor(atomic=True) as editor:
+                with self.assertRaisesRegex(
+                    NotImplementedError, "does not support OR conditions"
+                ):
+                    return migration.apply(ProjectState(), editor)

--- a/testapp/tests/test_constraints.py
+++ b/testapp/tests/test_constraints.py
@@ -1,8 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the BSD license.
 import logging
+from unittest import skipUnless
 
 import django.db.utils
+from django import VERSION
 from django.db import connections, migrations, models
 from django.db.migrations.state import ProjectState
 from django.db.utils import IntegrityError
@@ -163,6 +165,39 @@ class TestHandleOldStyleUniqueTogether(TransactionTestCase):
                 logger.exception('Failed to AlterField:')
                 self.fail('Check for regression of issue #137, AlterField failed with exception: %s' % e)
 
+
+
+@skipUnless(VERSION < (4, 0), "Django 3.2-specific _create_unique_sql branch")
+class TestCreateModelUniqueTogether(TransactionTestCase):
+    def test_create_model_with_unique_together_preserves_deferred_condition(self):
+        class TestMigration(migrations.Migration):
+            initial = True
+
+            operations = [
+                migrations.CreateModel(
+                    name='TestCreateModelUniqueTogether',
+                    fields=[
+                        ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                        ('a', models.CharField(max_length=50, null=True)),
+                        ('b', models.CharField(max_length=50)),
+                    ],
+                    options={'unique_together': {('a', 'b')}},
+                ),
+            ]
+
+        migration = TestMigration(
+            name='test_create_model_with_unique_together', app_label='testapp'
+        )
+        connection = connections['default']
+
+        with connection.schema_editor(atomic=True) as editor:
+            project_state = migration.apply(ProjectState(), editor)
+
+        model = project_state.apps.get_model('testapp', 'TestCreateModelUniqueTogether')
+        unique_index_names = get_constraint_names_where(
+            model._meta.db_table, index=True, unique=True
+        )
+        self.assertEqual(len(unique_index_names), 1)
 
 class TestRenameManyToManyField(TestCase):
     def test_uniqueness_still_enforced_afterwards(self):

--- a/testapp/tests/test_constraints.py
+++ b/testapp/tests/test_constraints.py
@@ -324,6 +324,217 @@ class TestUniqueConstraints(TransactionTestCase):
                 ):
                     return migration.apply(ProjectState(), editor)
 
+    def test_unsupportable_unique_constraint_nested_or(self):
+        """
+        The OR-connector guard in add_constraint() only inspected the root Q
+        node's connector. A root AND whose child is itself an OR (e.g.
+        Q(a=1) & (Q(b=2) | Q(c=3))) reports connector == 'AND' at the root
+        and slipped through, producing a filtered-index predicate SQL Server
+        rejects with a raw syntax error instead of this NotImplementedError.
+        """
+        # Only execute tests when running against SQL Server
+        connection = connections['default']
+        if isinstance(connection, DatabaseWrapper):
+
+            class TestMigration(migrations.Migration):
+                initial = True
+
+                operations = [
+                    migrations.CreateModel(
+                        name='TestUnsupportableUniqueConstraintNestedOr',
+                        fields=[
+                            (
+                                'id',
+                                models.AutoField(
+                                    auto_created=True,
+                                    primary_key=True,
+                                    serialize=False,
+                                    verbose_name='ID',
+                                ),
+                            ),
+                            ('_type', models.CharField(max_length=50)),
+                            ('status', models.CharField(max_length=50)),
+                        ],
+                    ),
+                    migrations.AddConstraint(
+                        model_name='testunsupportableuniqueconstraintnestedor',
+                        constraint=models.UniqueConstraint(
+                            condition=models.Q(_type='widget') & (
+                                models.Q(status='in_progress') | models.Q(status='needs_changes')
+                            ),
+                            fields=('_type',),
+                            name='nested_or_constraint',
+                        ),
+                    ),
+                ]
+
+            migration = TestMigration(
+                name='test_unsupportable_unique_constraint_nested_or', app_label='testapp'
+            )
+
+            with connection.schema_editor(atomic=True) as editor:
+                with self.assertRaisesRegex(
+                    NotImplementedError, "does not support OR conditions"
+                ):
+                    return migration.apply(ProjectState(), editor)
+
+    def test_unsupportable_unique_constraint_nested_or_via_create_model(self):
+        """
+        Same nested-OR predicate as test_unsupportable_unique_constraint_nested_or
+        above, but declared inline via CreateModel(options={'constraints': [...]}),
+        which reaches _create_deferred_unique_constraint_sql() directly instead of
+        add_constraint().
+        """
+        # Only execute tests when running against SQL Server
+        connection = connections['default']
+        if isinstance(connection, DatabaseWrapper):
+
+            class TestMigration(migrations.Migration):
+                initial = True
+
+                operations = [
+                    migrations.CreateModel(
+                        name='TestUnsupportableUniqueConstraintNestedOrCreateModel',
+                        fields=[
+                            (
+                                'id',
+                                models.AutoField(
+                                    auto_created=True,
+                                    primary_key=True,
+                                    serialize=False,
+                                    verbose_name='ID',
+                                ),
+                            ),
+                            ('_type', models.CharField(max_length=50)),
+                            ('status', models.CharField(max_length=50)),
+                        ],
+                        options={
+                            'constraints': [
+                                models.UniqueConstraint(
+                                    condition=models.Q(_type='widget') & (
+                                        models.Q(status='in_progress') | models.Q(status='needs_changes')
+                                    ),
+                                    fields=('_type',),
+                                    name='nested_or_constraint_create_model',
+                                ),
+                            ],
+                        },
+                    ),
+                ]
+
+            migration = TestMigration(
+                name='test_unsupportable_unique_constraint_nested_or_create_model', app_label='testapp'
+            )
+
+            with connection.schema_editor(atomic=True) as editor:
+                with self.assertRaisesRegex(
+                    NotImplementedError, "does not support OR conditions"
+                ):
+                    return migration.apply(ProjectState(), editor)
+
+    def test_unsupportable_unique_constraint_negated(self):
+        """
+        A negated Q (~Q(...)) still reports connector == 'AND' at the root, so
+        a guard that only checked the connector let it through, producing a
+        filtered-index predicate SQL Server rejects with a raw syntax error
+        instead of this NotImplementedError.
+        """
+        # Only execute tests when running against SQL Server
+        connection = connections['default']
+        if isinstance(connection, DatabaseWrapper):
+
+            class TestMigration(migrations.Migration):
+                initial = True
+
+                operations = [
+                    migrations.CreateModel(
+                        name='TestUnsupportableUniqueConstraintNegated',
+                        fields=[
+                            (
+                                'id',
+                                models.AutoField(
+                                    auto_created=True,
+                                    primary_key=True,
+                                    serialize=False,
+                                    verbose_name='ID',
+                                ),
+                            ),
+                            ('_type', models.CharField(max_length=50)),
+                            ('status', models.CharField(max_length=50)),
+                        ],
+                    ),
+                    migrations.AddConstraint(
+                        model_name='testunsupportableuniqueconstraintnegated',
+                        constraint=models.UniqueConstraint(
+                            condition=~models.Q(status='archived'),
+                            fields=('_type',),
+                            name='negated_constraint',
+                        ),
+                    ),
+                ]
+
+            migration = TestMigration(
+                name='test_unsupportable_unique_constraint_negated', app_label='testapp'
+            )
+
+            with connection.schema_editor(atomic=True) as editor:
+                with self.assertRaisesRegex(
+                    NotImplementedError, "does not support negated conditions"
+                ):
+                    return migration.apply(ProjectState(), editor)
+
+    def test_unsupportable_unique_constraint_negated_via_create_model(self):
+        """
+        Same negated predicate as test_unsupportable_unique_constraint_negated
+        above, but declared inline via CreateModel(options={'constraints': [...]}),
+        which reaches _create_deferred_unique_constraint_sql() directly instead of
+        add_constraint().
+        """
+        # Only execute tests when running against SQL Server
+        connection = connections['default']
+        if isinstance(connection, DatabaseWrapper):
+
+            class TestMigration(migrations.Migration):
+                initial = True
+
+                operations = [
+                    migrations.CreateModel(
+                        name='TestUnsupportableUniqueConstraintNegatedCreateModel',
+                        fields=[
+                            (
+                                'id',
+                                models.AutoField(
+                                    auto_created=True,
+                                    primary_key=True,
+                                    serialize=False,
+                                    verbose_name='ID',
+                                ),
+                            ),
+                            ('_type', models.CharField(max_length=50)),
+                            ('status', models.CharField(max_length=50)),
+                        ],
+                        options={
+                            'constraints': [
+                                models.UniqueConstraint(
+                                    condition=~models.Q(status='archived'),
+                                    fields=('_type',),
+                                    name='negated_constraint_create_model',
+                                ),
+                            ],
+                        },
+                    ),
+                ]
+
+            migration = TestMigration(
+                name='test_unsupportable_unique_constraint_negated_create_model', app_label='testapp'
+            )
+
+            with connection.schema_editor(atomic=True) as editor:
+                with self.assertRaisesRegex(
+                    NotImplementedError, "does not support negated conditions"
+                ):
+                    return migration.apply(ProjectState(), editor)
+
     def test_covering_conditional_unique_constraint_include_uses_db_column(self):
         """
         _create_deferred_unique_constraint_sql() converts constraint.include

--- a/testapp/tests/test_constraints.py
+++ b/testapp/tests/test_constraints.py
@@ -323,3 +323,84 @@ class TestUniqueConstraints(TransactionTestCase):
                     NotImplementedError, "does not support OR conditions"
                 ):
                     return migration.apply(ProjectState(), editor)
+
+    def test_covering_conditional_unique_constraint_include_uses_db_column(self):
+        """
+        _create_deferred_unique_constraint_sql() converts constraint.include
+        (field names) to physical columns before calling _create_unique_sql(),
+        matching Django's own UniqueConstraint.create_sql()/Index.create_sql()
+        convention - _index_include_sql() only quotes whatever string it is
+        given as a literal column identifier, it never resolves a field name
+        itself. An included field with a custom db_column must therefore
+        resolve to that db_column as the physical INCLUDE column, not the
+        field's Python name.
+        """
+        connection = connections['default']
+        if isinstance(connection, DatabaseWrapper):
+
+            class TestMigration(migrations.Migration):
+                initial = True
+
+                operations = [
+                    migrations.CreateModel(
+                        name='TestCoveringConstraintDbColumn',
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            (
+                                'a',
+                                models.CharField(
+                                    max_length=20, null=True, db_column='stable_a'
+                                ),
+                            ),
+                            ('b', models.CharField(max_length=20)),
+                        ],
+                        options={
+                            'constraints': [
+                                models.UniqueConstraint(
+                                    fields=['b'],
+                                    include=['a'],
+                                    condition=models.Q(a__isnull=False),
+                                    name='uq_covering_db_column',
+                                ),
+                            ],
+                        },
+                    ),
+                ]
+
+            migration = TestMigration(
+                name='test_covering_constraint_db_column', app_label='testapp'
+            )
+
+            with connection.schema_editor(atomic=True) as editor:
+                project_state = migration.apply(ProjectState(), editor)
+
+            model = project_state.apps.get_model(
+                'testapp', 'TestCoveringConstraintDbColumn'
+            )
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT ic.is_included_column, c.name
+                    FROM sys.indexes AS i
+                    INNER JOIN sys.index_columns AS ic
+                        ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+                    INNER JOIN sys.columns AS c
+                        ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+                    WHERE i.object_id = OBJECT_ID(%s) AND i.name = %s
+                    """,
+                    [model._meta.db_table, 'uq_covering_db_column'],
+                )
+                included_by_column = dict(
+                    (name, bool(is_included)) for is_included, name in cursor.fetchall()
+                )
+
+            self.assertEqual(
+                included_by_column.get('stable_a'), True,
+                "The include field's db_column 'stable_a' must be the "
+                "INCLUDE column - not the field's Python name 'a', and not "
+                "missing.",
+            )
+            self.assertEqual(
+                included_by_column.get('b'), False,
+                "The constraint's key column 'b' should remain key-only.",
+            )

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -599,18 +599,12 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     ),
                 )
 
-    @expectedFailure
     def test_index_from_meta_indexes_retained_after_rename_and_type_change(self):
         """
         Test that indexes from Meta.indexes are retained when a field is renamed
         AND has its type changed in the same migration.
 
-        This tests a known bug: the TYPE CHANGE PATH drops indexes, but the
-        RESTORE PHASE is skipped when column is renamed (old_field.column != new_field.column).
-
-        Additionally, _delete_indexes() fails with FieldDoesNotExist because it tries to
-        look up the index field by the old field name, but RenameField has already updated
-        the model state, so the old field name no longer exists.
+        Regression test for https://github.com/microsoft/mssql-django/issues/499
 
         Runs with both split and combined migrations
         """
@@ -830,18 +824,12 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     f"Expected unique_together to be retained."
                 )
 
-    @expectedFailure
     def test_index_from_meta_indexes_retained_after_rename_and_nullability_change(self):
         """
         Test that indexes from Meta.indexes are retained when a field is renamed
         AND has its nullability changed in the same migration.
 
-        This tests a known bug: the NULLABILITY CHANGE PATH drops indexes, but the
-        RESTORE PHASE is skipped when column is renamed (old_field.column != new_field.column).
-
-        Additionally, _delete_indexes() fails with FieldDoesNotExist because it tries to
-        look up the index field by the old field name, but RenameField has already updated
-        the model state, so the old field name no longer exists.
+        Regression test for https://github.com/microsoft/mssql-django/issues/499
 
         Runs with both split and combined migrations
         """

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -1902,9 +1902,48 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 self._assert_named_index_columns(
                     result.constraints,
                     index_name,
+
                     ['aa', 'bb'],
                     'A composite Meta.indexes definition was not restored after multiple renames.',
                 )
+    def test_filtered_meta_index_preserves_literal_after_field_rename(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestFilteredLiteral{suffix}'
+                index_name = f'idx_filtered_literal{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['b'],
+                                condition=models.Q(a='[a]'),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                    ],
+                    migration_name_prefix='test_filtered_literal',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                filter_definition = self._get_index_catalog(result.model, index_name)[0][2]
+                self.assertIn('[aa]', filter_definition)
+                self.assertIn("'[a]'", filter_definition)
+                self.assertNotIn("'[aa]'", filter_definition)
 
     def test_filtered_meta_index_retained_after_rename_and_alter(self):
         for use_single_migration in [False, True]:

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -1902,6 +1902,51 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 catalog = self._get_index_catalog(result.model, index_name)
                 self.assertIn('[aa]', catalog[0][2])
 
+    def test_expression_filtered_meta_index_retained_after_rename_and_alter(self):
+        """
+        Field references nested in positional lookup expressions must be updated
+        when a rename precedes an alteration that recreates the filtered index.
+        """
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestExpressionFilteredRename{suffix}'
+                index_name = f'idx_expression_rename{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['b'],
+                                condition=models.Q(Exact(models.F('a'), models.Value('value'))),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_expression_filtered_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self.assertIn('[aa]', self._get_index_catalog(result.model, index_name)[0][2])
+
     def test_covering_meta_index_retained_after_rename_and_alter(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -206,6 +206,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
         migration_name_prefix: str,
         model_name: str,
         use_single_migration: bool,
+        operations_c=None,
     ) -> MigrationTestResult:
         """
         Helper to run migration tests with either combined or split schema_editor contexts.
@@ -224,13 +225,14 @@ class TestMetaIndexesRetained(TransactionTestCase):
         # Use django.db.connections to get a fresh connection for TransactionTestCase
         conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
         suffix = '_combined' if use_single_migration else '_split'
+        operations_c = operations_c or []
 
         if use_single_migration:
             # Combined: Create ONE migration with all operations combined
             # This simulates combining operations in a single migration file
             class CombinedMigration(migrations.Migration):
                 initial = True
-                operations = operations_a + operations_b
+                operations = operations_a + operations_b + operations_c
 
             migration = CombinedMigration(name=f'{migration_name_prefix}{suffix}', app_label='testapp')
 
@@ -249,11 +251,21 @@ class TestMetaIndexesRetained(TransactionTestCase):
 
             migration_a = MigrationA(name=f'{migration_name_prefix}{suffix}_a', app_label='testapp')
             migration_b = MigrationB(name=f'{migration_name_prefix}{suffix}_b', app_label='testapp')
+            if operations_c:
+                class MigrationC(migrations.Migration):
+                    operations = operations_c
+
+                migration_c = MigrationC(
+                    name=f'{migration_name_prefix}{suffix}_c', app_label='testapp'
+                )
 
             with conn.schema_editor(atomic=True) as editor:
                 project_state = migration_a.apply(ProjectState(), editor)
             with conn.schema_editor(atomic=True) as editor:
                 project_state = migration_b.apply(project_state, editor)
+            if operations_c:
+                with conn.schema_editor(atomic=True) as editor:
+                    project_state = migration_c.apply(project_state, editor)
 
         # Get the model and constraints for assertions
         model = project_state.apps.get_model('testapp', model_name)
@@ -2120,48 +2132,350 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 )
                 catalog = self._get_index_catalog(result.model, index_name)
                 self.assertIn('[aa]', catalog[0][2])
-    def test_filtered_meta_index_tracks_tuple_rhs_expression(self):
-        migration = Migration('test_tuple_rhs_filtered_index', 'testapp')
-        migration.operations = [
-            migrations.CreateModel(
-                name='TestTupleRhsFilteredIndex',
-                fields=[
-                    ('id', models.AutoField(primary_key=True)),
-                    ('a', models.CharField(max_length=20)),
-                    ('b', models.CharField(max_length=20)),
-                    ('c', models.CharField(max_length=20)),
-                ],
-            ),
-            migrations.RenameField(
-                model_name='testtuplerhsfilteredindex', old_name='a', new_name='aa'
-            ),
-            migrations.RenameField(
-                model_name='testtuplerhsfilteredindex', old_name='b', new_name='bb'
-            ),
-        ]
-        conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
-        with patch.object(conn.features, 'connection_persists_old_columns', False):
-            with conn.schema_editor(collect_sql=True, atomic=False) as editor:
-                project_state = migration.apply(ProjectState(), editor)
-                model = project_state.apps.get_model('testapp', 'TestTupleRhsFilteredIndex')
-                index = models.Index(
-                    fields=['c'],
-                    condition=models.Q(a=models.F('b')),
-                    name='idx_tuple_rhs_filtered',
+    def test_filtered_meta_index_retained_across_migration_rename(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestFilteredIndexAcrossRename{suffix}'
+                index_name = f'idx_filtered_across_rename{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20, null=True)),
+                                ('b', models.CharField(max_length=20)),
+                                ('c', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['b'],
+                                include=['c'],
+                                condition=models.Q(a__isnull=False),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                    ],
+                    operations_c=[
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_filtered_index_across_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
                 )
+                self.assertIn(index_name, result.constraints)
+                catalog = self._get_index_catalog(result.model, index_name)
                 self.assertEqual(
-                    editor._get_condition_field_names(index.condition), ['a', 'b']
+                    [column for included, column, _ in catalog if not included], ['b']
                 )
-                editor.execute(
-                    editor._clone_index_with_replacements(
-                        index, {'a': 'aa', 'b': 'bb'}
-                    ).create_sql(model, editor)
+                filter_definition = catalog[0][2]
+                self.assertIn((True, 'c', filter_definition), catalog)
+                self.assertIn('[aa]', filter_definition)
+
+    def test_filtered_meta_index_retained_after_logical_rename(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestFilteredIndexLogicalRename{suffix}'
+                index_name = f'idx_filtered_logical_rename{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                (
+                                    'a',
+                                    models.CharField(
+                                        max_length=20,
+                                        null=True,
+                                        db_column='stable_a',
+                                    ),
+                                ),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['b'],
+                                condition=models.Q(a__isnull=False),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                    ],
+                    operations_c=[
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_filtered_index_logical_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
                 )
-        index_sql = next(
-            sql for sql in editor.collected_sql if 'idx_tuple_rhs_filtered' in sql
-        )
-        self.assertIn('[aa]', index_sql)
-        self.assertIn('[bb]', index_sql)
+                self._assert_named_index_columns(
+                    result.constraints,
+                    index_name,
+                    ['b'],
+                    'A logical rename did not update the filtered Meta.index reference.',
+                )
+                self.assertIn(
+                    '[stable_a]', self._get_index_catalog(result.model, index_name)[0][2]
+                )
+
+    def test_readded_meta_index_does_not_inherit_rename_replacements(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestReaddedFilteredIndex{suffix}'
+                index_name = f'idx_readded_filtered{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20, null=True)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['a'],
+                                condition=models.Q(a__isnull=False),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                        migrations.AddField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=20, null=True),
+                        ),
+                        migrations.RemoveIndex(
+                            model_name=model_name.lower(), name=index_name
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['a'],
+                                condition=models.Q(a__isnull=False),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_c=[
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='aa',
+                            field=models.CharField(max_length=40, null=True),
+                        ),
+                    ],
+                    migration_name_prefix='test_readded_filtered_index',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self._assert_named_index_columns(
+                    result.constraints,
+                    index_name,
+                    ['a'],
+                    'A re-added Meta index inherited replacements from a removed index.',
+                )
+                filter_definition = self._get_index_catalog(result.model, index_name)[0][2]
+                self.assertIn('[a]', filter_definition)
+                self.assertNotIn('[aa]', filter_definition)
+
+    def test_filtered_fk_meta_index_restored_after_constraint_removal(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                parent_model_name = f'TestFilteredFkParent{suffix}'
+                model_name = f'TestFilteredFkChild{suffix}'
+                index_name = f'idx_filtered_fk{suffix}'
+                parent_model = f'testapp.{parent_model_name}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=parent_model_name,
+                            fields=[('id', models.AutoField(primary_key=True))],
+                        ),
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                (
+                                    'parent',
+                                    models.ForeignKey(
+                                        parent_model,
+                                        on_delete=models.CASCADE,
+                                    ),
+                                ),
+                                ('flag', models.CharField(max_length=20, null=True)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['parent'],
+                                condition=models.Q(flag__isnull=False),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='parent',
+                            field=models.ForeignKey(
+                                parent_model,
+                                db_constraint=False,
+                                null=True,
+                                on_delete=models.CASCADE,
+                            ),
+                        ),
+                    ],
+                    migration_name_prefix='test_filtered_fk_index',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self._assert_named_index_columns(
+                    result.constraints,
+                    index_name,
+                    ['parent_id'],
+                    'A filtered FK Meta index was not restored after its constraint dropped.',
+                )
+                self.assertIn(
+                    '[flag]', self._get_index_catalog(result.model, index_name)[0][2]
+                )
+
+    def test_filtered_meta_index_tracks_tuple_rhs_expression(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestTupleRhsFilteredIndex{suffix}'
+                index_name = f'idx_tuple_rhs_filtered{suffix}'
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20)),
+                            ('b', models.CharField(max_length=20)),
+                            ('c', models.CharField(max_length=20)),
+                        ],
+                    ),
+                    migrations.AddIndex(
+                        model_name=model_name.lower(),
+                        index=models.Index(
+                            fields=['c'],
+                            condition=models.Q(a=models.F('b')),
+                            name=index_name,
+                        ),
+                    ),
+                ]
+                operations_b = [
+                    migrations.RenameField(
+                        model_name=model_name.lower(), old_name='a', new_name='aa'
+                    ),
+                    migrations.RenameField(
+                        model_name=model_name.lower(), old_name='b', new_name='bb'
+                    ),
+                ]
+                operations_c = [
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='c',
+                        field=models.CharField(max_length=40),
+                    ),
+                ]
+                conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+                with patch.object(conn.features, 'connection_persists_old_columns', False):
+                    if use_single_migration:
+                        class CombinedMigration(migrations.Migration):
+                            initial = True
+                            operations = operations_a + operations_b + operations_c
+
+                        migration = CombinedMigration(
+                            name=f'test_tuple_rhs_filtered{suffix}', app_label='testapp'
+                        )
+                        with conn.schema_editor(collect_sql=True, atomic=False) as editor:
+                            project_state = migration.apply(ProjectState(), editor)
+                            model = project_state.apps.get_model('testapp', model_name)
+                            index = next(
+                                index for index in model._meta.indexes
+                                if index.name == index_name
+                            )
+                            self.assertEqual(
+                                editor._get_condition_field_names(index.condition), ['aa', 'bb']
+                            )
+                            editor.execute(
+                                editor._clone_index_with_replacements(index, {}).create_sql(
+                                    model, editor
+                                )
+                            )
+                    else:
+                        class MigrationA(migrations.Migration):
+                            initial = True
+                            operations = operations_a
+
+                        class MigrationB(migrations.Migration):
+                            operations = operations_b
+
+                        class MigrationC(migrations.Migration):
+                            operations = operations_c
+
+                        with conn.schema_editor(collect_sql=True, atomic=False) as editor_a:
+                            project_state = MigrationA(
+                                name=f'test_tuple_rhs_filtered{suffix}_a', app_label='testapp'
+                            ).apply(ProjectState(), editor_a)
+                        with conn.schema_editor(collect_sql=True, atomic=False) as editor_b:
+                            project_state = MigrationB(
+                                name=f'test_tuple_rhs_filtered{suffix}_b', app_label='testapp'
+                            ).apply(project_state, editor_b)
+                        with conn.schema_editor(collect_sql=True, atomic=False) as editor:
+                            project_state = MigrationC(
+                                name=f'test_tuple_rhs_filtered{suffix}_c', app_label='testapp'
+                            ).apply(project_state, editor)
+                            model = project_state.apps.get_model('testapp', model_name)
+                            index = next(
+                                index for index in model._meta.indexes
+                                if index.name == index_name
+                            )
+                            self.assertEqual(
+                                editor._get_condition_field_names(index.condition), ['aa', 'bb']
+                            )
+                            editor.execute(
+                                editor._clone_index_with_replacements(index, {}).create_sql(
+                                    model, editor
+                                )
+                            )
+                index_sql = editor.collected_sql[-1]
+                self.assertIn('[aa]', index_sql)
+                self.assertIn('[bb]', index_sql)
+                self.assertIn('[c]', index_sql)
 
     def test_expression_filtered_meta_index_retained_after_rename_and_alter(self):
         """

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -2071,6 +2071,48 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 )
                 catalog = self._get_index_catalog(result.model, index_name)
                 self.assertIn('[aa]', catalog[0][2])
+    def test_filtered_meta_index_tracks_tuple_rhs_expression(self):
+        migration = Migration('test_tuple_rhs_filtered_index', 'testapp')
+        migration.operations = [
+            migrations.CreateModel(
+                name='TestTupleRhsFilteredIndex',
+                fields=[
+                    ('id', models.AutoField(primary_key=True)),
+                    ('a', models.CharField(max_length=20)),
+                    ('b', models.CharField(max_length=20)),
+                    ('c', models.CharField(max_length=20)),
+                ],
+            ),
+            migrations.RenameField(
+                model_name='testtuplerhsfilteredindex', old_name='a', new_name='aa'
+            ),
+            migrations.RenameField(
+                model_name='testtuplerhsfilteredindex', old_name='b', new_name='bb'
+            ),
+        ]
+        conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+        with patch.object(conn.features, 'connection_persists_old_columns', False):
+            with conn.schema_editor(collect_sql=True, atomic=False) as editor:
+                project_state = migration.apply(ProjectState(), editor)
+                model = project_state.apps.get_model('testapp', 'TestTupleRhsFilteredIndex')
+                index = models.Index(
+                    fields=['c'],
+                    condition=models.Q(a=models.F('b')),
+                    name='idx_tuple_rhs_filtered',
+                )
+                self.assertEqual(
+                    editor._get_condition_field_names(index.condition), ['a', 'b']
+                )
+                editor.execute(
+                    editor._clone_index_with_replacements(
+                        index, {'a': 'aa', 'b': 'bb'}
+                    ).create_sql(model, editor)
+                )
+        index_sql = next(
+            sql for sql in editor.collected_sql if 'idx_tuple_rhs_filtered' in sql
+        )
+        self.assertIn('[aa]', index_sql)
+        self.assertIn('[bb]', index_sql)
 
     def test_expression_filtered_meta_index_retained_after_rename_and_alter(self):
         """

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -3314,6 +3314,209 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     f"({self._get_context_description(use_single_migration)}).",
                 )
 
+    def test_db_index_retained_after_autofield_column_rename(self):
+        """
+        Same AutoField-own-db_column-rename scenario as
+        test_meta_index_retained_after_autofield_column_rename above, but for
+        a plain db_index=True column instead of a Meta.indexes entry. The
+        AutoField "drop all indexes" path drops this index too, and it must
+        be restored the same way the non-renamed "column alteration cleanup"
+        path restores db_index=True columns for a plain (non-renamed)
+        AutoField/BigAutoField change.
+        """
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestDbIdxAutoFieldRename{suffix}'
+
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20, db_index=True)),
+                        ],
+                    ),
+                ]
+                operations_b = [
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='id',
+                        field=models.AutoField(primary_key=True, db_column='new_id'),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_db_idx_autofield_column_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a'},
+                    error_msg=(
+                        "A db_index=True column's index was permanently lost after renaming an "
+                        "AutoField's own db_column "
+                        f"({self._get_context_description(use_single_migration)})."
+                    ),
+                )
+
+    @skipIf(VERSION >= (5, 1), "index_together is removed in Django 5.1+")
+    def test_index_together_retained_after_autofield_column_rename(self):
+        """
+        Same AutoField-own-db_column-rename scenario as
+        test_meta_index_retained_after_autofield_column_rename above, but for
+        an index_together entry instead of a Meta.indexes entry.
+        """
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestIdxTogetherAutoFieldRename{suffix}'
+
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20)),
+                            ('b', models.CharField(max_length=20)),
+                        ],
+                        options={
+                            'index_together': {('a', 'b')},
+                        },
+                    ),
+                ]
+                operations_b = [
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='id',
+                        field=models.AutoField(primary_key=True, db_column='new_id'),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_idx_together_autofield_column_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_index_exists(
+                    result.constraints,
+                    expected_columns={'a', 'b'},
+                    error_msg=(
+                        "An index_together index was permanently lost after renaming an "
+                        "AutoField's own db_column "
+                        f"({self._get_context_description(use_single_migration)})."
+                    ),
+                )
+
+    def test_unique_together_retained_after_autofield_column_rename(self):
+        """
+        Same AutoField-own-db_column-rename scenario as
+        test_meta_index_retained_after_autofield_column_rename above, but for
+        a unique_together entry instead of a Meta.indexes entry. Unlike
+        test_unique_together_retained_after_rename_and_type_change (a
+        different, non-AutoField scenario left as a documented
+        @expectedFailure), the AutoField-wholesale-drop path here is the one
+        this fix restores.
+        """
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestUniqTogetherAutoFieldRename{suffix}'
+
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20)),
+                            ('b', models.CharField(max_length=20)),
+                        ],
+                        options={
+                            'unique_together': {('a', 'b')},
+                        },
+                    ),
+                ]
+                operations_b = [
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='id',
+                        field=models.AutoField(primary_key=True, db_column='new_id'),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_uniq_together_autofield_column_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                unique_constraints = [
+                    info for info in result.constraints.values()
+                    if info.get('unique') and set(info['columns']) == {'a', 'b'}
+                ]
+                self.assertTrue(
+                    len(unique_constraints) > 0,
+                    "unique_together constraint on ('a', 'b') was permanently lost after "
+                    "renaming an AutoField's own db_column "
+                    f"({self._get_context_description(use_single_migration)})."
+                )
+
+    def test_unique_constraint_retained_after_autofield_column_rename(self):
+        """
+        Same AutoField-own-db_column-rename scenario as
+        test_meta_index_retained_after_autofield_column_rename above, but for
+        a Meta.constraints UniqueConstraint unrelated to the renamed field
+        instead of a Meta.indexes entry.
+        """
+        model_name = 'TestUniqueConstraintAutoFieldRename'
+        constraint_name = 'uq_autofield_rename_unrelated'
+
+        result = self._run_migration_test(
+            operations_a=[
+                migrations.CreateModel(
+                    name=model_name,
+                    fields=[
+                        ('id', models.AutoField(primary_key=True)),
+                        ('a', models.CharField(max_length=20, null=True)),
+                    ],
+                    options={
+                        'constraints': [
+                            UniqueConstraint(
+                                fields=['a'],
+                                condition=models.Q(a__isnull=False),
+                                name=constraint_name,
+                            ),
+                        ],
+                    },
+                ),
+            ],
+            operations_b=[
+                migrations.AlterField(
+                    model_name=model_name.lower(),
+                    name='id',
+                    field=models.AutoField(primary_key=True, db_column='new_id'),
+                ),
+            ],
+            migration_name_prefix='test_unique_constraint_autofield_column_rename',
+            model_name=model_name,
+            use_single_migration=False,
+        )
+
+        self.assertIn(
+            constraint_name, result.constraints,
+            "A Meta.constraints UniqueConstraint unrelated to the renamed field was "
+            "permanently lost after renaming an AutoField's own db_column."
+        )
+
     def test_covering_unique_constraint_include_semantics_retained_after_rename(self):
         """
         A covering UniqueConstraint's INCLUDE column, when renamed, must stay

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -2130,6 +2130,55 @@ class TestMetaIndexesRetained(TransactionTestCase):
         self.assertIn('[aa]', filter_definition)
         self.assertIn("'[a]'", filter_definition)
 
+    def test_filtered_meta_index_condition_only_rename_before_unrelated_alter(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestConditionOnlyRename{suffix}'
+                index_name = f'idx_condition_only_rename{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['b'],
+                                condition=models.Q(a__isnull=False),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_condition_only_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self._assert_named_index_columns(
+                    result.constraints,
+                    index_name,
+                    ['b'],
+                    'A predicate-only filtered Meta.index was not restored after a rename.',
+                )
+                filter_definition = self._get_index_catalog(result.model, index_name)[0][2]
+                self.assertIn('[aa]', filter_definition)
+                self.assertNotIn('[a]', filter_definition)
+
     @skipUnless(VERSION >= (4, 0), "Django 4.0+ ProjectState.rename_field support")
     def test_filtered_meta_index_retained_after_rename_and_alter(self):
         for use_single_migration in [False, True]:

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -2056,11 +2056,10 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 self.assertIn("'[b]'", catalog[0][2])
                 self.assertNotIn("'[aa]'", catalog[0][2])
 
-    @expectedFailure
     def test_deferred_filtered_meta_index_after_field_rename(self):
         """
-        A filtered Meta.indexes definition created with CreateModel is deferred
-        until after the RenameField. Its condition retains the old column name.
+        A filtered Meta.indexes condition remains structured until deferred SQL
+        executes, so a following RenameField updates its identifier only.
         """
         migration = Migration('test_deferred_filtered_index', 'testapp')
         migration.operations = [
@@ -2094,6 +2093,44 @@ class TestMetaIndexesRetained(TransactionTestCase):
         self.assertIn("'[a]'", index_sql)
 
     def test_filtered_meta_index_retained_after_rename_and_alter(self):
+
+    def test_deferred_filtered_meta_index_after_field_rename_executes(self):
+        index_name = 'idx_deferred_filtered_execution'
+        result = self._run_migration_test(
+            operations_a=[
+                migrations.CreateModel(
+                    name='TestDeferredFilteredIndexExecution',
+                    fields=[
+                        ('id', models.AutoField(primary_key=True)),
+                        ('a', models.CharField(max_length=20)),
+                        ('b', models.CharField(max_length=20)),
+                    ],
+                    options={
+                        'indexes': [
+                            models.Index(
+                                fields=['b'],
+                                condition=models.Q(a='[a]'),
+                                name=index_name,
+                            ),
+                        ],
+                    },
+                ),
+            ],
+            operations_b=[
+                migrations.RenameField(
+                    model_name='testdeferredfilteredindexexecution',
+                    old_name='a',
+                    new_name='aa',
+                ),
+            ],
+            migration_name_prefix='test_deferred_filtered_index_execution',
+            model_name='TestDeferredFilteredIndexExecution',
+            use_single_migration=True,
+        )
+        filter_definition = self._get_index_catalog(result.model, index_name)[0][2]
+        self.assertIn('[aa]', filter_definition)
+        self.assertIn("'[a]'", filter_definition)
+
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):
                 suffix = '_combined' if use_single_migration else '_split'

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -11,7 +11,8 @@ from django.db.models import UniqueConstraint
 from django.db.models.lookups import Exact
 from django.db.utils import DEFAULT_DB_ALIAS, ConnectionHandler, ProgrammingError
 from django.test import TestCase, TransactionTestCase
-from unittest import skipIf, expectedFailure
+from unittest import expectedFailure, skipIf
+from unittest.mock import patch
 
 from . import get_constraints
 from ..models import (
@@ -1998,39 +1999,36 @@ class TestMetaIndexesRetained(TransactionTestCase):
         A filtered Meta.indexes definition created with CreateModel is deferred
         until after the RenameField. Its condition retains the old column name.
         """
-        model_name = 'TestDeferredFilteredIndex'
-        index_name = 'idx_deferred_filtered'
-        result = self._run_migration_test(
-            operations_a=[
-                migrations.CreateModel(
-                    name=model_name,
-                    fields=[
-                        ('id', models.AutoField(primary_key=True)),
-                        ('a', models.CharField(max_length=20)),
-                        ('b', models.CharField(max_length=20)),
+        migration = Migration('test_deferred_filtered_index', 'testapp')
+        migration.operations = [
+            migrations.CreateModel(
+                name='TestDeferredFilteredIndex',
+                fields=[
+                    ('id', models.AutoField(primary_key=True)),
+                    ('a', models.CharField(max_length=20)),
+                    ('b', models.CharField(max_length=20)),
+                ],
+                options={
+                    'indexes': [
+                        models.Index(
+                            fields=['b'],
+                            condition=models.Q(a='[a]'),
+                            name='idx_deferred_filtered',
+                        ),
                     ],
-                    options={
-                        'indexes': [
-                            models.Index(
-                                fields=['b'],
-                                condition=models.Q(a='[a]'),
-                                name=index_name,
-                            ),
-                        ],
-                    },
-                ),
-                migrations.RenameField(
-                    model_name=model_name.lower(), old_name='a', new_name='aa'
-                ),
-            ],
-            operations_b=[],
-            migration_name_prefix='test_deferred_filtered_index',
-            model_name=model_name,
-            use_single_migration=True,
-        )
-        filter_definition = self._get_index_catalog(result.model, index_name)[0][2]
-        self.assertIn('[aa]', filter_definition)
-        self.assertIn("'[a]'", filter_definition)
+                },
+            ),
+            migrations.RenameField(
+                model_name='testdeferredfilteredindex', old_name='a', new_name='aa'
+            ),
+        ]
+        conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+        with patch.object(conn.features, 'connection_persists_old_columns', False):
+            with conn.schema_editor(collect_sql=True, atomic=False) as editor:
+                migration.apply(ProjectState(), editor)
+        index_sql = next(sql for sql in editor.collected_sql if 'idx_deferred_filtered' in sql)
+        self.assertIn('[aa]', index_sql)
+        self.assertIn("'[a]'", index_sql)
 
     def test_filtered_meta_index_retained_after_rename_and_alter(self):
         for use_single_migration in [False, True]:

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -2130,6 +2130,50 @@ class TestMetaIndexesRetained(TransactionTestCase):
         self.assertIn('[aa]', filter_definition)
         self.assertIn("'[a]'", filter_definition)
 
+    def test_deferred_conditional_unique_constraint_after_field_rename(self):
+        index_name = 'idx_deferred_conditional_unique_rename'
+        result = self._run_migration_test(
+            operations_a=[
+                migrations.CreateModel(
+                    name='TestDeferredConditionalUniqueRename',
+                    fields=[
+                        ('id', models.AutoField(primary_key=True)),
+                        ('a', models.CharField(max_length=20)),
+                        ('b', models.CharField(max_length=20)),
+                    ],
+                    options={
+                        'constraints': [
+                            UniqueConstraint(
+                                fields=['b'],
+                                condition=models.Q(a='[a]'),
+                                name=index_name,
+                            ),
+                        ],
+                    },
+                ),
+            ],
+            operations_b=[
+                migrations.RenameField(
+                    model_name='testdeferredconditionaluniquerename',
+                    old_name='a',
+                    new_name='aa',
+                ),
+            ],
+            migration_name_prefix='test_deferred_conditional_unique_rename',
+            model_name='TestDeferredConditionalUniqueRename',
+            use_single_migration=True,
+        )
+        self._assert_named_index_columns(
+            result.constraints,
+            index_name,
+            ['b'],
+            'A deferred conditional unique constraint was not created as an index.',
+        )
+        filter_definition = self._get_index_catalog(result.model, index_name)[0][2]
+        self.assertIn('[aa]', filter_definition)
+        self.assertIn("'[a]'", filter_definition)
+        self.assertNotIn("'[aa]'", filter_definition)
+
     def test_filtered_meta_index_condition_only_rename_before_unrelated_alter(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -3000,6 +3000,70 @@ class TestMetaIndexesRetained(TransactionTestCase):
 
         self.assertNotIn(constraint_name, result.constraints)
 
+    def test_squashed_create_model_rename_field_retains_meta_index(self):
+        """
+        When Django's migration optimizer folds a RenameField into a
+        preceding CreateModel (e.g. via squashmigrations, or autodetector-side
+        optimization within one makemigrations run), CreateModel.reduce()
+        rewrites only unique_together/index_together in its absorbed options,
+        never the structured Meta.indexes/.constraints - so a folded
+        CreateModel keeps referencing the pre-rename field name.
+        """
+        from django.db.migrations.optimizer import MigrationOptimizer
+
+        model_name = 'TestSquashedRenameIndex'
+        index_name = 'idx_squashed_rename'
+        operations = [
+            migrations.CreateModel(
+                name=model_name,
+                fields=[
+                    ('id', models.AutoField(primary_key=True)),
+                    ('a', models.CharField(max_length=20)),
+                    ('b', models.CharField(max_length=20)),
+                ],
+                options={
+                    'indexes': [
+                        models.Index(
+                            fields=['b'],
+                            condition=models.Q(a__isnull=False),
+                            name=index_name,
+                        ),
+                    ],
+                },
+            ),
+            migrations.RenameField(
+                model_name=model_name.lower(), old_name='a', new_name='aa'
+            ),
+        ]
+        optimized = MigrationOptimizer().optimize(operations, 'testapp')
+        # Precondition: confirm Django's optimizer actually folds CreateModel +
+        # RenameField into one CreateModel (the scenario this fix targets). If
+        # this assertion ever fails, Django's optimizer behavior changed and
+        # this test needs re-deriving, not weakening.
+        self.assertEqual(len(optimized), 1)
+        self.assertIsInstance(optimized[0], migrations.CreateModel)
+
+        class SquashedMigration(migrations.Migration):
+            initial = True
+            operations = optimized
+
+        migration = SquashedMigration(
+            name='test_squashed_rename_index', app_label='testapp'
+        )
+        conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+        with conn.schema_editor(atomic=True) as editor:
+            project_state = migration.apply(ProjectState(), editor)
+
+        model = project_state.apps.get_model('testapp', model_name)
+        constraints = get_constraints(table_name=model._meta.db_table)
+        self._assert_named_index_columns(
+            constraints, index_name, ['b'],
+            'A Meta.index folded into CreateModel by the optimizer lost its key column.',
+        )
+        filter_definition = self._get_index_catalog(model, index_name)[0][2]
+        self.assertIn('[aa]', filter_definition)
+        self.assertNotIn('[a]', filter_definition)
+
 
 
 

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -1776,6 +1776,52 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     'A stale Meta.indexes field was retargeted during an AutoField change.',
                 )
 
+    def test_stale_meta_index_reconciles_reused_field_name(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestReusedIndexField{suffix}'
+                index_name = f'idx_reused_field{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a'], name=index_name),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                        migrations.AddField(
+                            model_name=model_name.lower(),
+                            name='a',
+                            field=models.CharField(max_length=20),
+                        ),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='aa',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_reused_index_field',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self._assert_named_index_columns(
+                    result.constraints,
+                    index_name,
+                    ['aa'],
+                    'A stale Meta.indexes field was not reconciled after its old name was reused.',
+                )
+
     def test_removed_meta_index_not_retargeted_by_unrelated_alter(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -1906,6 +1906,53 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     ['aa', 'bb'],
                     'A composite Meta.indexes definition was not restored after multiple renames.',
                 )
+    def test_filtered_meta_index_restored_after_multiple_renames(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestFilteredMultipleRenames{suffix}'
+                index_name = f'idx_filtered_multiple{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('c', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['a'],
+                                condition=models.Q(c__isnull=False),
+                                name=index_name,
+                            ),
+                        ),
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='c', new_name='cc'
+                        ),
+                    ],
+                    migration_name_prefix='test_filtered_multiple_renames',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self._assert_named_index_columns(
+                    result.constraints,
+                    index_name,
+                    ['aa'],
+                    'A filtered Meta.indexes key was not restored after multiple renames.',
+                )
+                filter_definition = self._get_index_catalog(result.model, index_name)[0][2]
+                self.assertIn('[cc]', filter_definition)
+                self.assertNotIn('[c]', filter_definition)
+
     def test_filtered_meta_index_preserves_literal_after_field_rename(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -14,7 +14,7 @@ from django.test import TestCase, TransactionTestCase
 from unittest import expectedFailure, skipIf, skipUnless
 from unittest.mock import patch
 
-from mssql.schema import _clone_index_with_replacements
+from mssql.schema import _clone_index_with_replacements, _replace_condition_field_names
 
 from . import get_constraints
 from ..models import (
@@ -3063,6 +3063,28 @@ class TestMetaIndexesRetained(TransactionTestCase):
         filter_definition = self._get_index_catalog(model, index_name)[0][2]
         self.assertIn('[aa]', filter_definition)
         self.assertNotIn('[a]', filter_definition)
+
+    def test_condition_field_names_rewritten_for_collection_and_transformed_rhs(self):
+        """
+        Field references nested in a tuple/list RHS value, or reached through
+        a lookup transform on an F() reference, must be rewritten on rename,
+        not silently left stale (or silently dropped from the referenced
+        field names used to decide which indexes are affected by a rename).
+        """
+        conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+        editor = conn.schema_editor(collect_sql=True, atomic=False)
+
+        collection_condition = models.Q(a__in=(models.F('b'),))
+        _replace_condition_field_names(collection_condition, {'b': 'bb'})
+        self.assertEqual(
+            editor._get_condition_field_names(collection_condition), ['a', 'bb']
+        )
+
+        transformed_condition = models.Q(b=models.F('a__year'))
+        _replace_condition_field_names(transformed_condition, {'a': 'aa'})
+        self.assertEqual(
+            editor._get_condition_field_names(transformed_condition), ['b', 'aa']
+        )
 
 
 

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -8,6 +8,7 @@ from django.db import models, migrations
 from django.db.migrations.migration import Migration
 from django.db.migrations.state import ProjectState
 from django.db.models import UniqueConstraint
+from django.db.models.lookups import Exact
 from django.db.utils import DEFAULT_DB_ALIAS, ConnectionHandler, ProgrammingError
 from django.test import TestCase, TransactionTestCase
 from unittest import skipIf, expectedFailure
@@ -1936,10 +1937,52 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     model_name=model_name,
                     use_single_migration=use_single_migration,
                 )
-                self.assertEqual(
-                    self._get_index_catalog(result.model, index_name),
-                    [(False, 'b', None), (True, 'aa', None)],
+                catalog = self._get_index_catalog(result.model, index_name)
+                self.assertIn((False, 'b', None), catalog)
+                self.assertIn((True, 'aa', None), catalog)
+
+    def test_expression_filtered_meta_index_retained_after_alter(self):
+        """
+        A filtered Meta index may use a positional lookup expression instead of
+        a keyword-style Q tuple. Ensure altering its key field preserves the
+        index and doesn't treat the Exact expression as a subscriptable tuple.
+        """
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestExpressionFilteredIndex{suffix}'
+                index_name = f'idx_expression_filtered{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['b'],
+                                condition=models.Q(Exact(models.F('a'), models.Value('value'))),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_expression_filtered_index',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
                 )
+                self.assertIn('[a]', self._get_index_catalog(result.model, index_name)[0][2])
 
     @expectedFailure
     def test_unique_together_retained_when_field_also_has_unique_true(self):

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -3086,6 +3086,78 @@ class TestMetaIndexesRetained(TransactionTestCase):
             editor._get_condition_field_names(transformed_condition), ['b', 'aa']
         )
 
+    def test_filtered_meta_index_restored_with_unbound_replacement_field(self):
+        """
+        schema_editor.alter_field() may be called directly (as
+        TestIndexesBeingDropped.test_unique_index_dropped already does
+        elsewhere) with an unbound replacement field that has no .model
+        attribute. The rename-restoration path must use the same meta_model
+        fallback _alter_field() establishes for old_field/new_field elsewhere,
+        not new_field.model directly.
+
+        `to_model` (obtained via AlterField.state_forwards(), like a real
+        migration's to_state) is passed as the `model` argument so meta_model's
+        fallback has correct post-alter field metadata to restore against,
+        while `new_field` itself is a manually constructed field deliberately
+        left unbound (no .model), reproducing the exact caller shape that
+        crashes without the fix.
+        """
+        model_name = 'TestUnboundRenameFilteredIndex'
+        index_name = 'idx_unbound_rename_filtered'
+
+        class SetupMigration(migrations.Migration):
+            initial = True
+            operations = [
+                migrations.CreateModel(
+                    name=model_name,
+                    fields=[
+                        ('id', models.AutoField(primary_key=True)),
+                        ('a', models.CharField(max_length=20, null=True)),
+                        ('b', models.CharField(max_length=20)),
+                    ],
+                ),
+                migrations.AddIndex(
+                    model_name=model_name.lower(),
+                    index=models.Index(
+                        fields=['b'],
+                        condition=models.Q(a__isnull=False),
+                        name=index_name,
+                    ),
+                ),
+            ]
+
+        migration = SetupMigration(
+            name='test_unbound_rename_filtered', app_label='testapp'
+        )
+        conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+        with conn.schema_editor(atomic=True) as editor:
+            from_state = migration.apply(ProjectState(), editor)
+
+        to_state = from_state.clone()
+        migrations.AlterField(
+            model_name=model_name.lower(),
+            name='a',
+            field=models.CharField(max_length=20, null=True, db_column='aa'),
+        ).state_forwards('testapp', to_state)
+
+        from_model = from_state.apps.get_model('testapp', model_name)
+        to_model = to_state.apps.get_model('testapp', model_name)
+        old_field = from_model._meta.get_field('a')
+        new_field = models.CharField(max_length=20, null=True, db_column='aa')
+        new_field.set_attributes_from_name('a')
+        with conn.schema_editor(atomic=True) as editor:
+            editor.alter_field(to_model, old_field, new_field, strict=True)
+
+        constraints = get_constraints(table_name=to_model._meta.db_table)
+        self._assert_named_index_columns(
+            constraints, index_name, ['b'],
+            'A filtered Meta.index was lost when alter_field() was called '
+            'directly with an unbound replacement field.',
+        )
+        self.assertIn(
+            '[aa]', self._get_index_catalog(to_model, index_name)[0][2]
+        )
+
 
 
 

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -1945,6 +1945,46 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 self.assertIn("'[a]'", filter_definition)
                 self.assertNotIn("'[aa]'", filter_definition)
 
+    @expectedFailure
+    def test_deferred_filtered_meta_index_after_field_rename(self):
+        """
+        A filtered Meta.indexes definition created with CreateModel is deferred
+        until after the RenameField. Its condition retains the old column name.
+        """
+        model_name = 'TestDeferredFilteredIndex'
+        index_name = 'idx_deferred_filtered'
+        result = self._run_migration_test(
+            operations_a=[
+                migrations.CreateModel(
+                    name=model_name,
+                    fields=[
+                        ('id', models.AutoField(primary_key=True)),
+                        ('a', models.CharField(max_length=20)),
+                        ('b', models.CharField(max_length=20)),
+                    ],
+                    options={
+                        'indexes': [
+                            models.Index(
+                                fields=['b'],
+                                condition=models.Q(a='[a]'),
+                                name=index_name,
+                            ),
+                        ],
+                    },
+                ),
+                migrations.RenameField(
+                    model_name=model_name.lower(), old_name='a', new_name='aa'
+                ),
+            ],
+            operations_b=[],
+            migration_name_prefix='test_deferred_filtered_index',
+            model_name=model_name,
+            use_single_migration=True,
+        )
+        filter_definition = self._get_index_catalog(result.model, index_name)[0][2]
+        self.assertIn('[aa]', filter_definition)
+        self.assertIn("'[a]'", filter_definition)
+
     def test_filtered_meta_index_retained_after_rename_and_alter(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -2889,6 +2889,60 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     f"that only executes when the field does NOT have unique=True."
                 )
 
+    def test_plain_meta_index_retained_after_combined_rename_and_alter(self):
+        """
+        A single AlterField that changes both db_column (rename) and max_length
+        (type) on the same field must not drop a plain (non-conditional)
+        Meta.indexes entry referencing that field without recreating it.
+
+        Unlike RenameField (which never changes type/null in the same
+        operation), AlterField can combine a db_column rename with a type
+        change in one call - this is the repro shape for this regression.
+        """
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestPlainCombinedRename{suffix}'
+                index_name = f'idx_plain_combined_rename{suffix}'
+
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20)),
+                            ('b', models.CharField(max_length=20)),
+                        ],
+                    ),
+                    migrations.AddIndex(
+                        model_name=model_name.lower(),
+                        index=models.Index(fields=['b'], name=index_name),
+                    ),
+                ]
+
+                operations_b = [
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='b',
+                        field=models.CharField(max_length=40, db_column='bb'),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_plain_combined_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_named_index_columns(
+                    result.constraints, index_name, ['bb'],
+                    "A plain Meta.index was dropped and not restored after "
+                    "a combined db_column rename and type change "
+                    f"({self._get_context_description(use_single_migration)})."
+                )
+
 
 
 

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -2943,7 +2943,6 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     f"({self._get_context_description(use_single_migration)})."
                 )
 
-    @skipUnless(VERSION >= (4, 0), "Django 4.0+ ProjectState.rename_field support")
     def test_conditional_unique_constraint_removable_after_rename(self):
         """
         RenameField rewrites structured Meta.indexes state but not
@@ -3082,6 +3081,11 @@ class TestMetaIndexesRetained(TransactionTestCase):
 
         transformed_condition = models.Q(b=models.F('a__year'))
         _replace_condition_field_names(transformed_condition, {'a': 'aa'})
+        # Assert the rewritten F() object directly: _get_condition_field_names()
+        # deliberately strips everything after '__', so it alone cannot tell
+        # apart a correctly preserved 'aa__year' from a broken 'aa' that lost
+        # the year transform entirely.
+        self.assertEqual(transformed_condition.children[0][1].name, 'aa__year')
         self.assertEqual(
             editor._get_condition_field_names(transformed_condition), ['b', 'aa']
         )

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -3314,6 +3314,63 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     f"({self._get_context_description(use_single_migration)}).",
                 )
 
+    def test_covering_unique_constraint_include_semantics_retained_after_rename(self):
+        """
+        A covering UniqueConstraint's INCLUDE column, when renamed, must stay
+        an INCLUDE column - not get silently promoted into the unique key.
+        The generic "drop any unique index whose physical columns include
+        the renamed column" path does not distinguish key from INCLUDE
+        columns (sys.index_columns doesn't either, without an explicit
+        filter), so it must not be allowed to rebuild this constraint; only
+        the structured restoration (via _clone_constraint_with_replacements())
+        preserves the key/include distinction.
+        """
+        model_name = 'TestCoveringConstraintRename'
+        constraint_name = 'uq_covering_constraint_rename'
+
+        result = self._run_migration_test(
+            operations_a=[
+                migrations.CreateModel(
+                    name=model_name,
+                    fields=[
+                        ('id', models.AutoField(primary_key=True)),
+                        ('a', models.CharField(max_length=20, null=True)),
+                        ('b', models.CharField(max_length=20)),
+                    ],
+                    options={
+                        'constraints': [
+                            UniqueConstraint(
+                                fields=['b'],
+                                include=['a'],
+                                condition=models.Q(a__isnull=False),
+                                name=constraint_name,
+                            ),
+                        ],
+                    },
+                ),
+            ],
+            operations_b=[
+                migrations.RenameField(
+                    model_name=model_name.lower(), old_name='a', new_name='aa'
+                ),
+            ],
+            migration_name_prefix='test_covering_constraint_rename',
+            model_name=model_name,
+            use_single_migration=False,
+        )
+
+        catalog = self._get_index_catalog(result.model, constraint_name)
+        included_by_column = {name: is_included for is_included, name, _ in catalog}
+        self.assertEqual(
+            included_by_column.get('b'), False,
+            "The constraint's key column 'b' should remain key-only.",
+        )
+        self.assertEqual(
+            included_by_column.get('aa'), True,
+            "The renamed INCLUDE column must stay an INCLUDE column, not be "
+            "promoted into the unique key.",
+        )
+
 
 
 

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -1992,6 +1992,55 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 self.assertIn('[aa]', filter_definition)
                 self.assertIn("'[a]'", filter_definition)
                 self.assertNotIn("'[aa]'", filter_definition)
+    def test_filtered_meta_index_ignores_bracketed_literal(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestBracketedLiteral{suffix}'
+                index_name = f'idx_bracketed_literal{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['b'],
+                                condition=models.Q(a='[b]'),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_bracketed_literal',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                catalog = self._get_index_catalog(result.model, index_name)
+                self._assert_named_index_columns(
+                    result.constraints,
+                    index_name,
+                    ['b'],
+                    'A filtered Meta.indexes key was not restored after an unrelated rename.',
+                )
+                self.assertIn('[aa]', catalog[0][2])
+                self.assertIn("'[b]'", catalog[0][2])
+                self.assertNotIn("'[aa]'", catalog[0][2])
 
     @expectedFailure
     def test_deferred_filtered_meta_index_after_field_rename(self):

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -11,7 +11,7 @@ from django.db.models import UniqueConstraint
 from django.db.models.lookups import Exact
 from django.db.utils import DEFAULT_DB_ALIAS, ConnectionHandler, ProgrammingError
 from django.test import TestCase, TransactionTestCase
-from unittest import expectedFailure, skipIf
+from unittest import expectedFailure, skipIf, skipUnless
 from unittest.mock import patch
 
 from mssql.schema import _clone_index_with_replacements
@@ -2006,6 +2006,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 self.assertIn('[aa]', filter_definition)
                 self.assertIn("'[a]'", filter_definition)
                 self.assertNotIn("'[aa]'", filter_definition)
+    @skipUnless(VERSION >= (4, 0), "Django 4.0+ ProjectState.rename_field support")
     def test_filtered_meta_index_ignores_bracketed_literal(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):
@@ -2092,8 +2093,6 @@ class TestMetaIndexesRetained(TransactionTestCase):
         self.assertIn('[aa]', index_sql)
         self.assertIn("'[a]'", index_sql)
 
-    def test_filtered_meta_index_retained_after_rename_and_alter(self):
-
     def test_deferred_filtered_meta_index_after_field_rename_executes(self):
         index_name = 'idx_deferred_filtered_execution'
         result = self._run_migration_test(
@@ -2131,6 +2130,8 @@ class TestMetaIndexesRetained(TransactionTestCase):
         self.assertIn('[aa]', filter_definition)
         self.assertIn("'[a]'", filter_definition)
 
+    @skipUnless(VERSION >= (4, 0), "Django 4.0+ ProjectState.rename_field support")
+    def test_filtered_meta_index_retained_after_rename_and_alter(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):
                 suffix = '_combined' if use_single_migration else '_split'
@@ -2171,6 +2172,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 )
                 catalog = self._get_index_catalog(result.model, index_name)
                 self.assertIn('[aa]', catalog[0][2])
+    @skipUnless(VERSION >= (4, 0), "Django 4.0+ ProjectState.rename_field support")
     def test_filtered_meta_index_retained_across_migration_rename(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):
@@ -2223,6 +2225,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 self.assertIn((True, 'c', filter_definition), catalog)
                 self.assertIn('[aa]', filter_definition)
 
+    @skipUnless(VERSION >= (4, 0), "Django 4.0+ ProjectState.rename_field support")
     def test_filtered_meta_index_survives_reconstructed_rename_state(self):
         """
         MigrationExecutor startup rebuilds applied-migration state without replaying
@@ -2295,6 +2298,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
         catalog = self._get_index_catalog(model, 'idx_filtered_reconstructed')
         self.assertIn('[aa]', catalog[0][2])
 
+    @skipUnless(VERSION >= (4, 0), "Django 4.0+ ProjectState.rename_field support")
     def test_filtered_meta_index_retained_after_logical_rename(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):
@@ -2482,6 +2486,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     '[flag]', self._get_index_catalog(result.model, index_name)[0][2]
                 )
 
+    @skipUnless(VERSION >= (4, 0), "Django 4.0+ expression conditions")
     def test_filtered_meta_index_tracks_tuple_rhs_expression(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):
@@ -2588,6 +2593,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 self.assertIn('[bb]', index_sql)
                 self.assertIn('[c]', index_sql)
 
+    @skipUnless(VERSION >= (4, 0), "Django 4.0+ ProjectState.rename_field support")
     def test_expression_filtered_meta_index_retained_after_rename_and_alter(self):
         """
         Field references nested in positional lookup expressions must be updated
@@ -2672,6 +2678,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 self.assertIn((False, 'b', None), catalog)
                 self.assertIn((True, 'aa', None), catalog)
 
+    @skipUnless(VERSION >= (4, 0), "Django 4.0+ expression conditions")
     def test_expression_filtered_meta_index_retained_after_alter(self):
         """
         A filtered Meta index may use a positional lookup expression instead of

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -3158,6 +3158,56 @@ class TestMetaIndexesRetained(TransactionTestCase):
             '[aa]', self._get_index_catalog(to_model, index_name)[0][2]
         )
 
+    def test_meta_index_restore_skips_still_deferred_creation(self):
+        """
+        A Meta.indexes entry declared inline via CreateModel(options={...})
+        is legitimately absent from the catalog until its deferred CREATE
+        INDEX statement runs at schema_editor context exit. A combined
+        db_column rename and type change on that index's field within the
+        SAME migration must not have _restore_missing_meta_indexes() treat
+        that still-pending index as one it needs to recreate - doing so
+        collides with the original deferred CREATE INDEX once it finally
+        executes.
+        """
+        model_name = 'TestDeferredIndexCollision'
+        index_name = 'idx_deferred_index_collision'
+
+        operations_a = [
+            migrations.CreateModel(
+                name=model_name,
+                fields=[
+                    ('id', models.AutoField(primary_key=True)),
+                    ('a', models.CharField(max_length=20)),
+                    ('b', models.CharField(max_length=20)),
+                ],
+                options={
+                    'indexes': [
+                        models.Index(fields=['b'], name=index_name),
+                    ],
+                },
+            ),
+            migrations.AlterField(
+                model_name=model_name.lower(),
+                name='b',
+                field=models.CharField(max_length=40, db_column='bb'),
+            ),
+        ]
+
+        result = self._run_migration_test(
+            operations_a=operations_a,
+            operations_b=[],
+            migration_name_prefix='test_deferred_index_collision',
+            model_name=model_name,
+            use_single_migration=True,
+        )
+
+        self._assert_named_index_columns(
+            result.constraints, index_name, ['bb'],
+            'A Meta.index declared inline via CreateModel was not correctly '
+            'restored after a combined rename and type change in the same '
+            'migration.',
+        )
+
 
 
 

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -3261,6 +3261,59 @@ class TestMetaIndexesRetained(TransactionTestCase):
             "when an unrelated field's type was altered.",
         )
 
+    def test_meta_index_retained_after_autofield_column_rename(self):
+        """
+        Altering an AutoField/BigAutoField field unconditionally drops every
+        index on the table (SQL Server requires this before an ALTER COLUMN
+        on an IDENTITY column). When that alteration also renames the
+        AutoField's own db_column, the normal "column alteration cleanup"
+        restoration is skipped (it only runs when the column was NOT
+        renamed), so a Meta.index on an unrelated field must still be
+        restored via the rename-restoration path, not silently dropped for
+        good.
+        """
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestAutoFieldColumnRename{suffix}'
+                index_name = f'idx_autofield_column_rename{suffix}'
+
+                operations_a = [
+                    migrations.CreateModel(
+                        name=model_name,
+                        fields=[
+                            ('id', models.AutoField(primary_key=True)),
+                            ('a', models.CharField(max_length=20)),
+                        ],
+                    ),
+                    migrations.AddIndex(
+                        model_name=model_name.lower(),
+                        index=models.Index(fields=['a'], name=index_name),
+                    ),
+                ]
+                operations_b = [
+                    migrations.AlterField(
+                        model_name=model_name.lower(),
+                        name='id',
+                        field=models.AutoField(primary_key=True, db_column='new_id'),
+                    ),
+                ]
+
+                result = self._run_migration_test(
+                    operations_a=operations_a,
+                    operations_b=operations_b,
+                    migration_name_prefix='test_autofield_column_rename',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+
+                self._assert_named_index_columns(
+                    result.constraints, index_name, ['a'],
+                    'A Meta.index was permanently lost after renaming an '
+                    "AutoField's own db_column "
+                    f"({self._get_context_description(use_single_migration)}).",
+                )
+
 
 
 

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -2943,6 +2943,63 @@ class TestMetaIndexesRetained(TransactionTestCase):
                     f"({self._get_context_description(use_single_migration)})."
                 )
 
+    @skipUnless(VERSION >= (4, 0), "Django 4.0+ ProjectState.rename_field support")
+    def test_conditional_unique_constraint_removable_after_rename(self):
+        """
+        RenameField rewrites structured Meta.indexes state but not
+        Meta.constraints (UniqueConstraint.condition/fields/include), leaving a
+        stale field reference that raises FieldError when a later operation
+        (e.g. RemoveConstraint) renders it.
+
+        Uses split migrations (each operation committed in its own
+        schema_editor context) so the filtered unique index physically exists
+        before the rename, exercising the real rename-time DDL path rather
+        than racing CreateModel's deferred index-creation SQL.
+        """
+        model_name = 'TestStaleConstraintRename'
+        constraint_name = 'uq_stale_rename'
+
+        operations_a = [
+            migrations.CreateModel(
+                name=model_name,
+                fields=[
+                    ('id', models.AutoField(primary_key=True)),
+                    ('a', models.CharField(max_length=20)),
+                    ('b', models.CharField(max_length=20)),
+                ],
+                options={
+                    'constraints': [
+                        UniqueConstraint(
+                            fields=['b'],
+                            condition=models.Q(a__isnull=False),
+                            name=constraint_name,
+                        ),
+                    ],
+                },
+            ),
+        ]
+        operations_b = [
+            migrations.RenameField(
+                model_name=model_name.lower(), old_name='a', new_name='aa'
+            ),
+        ]
+        operations_c = [
+            migrations.RemoveConstraint(
+                model_name=model_name.lower(), name=constraint_name
+            ),
+        ]
+
+        result = self._run_migration_test(
+            operations_a=operations_a,
+            operations_b=operations_b,
+            operations_c=operations_c,
+            migration_name_prefix='test_stale_constraint_rename',
+            model_name=model_name,
+            use_single_migration=False,
+        )
+
+        self.assertNotIn(constraint_name, result.constraints)
+
 
 
 

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -3208,6 +3208,55 @@ class TestMetaIndexesRetained(TransactionTestCase):
             'migration.',
         )
 
+    def test_pk_alias_condition_survives_unrelated_alter(self):
+        """
+        A Meta.index condition may reference the 'pk' query alias (e.g.
+        Q(pk__gt=0)), which Options.get_field() does not recognize as a
+        literal field name. Altering the type of ANY field on the model
+        must not crash while resolving that index's reference names -
+        _delete_indexes() inspects every existing index on the model, not
+        just ones tied to the field being altered.
+        """
+        model_name = 'TestPkAliasCondition'
+        index_name = 'idx_pk_alias_condition'
+
+        operations_a = [
+            migrations.CreateModel(
+                name=model_name,
+                fields=[
+                    ('id', models.AutoField(primary_key=True)),
+                    ('a', models.CharField(max_length=20)),
+                ],
+            ),
+            migrations.AddIndex(
+                model_name=model_name.lower(),
+                index=models.Index(
+                    fields=['a'], condition=models.Q(pk__gt=0), name=index_name
+                ),
+            ),
+        ]
+        operations_b = [
+            migrations.AlterField(
+                model_name=model_name.lower(),
+                name='a',
+                field=models.CharField(max_length=40),
+            ),
+        ]
+
+        result = self._run_migration_test(
+            operations_a=operations_a,
+            operations_b=operations_b,
+            migration_name_prefix='test_pk_alias_condition',
+            model_name=model_name,
+            use_single_migration=True,
+        )
+
+        self._assert_named_index_columns(
+            result.constraints, index_name, ['a'],
+            "A Meta.index filtered on the 'pk' alias was lost (or crashed) "
+            "when an unrelated field's type was altered.",
+        )
+
 
 
 

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -14,6 +14,8 @@ from django.test import TestCase, TransactionTestCase
 from unittest import expectedFailure, skipIf
 from unittest.mock import patch
 
+from mssql.schema import _clone_index_with_replacements
+
 from . import get_constraints
 from ..models import (
     TestIndexesRetainedRenamed,
@@ -2184,6 +2186,78 @@ class TestMetaIndexesRetained(TransactionTestCase):
                 self.assertIn((True, 'c', filter_definition), catalog)
                 self.assertIn('[aa]', filter_definition)
 
+    def test_filtered_meta_index_survives_reconstructed_rename_state(self):
+        """
+        MigrationExecutor startup rebuilds applied-migration state without replaying
+        DDL, unlike the existing across-migration rename test.
+        """
+        class MigrationA(Migration):
+            initial = True
+            operations = [
+                migrations.CreateModel(
+                    name='TestFilteredIndexReconstructed',
+                    fields=[
+                        ('id', models.AutoField(primary_key=True)),
+                        ('a', models.CharField(max_length=20, null=True)),
+                        ('b', models.CharField(max_length=20)),
+                    ],
+                ),
+                migrations.AddIndex(
+                    model_name='testfilteredindexreconstructed',
+                    index=models.Index(
+                        fields=['b'],
+                        condition=models.Q(a__isnull=False),
+                        name='idx_filtered_reconstructed',
+                    ),
+                ),
+            ]
+
+        class MigrationB(Migration):
+            operations = [
+                migrations.RenameField(
+                    model_name='testfilteredindexreconstructed',
+                    old_name='a',
+                    new_name='aa',
+                ),
+            ]
+
+        class MigrationC(Migration):
+            operations = [
+                migrations.AlterField(
+                    model_name='testfilteredindexreconstructed',
+                    name='b',
+                    field=models.CharField(max_length=40),
+                ),
+            ]
+
+        migration_a = MigrationA('test_filtered_index_reconstructed_a', 'testapp')
+        migration_b = MigrationB('test_filtered_index_reconstructed_b', 'testapp')
+        migration_c = MigrationC('test_filtered_index_reconstructed_c', 'testapp')
+        conn = django.db.connections[django.db.DEFAULT_DB_ALIAS]
+
+        with conn.schema_editor(atomic=True) as editor:
+            applied_state = migration_a.apply(ProjectState(), editor)
+        with conn.schema_editor(atomic=True) as editor:
+            migration_b.apply(applied_state, editor)
+
+        # Deliberately bypass Migration.apply(), as MigrationExecutor does while
+        # rebuilding applied state through mutate_state().
+        rebuilt_state = migration_a.mutate_state(ProjectState())
+        rebuilt_state = migration_b.mutate_state(rebuilt_state)
+        with conn.schema_editor(atomic=True) as editor:
+            project_state = migration_c.apply(rebuilt_state, editor)
+
+        model = project_state.apps.get_model('testapp', 'TestFilteredIndexReconstructed')
+        constraints = get_constraints(table_name=model._meta.db_table)
+        self._assert_named_index_columns(
+            constraints,
+            'idx_filtered_reconstructed',
+            ['b'],
+            'A reconstructed filtered Meta.index was not restored after a rename.',
+        )
+        catalog = self._get_index_catalog(model, 'idx_filtered_reconstructed')
+        self.assertIn('[aa]', catalog[0][2])
+
     def test_filtered_meta_index_retained_after_logical_rename(self):
         for use_single_migration in [False, True]:
             with self.subTest(single_migration=use_single_migration):
@@ -2432,7 +2506,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
                                 editor._get_condition_field_names(index.condition), ['aa', 'bb']
                             )
                             editor.execute(
-                                editor._clone_index_with_replacements(index, {}).create_sql(
+                                _clone_index_with_replacements(index, {}).create_sql(
                                     model, editor
                                 )
                             )
@@ -2468,7 +2542,7 @@ class TestMetaIndexesRetained(TransactionTestCase):
                                 editor._get_condition_field_names(index.condition), ['aa', 'bb']
                             )
                             editor.execute(
-                                editor._clone_index_with_replacements(index, {}).create_sql(
+                                _clone_index_with_replacements(index, {}).create_sql(
                                     model, editor
                                 )
                             )

--- a/testapp/tests/test_indexes.py
+++ b/testapp/tests/test_indexes.py
@@ -277,6 +277,27 @@ class TestMetaIndexesRetained(TransactionTestCase):
     def _get_context_description(self, use_single_migration: bool) -> str:
         return "combined single migration" if use_single_migration else "split into 2 migrations"
 
+    def _assert_named_index_columns(self, constraints, index_name, expected_columns, error_msg):
+        self.assertIn(index_name, constraints, error_msg)
+        self.assertEqual(constraints[index_name]['columns'], expected_columns, error_msg)
+
+    def _get_index_catalog(self, model, index_name):
+        with django.db.connections[django.db.DEFAULT_DB_ALIAS].cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT ic.is_included_column, c.name, i.filter_definition
+                FROM sys.indexes AS i
+                INNER JOIN sys.index_columns AS ic
+                    ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+                INNER JOIN sys.columns AS c
+                    ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+                WHERE i.object_id = OBJECT_ID(%s) AND i.name = %s
+                ORDER BY ic.key_ordinal, ic.index_column_id
+                """,
+                [model._meta.db_table, index_name],
+            )
+            return cursor.fetchall()
+
     def test_index_from_meta_indexes_retained_after_type_change(self):
         """
         Test that indexes defined in Meta.indexes are retained when altering field type (max_length change).
@@ -1712,6 +1733,212 @@ class TestMetaIndexesRetained(TransactionTestCase):
                         f"({self._get_context_description(use_single_migration)}). "
                         f"Expected index_together to be restored for field without db_index=True."
                     ),
+                )
+    def test_stale_meta_index_not_retargeted_by_autofield_change(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestStaleIndexAuto{suffix}'
+                index_name = f'idx_stale_auto{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a'], name=index_name),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='id',
+                            field=models.BigAutoField(primary_key=True),
+                        ),
+                    ],
+                    migration_name_prefix='test_stale_index_auto',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self._assert_named_index_columns(
+                    result.constraints,
+                    index_name,
+                    ['aa'],
+                    'A stale Meta.indexes field was retargeted during an AutoField change.',
+                )
+
+    def test_removed_meta_index_not_retargeted_by_unrelated_alter(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestRemovedIndex{suffix}'
+                index_name = f'idx_removed{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a'], name=index_name),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RemoveField(model_name=model_name.lower(), name='a'),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_removed_index',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self.assertNotIn(
+                    index_name,
+                    result.constraints,
+                    'A removed Meta.indexes definition was recreated on an unrelated field.',
+                )
+
+    def test_meta_index_restored_after_multiple_renames(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestMultipleRenames{suffix}'
+                index_name = f'idx_multiple_renames{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['a', 'b'], name=index_name),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='b', new_name='bb'
+                        ),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='aa',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_multiple_renames',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self._assert_named_index_columns(
+                    result.constraints,
+                    index_name,
+                    ['aa', 'bb'],
+                    'A composite Meta.indexes definition was not restored after multiple renames.',
+                )
+
+    def test_filtered_meta_index_retained_after_rename_and_alter(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestFilteredIndex{suffix}'
+                index_name = f'idx_filtered{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20, null=True)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(
+                                fields=['b'],
+                                condition=models.Q(a__isnull=False),
+                                name=index_name,
+                            ),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='b',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_filtered_index',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                catalog = self._get_index_catalog(result.model, index_name)
+                self.assertIn('[aa]', catalog[0][2])
+
+    def test_covering_meta_index_retained_after_rename_and_alter(self):
+        for use_single_migration in [False, True]:
+            with self.subTest(single_migration=use_single_migration):
+                suffix = '_combined' if use_single_migration else '_split'
+                model_name = f'TestCoveringIndex{suffix}'
+                index_name = f'idx_covering{suffix}'
+                result = self._run_migration_test(
+                    operations_a=[
+                        migrations.CreateModel(
+                            name=model_name,
+                            fields=[
+                                ('id', models.AutoField(primary_key=True)),
+                                ('a', models.CharField(max_length=20)),
+                                ('b', models.CharField(max_length=20)),
+                            ],
+                        ),
+                        migrations.AddIndex(
+                            model_name=model_name.lower(),
+                            index=models.Index(fields=['b'], include=['a'], name=index_name),
+                        ),
+                    ],
+                    operations_b=[
+                        migrations.RenameField(
+                            model_name=model_name.lower(), old_name='a', new_name='aa'
+                        ),
+                        migrations.AlterField(
+                            model_name=model_name.lower(),
+                            name='aa',
+                            field=models.CharField(max_length=40),
+                        ),
+                    ],
+                    migration_name_prefix='test_covering_index',
+                    model_name=model_name,
+                    use_single_migration=use_single_migration,
+                )
+                self.assertEqual(
+                    self._get_index_catalog(result.model, index_name),
+                    [(False, 'b', None), (True, 'aa', None)],
                 )
 
     @expectedFailure


### PR DESCRIPTION
Fixes #499.
Fixes #619.

A migration that renames a field and then changes its type or nullability could permanently drop a `Meta.indexes` index or raise `FieldDoesNotExist`. Django updates the model field during `RenameField`, but structured index metadata can retain the old field name; the SQL Server schema editor then sees migration state that no longer matches the physical index.

This PR now addresses the full rename-sensitive structured-index path uncovered during review. It keeps `Meta.indexes` and `Meta.constraints` `UniqueConstraint` references aligned across migration state, deferred SQL, schema-editor drop/recreate operations, and optimizer-folded `CreateModel` operations.

The initial change addressed the two rename-plus-alter regressions in #499. Review correctly identified that resolving every unknown field name to the field currently being altered was unsafe: removed fields, reused names, multiple renames, filtered conditions, and covering indexes could otherwise fail or silently move an index to the wrong column.

Addressing those findings required preserving structured field references through migration state and deferred SQL rather than guessing from `FieldDoesNotExist`. The same machinery is used by conditional and covering `UniqueConstraint` definitions, particularly when a rename is reconstructed from migration state or folded into `CreateModel`. Review of that deferred constraint path then exposed inconsistent handling of unsupported OR/negated predicates between `AddConstraint` and `CreateModel`.

The constraint changes are therefore included deliberately. They share the state-rewrite, condition-rewrite, deferred-rendering, and drop/recreate paths needed for #499; splitting them now would require duplicating or temporarily undoing that shared machinery and would leave the optimizer/deferred cases divided across interdependent PRs. Issue #619 records the expanded behavior and acceptance criteria explicitly.

## Changes

### Preserve structured migration state

- Rewrite renamed field references in `Meta.indexes` and `Meta.constraints` `UniqueConstraint` definitions.
- Cover `ProjectState.rename_field()`, the Django 3.2 `RenameField.state_forwards()` path, and `CreateModel.reduce()` when migration optimization absorbs a rename.
- Clone definitions instead of mutating preserved historical state.

### Reconcile and restore indexes safely

- Match stale `Meta.indexes` key and `include` entries to the existing named physical index instead of mapping every unresolved name to `new_field`.
- Fetch table index metadata in one catalog query and preserve explicit names, ordering, conditions, expressions, included columns, and other index options when rebuilding.
- Track indexes actually dropped by the current alteration, so removed indexes are not retargeted and indexes still queued in `deferred_sql` are not created twice.
- Handle multiple renames, reused field names, removed fields, combined column rename/type changes, and unbound replacement fields.

### Keep filtered definitions structured

- Rewrite field references inside copied `Q`/expression trees, including nested and transformed `F()` references and tuple/list RHS values, without changing string literals.
- Resolve `pk` aliases and `ForeignKey` attnames when deciding whether a filtered index or constraint depends on the renamed field.
- Keep deferred filtered-index and conditional-unique predicates structured until SQL rendering so later renames update identifiers safely.

### Preserve `UniqueConstraint` semantics

- Rebuild affected `Meta.constraints` `UniqueConstraint` objects through their structured definitions, preserving conditions and key-versus-`INCLUDE` semantics for covering constraints.
- Defer conditional constraints declared through `CreateModel` through the same structured predicate path used by later renames.
- Apply the backend's existing predicate limitation consistently to `AddConstraint` and `CreateModel`: nested OR and negated conditions raise `NotImplementedError` instead of reaching SQL Server as invalid filtered-index SQL.

### Restore indexes dropped by AutoField changes

For AutoField/BigAutoField column-renaming paths, SQL Server requires all indexes on the table to be dropped. Restore the dropped `db_index`, `index_together` (Django < 5.1), `unique_together`, `Meta.indexes`, and `Meta.constraints` `UniqueConstraint` definitions while avoiding deferred-create collisions.

## Testing

Regression coverage in `testapp/tests/test_indexes.py` and `testapp/tests/test_constraints.py` includes:

- rename plus type or nullability change, in split and combined migrations;
- removed/reused names and multiple renames;
- filtered, expression, covering, deferred, and condition-only indexes;
- migration-state reconstruction and optimizer-folded `CreateModel`;
- `pk` aliases and `ForeignKey` attname references;
- conditional and covering `UniqueConstraint` rename behavior;
- consistent rejection of top-level/nested OR and negated unique conditions;
- AutoField/BigAutoField index restoration across the supported index/constraint categories; and
- Django-version-specific state and `index_together` paths.

The separate pre-existing AutoField restoration gap for an unrelated `null=True, unique=True` field-level index is not fixed by this PR; that index is created by the nullable-unique field path and has `db_index=False`.