### PR TITLE
CHORE: pin coverage publish to py314-django61

### DIFF
--- a/azure-pipelines-steps-linux.yml
+++ b/azure-pipelines-steps-linux.yml
@@ -141,9 +141,9 @@ steps:
     # Every Linux leg produces a django/coverage.xml and, without a guard,
     # they all publish to the same artifact path so the posted number is a
     # nondeterministic upload race across the matrix. Pin publishing to the
-    # newest supported stack (Python 3.14 / Django 6.0) so the number is
+    # newest supported stack (Python 3.14 / Django 6.1) so the number is
     # deterministic and reflects the most backend code paths exercised.
-    condition: and(succeeded(), eq(variables['tox.env'], 'py314-django60'))
+    condition: and(succeeded(), eq(variables['tox.env'], 'py314-django61'))
     inputs:
       codeCoverageTool: 'Cobertura'
       summaryFileLocation: 'django/coverage.xml'


### PR DESCRIPTION
Django 6.1 is now the newest supported stack (shipped in 1.8.0, matrix has py314-django61 on Linux_Core). Move the coverage-publishing pin from py314-django60 to py314-django61 so the posted number tracks the newest backend code paths.

still a single deterministic Linux leg, so no upload race across the matrix. 6.1 exercises the same or more mssql backend lines than 6.0, so the number won't drop.

one line (plus the comment). no product code.
