### PR TITLE
FEAT: support database cloning for parallel tests (closes #342)

### DIFF
--- a/.devcontainer/scripts/run-tests.sh
+++ b/.devcontainer/scripts/run-tests.sh
@@ -29,7 +29,7 @@ case "${1:-}" in
             git checkout "${DJANGO_VERSION}" 2>/dev/null || true
         fi
         pip install -q -r tests/requirements/py3.txt 2>/dev/null || true
-        coverage run tests/runtests.py --settings=testapp.settings --noinput "${MODULE}"
+        coverage run tests/runtests.py --settings=testapp.settings --noinput --parallel 1 "${MODULE}"
         coverage report --include='*mssql*' --omit='*virtualenvs*'
         coverage xml --include='*mssql*' --omit='*virtualenvs*' -o coverage.xml
         echo "Coverage report written to coverage.xml"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,7 +115,7 @@ python manage.py test testapp.tests
 
 ### Run specific Django test module
 ```bash
-cd django && python tests/runtests.py --settings=testapp.settings <module>
+cd django && python tests/runtests.py --settings=testapp.settings --parallel 1 <module>
 ```
 
 ### Common test modules for validation
@@ -143,7 +143,7 @@ Add test to `EXCLUDED_TESTS` - this is a SQL Server limitation, not a bug.
 ### Tests hanging on database creation
 The test database may already exist. Answer "yes" to drop it, or use:
 ```bash
-echo "yes" | python tests/runtests.py --settings=testapp.settings <module>
+echo "yes" | python tests/runtests.py --settings=testapp.settings --parallel 1 <module>
 ```
 
 ## Pull Request Guidelines

--- a/.github/prompts/mssql-django-dev-environment-setup.prompt.md
+++ b/.github/prompts/mssql-django-dev-environment-setup.prompt.md
@@ -113,7 +113,7 @@ python manage.py test --noinput
 bash test.sh
 
 # Run specific Django test module
-cd django && python tests/runtests.py --settings=testapp.settings composite_pk
+cd django && python tests/runtests.py --settings=testapp.settings --parallel 1 composite_pk
 
 # Check Python syntax
 python -m py_compile mssql/compiler.py

--- a/.github/prompts/mssql-django-pr-self-check-gate.prompt.md
+++ b/.github/prompts/mssql-django-pr-self-check-gate.prompt.md
@@ -93,7 +93,7 @@ python manage.py test testapp.tests.test_jsonfield --verbosity 2
 
 # Upstream targeted test(s)
 cd django
-PYTHONPATH=/workspaces/mssql-django/django python tests/runtests.py --settings=testapp.settings <module.or.test>
+PYTHONPATH=/workspaces/mssql-django/django python tests/runtests.py --settings=testapp.settings --parallel 1 <module.or.test>
 
 # HOT matrix / CI guard
 # Run or verify the HOT matrix / CI guard workflow for this branch in your CI system

--- a/.github/prompts/mssql-django-run-django-test-suite.prompt.md
+++ b/.github/prompts/mssql-django-run-django-test-suite.prompt.md
@@ -121,7 +121,7 @@ git checkout $DJANGO_VERSION
 pip install -r tests/requirements/py3.txt
 
 # Run tests
-coverage run tests/runtests.py --settings=testapp.settings --noinput \
+coverage run tests/runtests.py --settings=testapp.settings --noinput --parallel 1 \
     aggregation \
     annotations \
     basic \
@@ -134,14 +134,14 @@ coverage run tests/runtests.py --settings=testapp.settings --noinput \
 
 ```bash
 cd /workspaces/mssql-django/django
-python tests/runtests.py --settings=testapp.settings --noinput composite_pk
+python tests/runtests.py --settings=testapp.settings --noinput --parallel 1 composite_pk
 ```
 
 ### Run Specific Test
 
 ```bash
 cd /workspaces/mssql-django/django
-python tests/runtests.py --settings=testapp.settings --noinput \
+python tests/runtests.py --settings=testapp.settings --noinput --parallel 1 \
     composite_pk.test_filter.CompositePKFilterTests.test_explicit_subquery
 ```
 

--- a/mssql/creation.py
+++ b/mssql/creation.py
@@ -84,6 +84,126 @@ class DatabaseCreation(BaseDatabaseCreation):
             cursor.execute("DROP DATABASE %s"
                            % self.connection.ops.quote_name(test_database_name))
 
+    def _clone_test_db(self, suffix, verbosity, keepdb=False):
+        """
+        Clone the already-created test database so Django can run tests with
+        the --parallel flag (one clone per worker process).
+
+        SQL Server has no CREATE DATABASE ... TEMPLATE, so the clone is made
+        with a server-side BACKUP of the source test database followed by a
+        RESTORE ... WITH MOVE into a new database. This copies both schema and
+        data, matching what Django expects from a cloned test database.
+
+        The source is identical for every clone, so it is backed up once and
+        that single backup is restored for each worker.
+        """
+        if self.connection.to_azure_sql_db:
+            raise NotImplementedError(
+                "Cloning test databases is not supported on Azure SQL Database, "
+                "which does not allow BACKUP/RESTORE to disk. Run tests without "
+                "the --parallel flag."
+            )
+
+        source_database_name = self.connection.settings_dict['NAME']
+        target_database_name = self.get_test_db_clone_settings(suffix)['NAME']
+        quote_name = self.connection.ops.quote_name
+
+        with self.cursor() as cursor:
+            if keepdb and self._database_exists(cursor, target_database_name):
+                return
+            self._drop_database_if_exists(cursor, target_database_name)
+
+            # Resolve the instance default data/log directories so the restored
+            # files land somewhere the server can write, regardless of platform.
+            cursor.execute(
+                "SELECT CAST(SERVERPROPERTY('InstanceDefaultDataPath') AS nvarchar(4000)), "
+                "CAST(SERVERPROPERTY('InstanceDefaultLogPath') AS nvarchar(4000))"
+            )
+            data_path, log_path = cursor.fetchone()
+
+            backup_path, logical_files = self._backup_source_once(
+                cursor, source_database_name, data_path)
+
+            # A RESTORE onto the same instance must relocate every logical file
+            # to a new physical path, so build MOVE clauses from the source's
+            # logical file list.
+            move_clauses = []
+            for logical_name, file_type in logical_files:
+                extension = {0: '.mdf', 1: '.ldf'}.get(file_type, '.ndf')
+                directory = log_path if file_type == 1 else data_path
+                physical_path = '%s%s_%s%s' % (
+                    directory, target_database_name, logical_name, extension)
+                move_clauses.append('MOVE %s TO %s' % (
+                    self._quote_literal(logical_name),
+                    self._quote_literal(physical_path),
+                ))
+
+            cursor.execute(
+                "RESTORE DATABASE %s FROM DISK = %s WITH %s, RECOVERY, REPLACE" % (
+                    quote_name(target_database_name),
+                    self._quote_literal(backup_path),
+                    ', '.join(move_clauses),
+                )
+            )
+            self._drain(cursor)
+
+    def _backup_source_once(self, cursor, source_database_name, data_path):
+        """Back up the source test database a single time and cache the result.
+
+        Returns (backup_path, logical_files) where logical_files is a list of
+        (logical_name, file_type) tuples. All clones of the same source restore
+        from this one backup instead of re-dumping it per worker.
+        """
+        cache = getattr(self, '_clone_backup_cache', None)
+        if cache and cache[0] == source_database_name:
+            return cache[1], cache[2]
+
+        backup_path = '%s%s_clone_source.bak' % (data_path, source_database_name)
+        cursor.execute(
+            "BACKUP DATABASE %s TO DISK = %s WITH INIT, COPY_ONLY" % (
+                self.connection.ops.quote_name(source_database_name),
+                self._quote_literal(backup_path),
+            )
+        )
+        self._drain(cursor)
+
+        cursor.execute(
+            "SELECT name, type FROM sys.master_files WHERE database_id = DB_ID(%s)",
+            [source_database_name],
+        )
+        logical_files = cursor.fetchall()
+        self._clone_backup_cache = (source_database_name, backup_path, logical_files)
+        return backup_path, logical_files
+
+    @staticmethod
+    def _quote_literal(value):
+        """Quote a string as a T-SQL literal (BACKUP/RESTORE reject parameters)."""
+        return "N'%s'" % value.replace("'", "''")
+
+    @staticmethod
+    def _drain(cursor):
+        """Consume the informational result sets BACKUP/RESTORE emit.
+
+        Without this the connection is still finishing the restore when the next
+        statement runs, which raises 'database is in the middle of a restore'.
+        """
+        while cursor.nextset():
+            pass
+
+    def _database_exists(self, cursor, database_name):
+        cursor.execute(
+            "SELECT 1 FROM sys.databases WHERE name = %s", [database_name])
+        return cursor.fetchone() is not None
+
+    def _drop_database_if_exists(self, cursor, database_name):
+        if not self._database_exists(cursor, database_name):
+            return
+        quoted = self.connection.ops.quote_name(database_name)
+        if not self.connection.to_azure_sql_db:
+            cursor.execute(
+                "ALTER DATABASE %s SET SINGLE_USER WITH ROLLBACK IMMEDIATE" % quoted)
+        cursor.execute("DROP DATABASE %s" % quoted)
+
     def sql_table_creation_suffix(self):
         suffix = []
         collation = self.connection.settings_dict['TEST'].get('COLLATION', None)

--- a/mssql/creation.py
+++ b/mssql/creation.py
@@ -113,29 +113,22 @@ class DatabaseCreation(BaseDatabaseCreation):
                 return target_database_name
             self._drop_database_if_exists(cursor, target_database_name)
 
-            # Resolve the instance default data/log directories so the restored
-            # files land somewhere the server can write, regardless of platform.
-            cursor.execute(
-                "SELECT CAST(SERVERPROPERTY('InstanceDefaultDataPath') AS nvarchar(4000)), "
-                "CAST(SERVERPROPERTY('InstanceDefaultLogPath') AS nvarchar(4000))"
-            )
-            data_path, log_path = cursor.fetchone()
-
             backup_path, logical_files = self._backup_source_once(
-                cursor, source_database_name, data_path)
+                cursor, source_database_name)
 
             # A RESTORE onto the same instance must relocate every logical file
-            # to a new physical path, so build MOVE clauses from the source's
-            # logical file list.
+            # to a new physical path. Put each clone file in the same directory
+            # as its source file, which is guaranteed to exist and be writable
+            # by the server (no dependency on SERVERPROPERTY default paths).
             move_clauses = []
-            for logical_name, file_type in logical_files:
+            for logical_name, file_type, physical_name in logical_files:
                 extension = {0: '.mdf', 1: '.ldf'}.get(file_type, '.ndf')
-                directory = log_path if file_type == 1 else data_path
-                physical_path = '%s%s_%s%s' % (
+                directory = self._directory_of(physical_name)
+                target_physical = '%s%s_%s%s' % (
                     directory, target_database_name, logical_name, extension)
                 move_clauses.append('MOVE %s TO %s' % (
                     self._quote_literal(logical_name),
-                    self._quote_literal(physical_path),
+                    self._quote_literal(target_physical),
                 ))
 
             cursor.execute(
@@ -149,18 +142,32 @@ class DatabaseCreation(BaseDatabaseCreation):
 
         return target_database_name
 
-    def _backup_source_once(self, cursor, source_database_name, data_path):
+    def _backup_source_once(self, cursor, source_database_name):
         """Back up the source test database a single time and cache the result.
 
         Returns (backup_path, logical_files) where logical_files is a list of
-        (logical_name, file_type) tuples. All clones of the same source restore
-        from this one backup instead of re-dumping it per worker.
+        (logical_name, file_type, physical_name) tuples. All clones of the same
+        source restore from this one backup instead of re-dumping it per worker.
         """
         cache = getattr(self, '_clone_backup_cache', None)
         if cache and cache[0] == source_database_name:
             return cache[1], cache[2]
 
-        backup_path = '%s%s_clone_source.bak' % (data_path, source_database_name)
+        cursor.execute(
+            "SELECT name, type, physical_name FROM sys.master_files "
+            "WHERE database_id = DB_ID(%s)",
+            [source_database_name],
+        )
+        logical_files = cursor.fetchall()
+
+        # Write the backup next to a source data file (a directory the server
+        # can definitely write to).
+        data_file = next(
+            (pn for _, ftype, pn in logical_files if ftype == 0),
+            logical_files[0][2],
+        )
+        backup_path = '%s%s_clone_source.bak' % (
+            self._directory_of(data_file), source_database_name)
         cursor.execute(
             "BACKUP DATABASE %s TO DISK = %s WITH INIT, COPY_ONLY" % (
                 self.connection.ops.quote_name(source_database_name),
@@ -168,12 +175,6 @@ class DatabaseCreation(BaseDatabaseCreation):
             )
         )
         self._drain(cursor)
-
-        cursor.execute(
-            "SELECT name, type FROM sys.master_files WHERE database_id = DB_ID(%s)",
-            [source_database_name],
-        )
-        logical_files = cursor.fetchall()
         self._clone_backup_cache = (source_database_name, backup_path, logical_files)
         return backup_path, logical_files
 
@@ -181,6 +182,13 @@ class DatabaseCreation(BaseDatabaseCreation):
     def _quote_literal(value):
         """Quote a string as a T-SQL literal (BACKUP/RESTORE reject parameters)."""
         return "N'%s'" % value.replace("'", "''")
+
+    @staticmethod
+    def _directory_of(physical_name):
+        """Return the directory portion (with trailing separator) of a SQL
+        Server physical file path, handling both Windows and POSIX separators."""
+        separator = '\\' if '\\' in physical_name else '/'
+        return physical_name.rsplit(separator, 1)[0] + separator
 
     @staticmethod
     def _drain(cursor):

--- a/mssql/creation.py
+++ b/mssql/creation.py
@@ -22,6 +22,9 @@ class DatabaseCreation(BaseDatabaseCreation):
         Internal implementation - create the test db tables.
         """
 
+        # A fresh source means any cached clone backup is stale.
+        self._clone_backup_cache = None
+
         # Try to create the test DB, but if we fail due to 28000 (Login failed for user),
         #   it's probably because the user doesn't have permission to [dbo].[master],
         #   so we can proceed if we're keeping the DB anyway.
@@ -83,6 +86,12 @@ class DatabaseCreation(BaseDatabaseCreation):
                                % self.connection.ops.quote_name(test_database_name))
             cursor.execute("DROP DATABASE %s"
                            % self.connection.ops.quote_name(test_database_name))
+            # If this was the source of a clone backup, remove the backup file
+            # and drop the cache so it is not reused for a later database.
+            cache = getattr(self, '_clone_backup_cache', None)
+            if cache and cache[0] == test_database_name:
+                self._delete_backup_file(cursor, cache[1])
+                self._clone_backup_cache = None
 
     def _clone_test_db(self, suffix, verbosity, keepdb=False):
         """
@@ -99,9 +108,10 @@ class DatabaseCreation(BaseDatabaseCreation):
         """
         if self.connection.to_azure_sql_db:
             raise NotImplementedError(
-                "Cloning test databases is not supported on Azure SQL Database, "
-                "which does not allow BACKUP/RESTORE to disk. Run tests without "
-                "the --parallel flag."
+                "Cloning test databases is not supported on the Azure SQL "
+                "family (Database, Managed Instance, Fabric), which does not "
+                "allow BACKUP/RESTORE to disk. Run tests without the --parallel "
+                "flag."
             )
 
         source_database_name = self.connection.settings_dict['NAME']
@@ -131,8 +141,11 @@ class DatabaseCreation(BaseDatabaseCreation):
                     self._quote_literal(target_physical),
                 ))
 
+            # The target was just dropped and each file is restored to a path
+            # named after the target database, so RESTORE does not need (and
+            # should not use) WITH REPLACE, which would bypass safety checks.
             cursor.execute(
-                "RESTORE DATABASE %s FROM DISK = %s WITH %s, RECOVERY, REPLACE" % (
+                "RESTORE DATABASE %s FROM DISK = %s WITH %s, RECOVERY" % (
                     quote_name(target_database_name),
                     self._quote_literal(backup_path),
                     ', '.join(move_clauses),
@@ -189,6 +202,21 @@ class DatabaseCreation(BaseDatabaseCreation):
         Server physical file path, handling both Windows and POSIX separators."""
         separator = '\\' if '\\' in physical_name else '/'
         return physical_name.rsplit(separator, 1)[0] + separator
+
+    def _delete_backup_file(self, cursor, backup_path):
+        """Best-effort removal of the server-side clone backup file.
+
+        DROP DATABASE removes a database's data/log files but not a backup, so
+        the clone backup would otherwise linger. xp_delete_files is used where
+        available; failures (e.g. older servers, permissions) are ignored since
+        the file is harmless and overwritten on the next run.
+        """
+        try:
+            cursor.execute(
+                "EXEC master.sys.xp_delete_files %s" % self._quote_literal(backup_path))
+            self._drain(cursor)
+        except Exception:
+            pass
 
     @staticmethod
     def _drain(cursor):

--- a/mssql/creation.py
+++ b/mssql/creation.py
@@ -110,7 +110,7 @@ class DatabaseCreation(BaseDatabaseCreation):
 
         with self.cursor() as cursor:
             if keepdb and self._database_exists(cursor, target_database_name):
-                return
+                return target_database_name
             self._drop_database_if_exists(cursor, target_database_name)
 
             # Resolve the instance default data/log directories so the restored
@@ -146,6 +146,8 @@ class DatabaseCreation(BaseDatabaseCreation):
                 )
             )
             self._drain(cursor)
+
+        return target_database_name
 
     def _backup_source_once(self, cursor, source_database_name, data_path):
         """Back up the source test database a single time and cache the result.

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -28,6 +28,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_return_columns_from_insert = True
     can_return_id_from_insert = True
     can_return_rows_from_bulk_insert = False
+    can_clone_databases = True
     can_rollback_ddl = True
     can_use_chunked_reads = False
     for_update_after_from = True

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -28,7 +28,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_return_columns_from_insert = True
     can_return_id_from_insert = True
     can_return_rows_from_bulk_insert = False
-    can_clone_databases = True
     can_rollback_ddl = True
     can_use_chunked_reads = False
     for_update_after_from = True
@@ -88,6 +87,13 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         supports_tuple_lookups = False
         if django_version >= (5, 2, 4):
             supports_tuple_comparison_against_subquery = False
+    @cached_property
+    def can_clone_databases(self):
+        # Cloning uses server-side BACKUP/RESTORE to disk, which Azure SQL
+        # Database does not allow, so only advertise the capability for a
+        # regular SQL Server instance.
+        return not self.connection.to_azure_sql_db
+
     @cached_property
     def has_zoneinfo_database(self):
         with self.connection.cursor() as cursor:

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -28,7 +28,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_return_columns_from_insert = True
     can_return_id_from_insert = True
     can_return_rows_from_bulk_insert = False
-    can_clone_databases = True
     can_rollback_ddl = True
     can_use_chunked_reads = False
     for_update_after_from = True
@@ -88,6 +87,20 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         supports_tuple_lookups = False
         if django_version >= (5, 2, 4):
             supports_tuple_comparison_against_subquery = False
+    @cached_property
+    def can_clone_databases(self):
+        # Cloning uses server-side BACKUP/RESTORE to disk, which the Azure SQL
+        # family (Database, Managed Instance, Fabric) does not allow. Detect the
+        # engine edition through a master-scoped connection: master exists even
+        # before the test database is created, so Django's runtests.py can
+        # evaluate this on a fresh server without connecting to the not-yet-
+        # created application database.
+        from mssql.base import _AZURE_EDITIONS
+        with self.connection._nodb_cursor() as cursor:
+            cursor.execute("SELECT CAST(SERVERPROPERTY('EngineEdition') AS integer)")
+            edition = cursor.fetchone()[0]
+        return edition not in _AZURE_EDITIONS
+
     @cached_property
     def has_zoneinfo_database(self):
         with self.connection.cursor() as cursor:

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -28,6 +28,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_return_columns_from_insert = True
     can_return_id_from_insert = True
     can_return_rows_from_bulk_insert = False
+    can_clone_databases = True
     can_rollback_ddl = True
     can_use_chunked_reads = False
     for_update_after_from = True
@@ -87,13 +88,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         supports_tuple_lookups = False
         if django_version >= (5, 2, 4):
             supports_tuple_comparison_against_subquery = False
-    @cached_property
-    def can_clone_databases(self):
-        # Cloning uses server-side BACKUP/RESTORE to disk, which Azure SQL
-        # Database does not allow, so only advertise the capability for a
-        # regular SQL Server instance.
-        return not self.connection.to_azure_sql_db
-
     @cached_property
     def has_zoneinfo_database(self):
         with self.connection.cursor() as cursor:

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,11 @@ if python -c "import django; exit(0 if django.VERSION >= (5, 2) else 1)"; then
     COMPOSITE_PK_TESTS="composite_pk"
 fi
 
-PYTHONPATH=.. coverage run --parallel-mode tests/runtests.py --settings=testapp.settings --noinput \
+# Force --parallel 1: enabling database cloning (for the --parallel feature)
+# makes runtests.py default to one process per core, but this suite's custom
+# runner (expected-failure masking + xmlrunner) does not support parallel
+# workers yet. Keep the suite serial until that runner is reworked.
+PYTHONPATH=.. coverage run --parallel-mode tests/runtests.py --settings=testapp.settings --noinput --parallel 1 \
     aggregation \
     aggregation_regress \
     annotations \

--- a/testapp/settings_parallel.py
+++ b/testapp/settings_parallel.py
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the BSD license.
+
+# Settings for the parallel-cloning smoke test: identical to testapp.settings
+# but using Django's stock DiscoverRunner instead of the project's custom
+# XML/expected-failure runner, which does not support parallel workers. Driven
+# by testapp.tests.test_creation_cloning.DatabaseCloningTests.
+from testapp.settings import *  # noqa: F401,F403
+
+TEST_RUNNER = "django.test.runner.DiscoverRunner"

--- a/testapp/tests/test_creation_cloning.py
+++ b/testapp/tests/test_creation_cloning.py
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the BSD license.
 
+import os
+import subprocess
+import sys
+
 from django.db import connection
 from django.test import TransactionTestCase, skipUnlessDBFeature
 
@@ -17,19 +21,22 @@ class DatabaseCloningTests(TransactionTestCase):
     available_apps = ['testapp']
 
     def test_feature_flag_enabled(self):
-        # Cloning is advertised for SQL Server. The Azure SQL Database case
-        # (no BACKUP/RESTORE to disk) is handled in _clone_test_db, which
-        # raises NotImplementedError there.
-        self.assertTrue(connection.features.can_clone_databases)
+        # Detection is via the master-scoped engine edition, so it is accurate
+        # (False on the Azure SQL family) without connecting to the application
+        # database.
+        self.assertEqual(
+            connection.features.can_clone_databases,
+            not connection.to_azure_sql_db,
+        )
 
     @skipUnlessDBFeature('can_clone_databases')
     def test_clone_is_a_working_copy(self):
         creation = connection.creation
         suffix = 'clonetest'
         clone_name = creation.get_test_db_clone_settings(suffix)['NAME']
-
-        returned_name = creation._clone_test_db(suffix, verbosity=0)
+        quoted_clone = connection.ops.quote_name(clone_name)
         try:
+            returned_name = creation._clone_test_db(suffix, verbosity=0)
             self.assertEqual(returned_name, clone_name)
             with connection._nodb_cursor() as cursor:
                 cursor.execute(
@@ -37,13 +44,16 @@ class DatabaseCloningTests(TransactionTestCase):
                 self.assertIsNotNone(
                     cursor.fetchone(), 'clone database was not created')
 
-                # The schema is copied, so the testapp tables exist in the clone.
+                # Schema is copied: the testapp tables exist in the clone.
                 cursor.execute(
                     "SELECT COUNT(*) FROM %s.sys.tables WHERE name = %%s"
-                    % connection.ops.quote_name(clone_name),
-                    ['testapp_author'],
-                )
+                    % quoted_clone, ['testapp_author'])
                 self.assertEqual(cursor.fetchone()[0], 1)
+
+                # Data is copied too: the applied-migration rows come across.
+                cursor.execute(
+                    "SELECT COUNT(*) FROM %s.dbo.django_migrations" % quoted_clone)
+                self.assertGreater(cursor.fetchone()[0], 0)
         finally:
             with connection._nodb_cursor() as cursor:
                 creation._drop_database_if_exists(cursor, clone_name)
@@ -54,9 +64,9 @@ class DatabaseCloningTests(TransactionTestCase):
         suffix = 'clonekeep'
         clone_name = creation.get_test_db_clone_settings(suffix)['NAME']
         quoted_clone = connection.ops.quote_name(clone_name)
-
-        creation._clone_test_db(suffix, verbosity=0)
         try:
+            creation._clone_test_db(suffix, verbosity=0)
+
             # Write a marker that exists only in the clone (the source backup
             # has no such table), so a genuine keepdb no-op can be told apart
             # from a silent drop-and-restore.
@@ -71,12 +81,39 @@ class DatabaseCloningTests(TransactionTestCase):
             with connection._nodb_cursor() as cursor:
                 cursor.execute(
                     "SELECT COUNT(*) FROM %s.sys.tables WHERE name = %%s"
-                    % quoted_clone,
-                    ['keepdb_marker'],
-                )
+                    % quoted_clone, ['keepdb_marker'])
                 self.assertEqual(
                     cursor.fetchone()[0], 1,
                     'keepdb=True should reuse the clone, not recreate it')
         finally:
             with connection._nodb_cursor() as cursor:
                 creation._drop_database_if_exists(cursor, clone_name)
+
+    @skipUnlessDBFeature('can_clone_databases')
+    def test_parallel_run_end_to_end(self):
+        """Drive a real two-worker run with Django's stock DiscoverRunner.
+
+        This exercises the whole lifecycle the project's own custom runner
+        cannot: setup_databases creates the test DB, clones it per worker, the
+        workers connect to their clone, run, and everything is torn down. Runs
+        in a subprocess with isolated database names so it does not collide with
+        the outer test run's databases.
+        """
+        repo_root = os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        env = dict(
+            os.environ,
+            MSSQL_DB_NAME='parallel_clone_smoke',
+            MSSQL_DB_NAME_OTHER='parallel_clone_smoke_other',
+        )
+        result = subprocess.run(
+            [sys.executable, 'manage.py', 'test',
+             'testapp.tests.test_fields',
+             '--parallel', '2', '--noinput', '--verbosity', '2',
+             '--settings=testapp.settings_parallel'],
+            cwd=repo_root, env=env, capture_output=True, text=True, timeout=600,
+        )
+        output = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 0, 'parallel run failed:\n' + output)
+        # Confirm cloning actually happened (not silently downgraded to serial).
+        self.assertIn('Cloning test database', output)

--- a/testapp/tests/test_creation_cloning.py
+++ b/testapp/tests/test_creation_cloning.py
@@ -2,7 +2,7 @@
 # Licensed under the BSD license.
 
 from django.db import connection
-from django.test import TransactionTestCase
+from django.test import TransactionTestCase, skipUnlessDBFeature
 
 
 class DatabaseCloningTests(TransactionTestCase):
@@ -24,6 +24,7 @@ class DatabaseCloningTests(TransactionTestCase):
             not connection.to_azure_sql_db,
         )
 
+    @skipUnlessDBFeature('can_clone_databases')
     def test_clone_is_a_working_copy(self):
         creation = connection.creation
         suffix = 'clonetest'
@@ -49,19 +50,35 @@ class DatabaseCloningTests(TransactionTestCase):
             with connection._nodb_cursor() as cursor:
                 creation._drop_database_if_exists(cursor, clone_name)
 
+    @skipUnlessDBFeature('can_clone_databases')
     def test_clone_keepdb_reuses_existing(self):
         creation = connection.creation
         suffix = 'clonekeep'
         clone_name = creation.get_test_db_clone_settings(suffix)['NAME']
+        quoted_clone = connection.ops.quote_name(clone_name)
 
         creation._clone_test_db(suffix, verbosity=0)
         try:
-            # A second clone with keepdb=True must be a no-op, not an error.
-            creation._clone_test_db(suffix, verbosity=0, keepdb=True)
+            # Write a marker that exists only in the clone (the source backup
+            # has no such table), so a genuine keepdb no-op can be told apart
+            # from a silent drop-and-restore.
             with connection._nodb_cursor() as cursor:
                 cursor.execute(
-                    "SELECT 1 FROM sys.databases WHERE name = %s", [clone_name])
-                self.assertIsNotNone(cursor.fetchone())
+                    "EXEC('USE %s; CREATE TABLE keepdb_marker (id int)')"
+                    % quoted_clone)
+
+            # A second clone with keepdb=True must reuse the existing database.
+            creation._clone_test_db(suffix, verbosity=0, keepdb=True)
+
+            with connection._nodb_cursor() as cursor:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM %s.sys.tables WHERE name = %%s"
+                    % quoted_clone,
+                    ['keepdb_marker'],
+                )
+                self.assertEqual(
+                    cursor.fetchone()[0], 1,
+                    'keepdb=True should reuse the clone, not recreate it')
         finally:
             with connection._nodb_cursor() as cursor:
                 creation._drop_database_if_exists(cursor, clone_name)

--- a/testapp/tests/test_creation_cloning.py
+++ b/testapp/tests/test_creation_cloning.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the BSD license.
+
+from django.db import connection
+from django.test import TransactionTestCase
+
+
+class DatabaseCloningTests(TransactionTestCase):
+    """Regression tests for parallel-test database cloning (issue #342).
+
+    SQL Server has no CREATE DATABASE ... TEMPLATE, so mssql-django clones the
+    test database with a server-side BACKUP + RESTORE WITH MOVE. These tests
+    exercise that path directly (the --parallel test runner drives the same
+    code) and clean up the clone they create.
+    """
+
+    available_apps = ['testapp']
+
+    def test_feature_flag_enabled(self):
+        self.assertTrue(connection.features.can_clone_databases)
+
+    def test_clone_is_a_working_copy(self):
+        creation = connection.creation
+        suffix = 'clonetest'
+        clone_name = creation.get_test_db_clone_settings(suffix)['NAME']
+
+        creation._clone_test_db(suffix, verbosity=0)
+        try:
+            with connection._nodb_cursor() as cursor:
+                cursor.execute(
+                    "SELECT 1 FROM sys.databases WHERE name = %s", [clone_name])
+                self.assertIsNotNone(
+                    cursor.fetchone(), 'clone database was not created')
+
+                # The schema is copied, so the testapp tables exist in the clone.
+                cursor.execute(
+                    "SELECT COUNT(*) FROM %s.sys.tables WHERE name = %%s"
+                    % connection.ops.quote_name(clone_name),
+                    ['testapp_author'],
+                )
+                self.assertEqual(cursor.fetchone()[0], 1)
+        finally:
+            with connection._nodb_cursor() as cursor:
+                creation._drop_database_if_exists(cursor, clone_name)
+
+    def test_clone_keepdb_reuses_existing(self):
+        creation = connection.creation
+        suffix = 'clonekeep'
+        clone_name = creation.get_test_db_clone_settings(suffix)['NAME']
+
+        creation._clone_test_db(suffix, verbosity=0)
+        try:
+            # A second clone with keepdb=True must be a no-op, not an error.
+            creation._clone_test_db(suffix, verbosity=0, keepdb=True)
+            with connection._nodb_cursor() as cursor:
+                cursor.execute(
+                    "SELECT 1 FROM sys.databases WHERE name = %s", [clone_name])
+                self.assertIsNotNone(cursor.fetchone())
+        finally:
+            with connection._nodb_cursor() as cursor:
+                creation._drop_database_if_exists(cursor, clone_name)

--- a/testapp/tests/test_creation_cloning.py
+++ b/testapp/tests/test_creation_cloning.py
@@ -17,7 +17,12 @@ class DatabaseCloningTests(TransactionTestCase):
     available_apps = ['testapp']
 
     def test_feature_flag_enabled(self):
-        self.assertTrue(connection.features.can_clone_databases)
+        # Cloning is available on regular SQL Server, but not on Azure SQL
+        # Database (no BACKUP/RESTORE to disk).
+        self.assertEqual(
+            connection.features.can_clone_databases,
+            not connection.to_azure_sql_db,
+        )
 
     def test_clone_is_a_working_copy(self):
         creation = connection.creation

--- a/testapp/tests/test_creation_cloning.py
+++ b/testapp/tests/test_creation_cloning.py
@@ -29,8 +29,9 @@ class DatabaseCloningTests(TransactionTestCase):
         suffix = 'clonetest'
         clone_name = creation.get_test_db_clone_settings(suffix)['NAME']
 
-        creation._clone_test_db(suffix, verbosity=0)
+        returned_name = creation._clone_test_db(suffix, verbosity=0)
         try:
+            self.assertEqual(returned_name, clone_name)
             with connection._nodb_cursor() as cursor:
                 cursor.execute(
                     "SELECT 1 FROM sys.databases WHERE name = %s", [clone_name])

--- a/testapp/tests/test_creation_cloning.py
+++ b/testapp/tests/test_creation_cloning.py
@@ -17,12 +17,10 @@ class DatabaseCloningTests(TransactionTestCase):
     available_apps = ['testapp']
 
     def test_feature_flag_enabled(self):
-        # Cloning is available on regular SQL Server, but not on Azure SQL
-        # Database (no BACKUP/RESTORE to disk).
-        self.assertEqual(
-            connection.features.can_clone_databases,
-            not connection.to_azure_sql_db,
-        )
+        # Cloning is advertised for SQL Server. The Azure SQL Database case
+        # (no BACKUP/RESTORE to disk) is handled in _clone_test_db, which
+        # raises NotImplementedError there.
+        self.assertTrue(connection.features.can_clone_databases)
 
     @skipUnlessDBFeature('can_clone_databases')
     def test_clone_is_a_working_copy(self):

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ passenv =
     MSSQL_*
 
 commands =
-    coverage run --parallel-mode manage.py test --noinput
+    coverage run --parallel-mode manage.py test --noinput --parallel 1
     bash test.sh
 
 deps =


### PR DESCRIPTION
closes #342.

Django's test runner needs a per-worker copy of the test database to run tests with `--parallel`. mssql-django didn't implement cloning, so `manage.py test --parallel` (and `runtests.py --parallel`) failed with `NotImplementedError: The database backend doesn't support cloning databases`.

**what this does**

- adds `can_clone_databases` and implements `_clone_test_db`.
- SQL Server has no `CREATE DATABASE ... TEMPLATE`, so the clone is a server-side `BACKUP` of the test database followed by `RESTORE ... WITH MOVE` into `test_<name>_<n>`. this copies schema and data.
- the source is identical for every worker, so it's backed up once and that one backup is restored per clone.
- physical file paths for each clone are derived from the source database's own files (`sys.master_files.physical_name`), so it works wherever the source lives and does not depend on `SERVERPROPERTY` default paths (which can be NULL). directory handling is cross-platform.
- BACKUP/RESTORE informational result sets are drained so the next statement doesn't hit `database ... is in the middle of a restore`.

**Azure SQL family**

- `can_clone_databases` detects the engine edition through a master-scoped connection (master exists before the test DB is created and on Azure), so it reports `False` on Azure SQL Database / Managed Instance / Fabric without connecting to the not-yet-created application database. Django's pre-create feature check in `runtests.py` therefore stays serial there instead of failing.
- `_clone_test_db` also guards Azure explicitly with a clear `NotImplementedError`.

**cleanup and safety**

- the clone backup file is deleted after the source test database is destroyed, and the name-keyed backup cache is cleared when the source is (re)created, so no stale backup is reused and no data-bearing `.bak` lingers.
- `RESTORE` does not use `WITH REPLACE`: the target is dropped first and restored to target-named files, so REPLACE (which bypasses safety checks) is unnecessary.

**this repo's own suite**

- enabling cloning makes Django's source-suite `runtests.py` auto-select multiple workers, but this project's custom XML/expected-failure runner does not support parallel workers. `test.sh`, `tox.ini`, the devcontainer script, and the developer docs pin `--parallel 1` to keep that suite serial until the runner is reworked (tracked separately).

**tests**

`testapp/tests/test_creation_cloning.py`:
- clones the test database and asserts the copy is a real, online database with the schema present and migration data copied.
- the `keepdb` reuse path, proven with a marker table that must survive a second `keepdb=True` call.
- an end-to-end two-worker run via Django's stock `DiscoverRunner` in a subprocess (isolated DB names) exercising setup -> clone -> worker -> teardown.

verified locally against SQL Server 2022: cloning works, `--parallel 4` runs green with clean teardown (no orphan databases, no leftover backup files), full testapp suite stays green, and `can_clone_databases` evaluates on a fresh server (no application database) in well under a second.
