### PR TITLE
FIX: Honor explicit MARS settings for Fabric Warehouse connections

### DIFF
--- a/.github/instructions/mssql-base.instructions.md
+++ b/.github/instructions/mssql-base.instructions.md
@@ -15,11 +15,11 @@ them carefully.
   if the user set the keyword explicitly in `extra_params`, skip our injection. Apply the
   same pattern to any newly injected keyword; parse `extra_params` (case-insensitive) to
   detect it.
-- **MARS is force-added on Windows for Microsoft drivers and cannot currently be turned
-  off**, which breaks backends that don't support it (e.g. Microsoft Fabric DWH). A fix
-  must (a) honor an explicit `MARS_Connection` in `extra_params`, and (b) keep the runtime
-  `supports_mars` feature flag consistent with the effective setting — the flag is derived
-  from the driver name, not from the actual connection string, so they can disagree. See #415.
+- **MARS defaults on for Microsoft drivers on Windows.** Honor an explicit
+  `MARS_Connection` in `extra_params` without injecting a duplicate, and keep
+  `supports_mars` and `can_use_chunked_reads` consistent with that setting. Disabling
+  MARS must not apply the FreeTDS `fetchone()` result-discard workaround to Microsoft
+  drivers. See #415.
 - **`extra_params` is appended verbatim.** A keyword the backend also sets can appear
   twice; dedupe rather than emit duplicates.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,29 @@ DATABASE_CONNECTION_POOLING = False
 | `setencoding` / `setdecoding` | List | — | pyodbc [encoding](https://github.com/mkleehammer/pyodbc/wiki/Connection#setencoding) / [decoding](https://github.com/mkleehammer/pyodbc/wiki/Connection#setdecoding) config |
 | `return_rows_bulk_insert` | Boolean | `False` | Allow returning rows from bulk insert. Must be `False` if tables have triggers. |
 
+#### Disabling MARS
+
+The backend enables Multiple Active Result Sets (MARS) by default with Microsoft
+ODBC drivers on Windows. To connect to an endpoint that does not support MARS,
+such as Microsoft Fabric Warehouse, set `MARS_Connection=no` in that database
+alias's `extra_params`:
+
+```python
+'OPTIONS': {
+    'driver': 'ODBC Driver 18 for SQL Server',
+    'extra_params': 'Authentication=ActiveDirectoryServicePrincipal;MARS_Connection=no',
+},
+```
+
+Keep your existing `HOST`, `NAME`, `USER` (client ID), and `PASSWORD` (client
+secret) settings. For other authentication methods, keep the corresponding
+authentication settings and append `MARS_Connection=no` to `extra_params`.
+An explicit MARS setting is honored case-insensitively, without adding a
+conflicting default. With MARS disabled, ORM iteration buffers results before
+yielding them so nested queries can use the same connection; this can use more
+memory for large querysets. This connection setting does not imply full
+Warehouse support for Django migrations or other SQL Server features.
+
 ### Backend-Specific Settings
 
 | Setting | Type | Default | Description |

--- a/mssql/base.py
+++ b/mssql/base.py
@@ -239,6 +239,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         # capability for multiple result sets or cursors
         self.supports_mars = False
+        self._is_microsoft_driver = False
 
         # Some drivers need unicode encoded as UTF8. If this is left as
         # None, it will be determined based on the driver, namely it'll be
@@ -481,7 +482,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         cstr_parts['DATABASE'] = database
 
-        if ms_drivers.match(driver) and os.name == 'nt':
+        if (ms_drivers.match(driver) and os.name == 'nt' and
+                'mars_connection' not in self._parse_extra_params(options_extra_params)):
             cstr_parts['MARS_Connection'] = 'yes'
 
         connstr = encode_connection_string(cstr_parts)
@@ -602,16 +604,19 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         ms_drv_names = re.compile('^(LIB)?(SQLNCLI|MSODBCSQL)')
 
-        if ms_drv_names.match(drv_name):
+        settings_dict = self.settings_dict
+        options = settings_dict.get('OPTIONS', {})
+        self._is_microsoft_driver = bool(ms_drv_names.match(drv_name))
+
+        if self._is_microsoft_driver:
             self.driver_charset = None
             # http://msdn.microsoft.com/en-us/library/ms131686.aspx
-            self.supports_mars = True
-            self.features.can_use_chunked_reads = True
+            extra_params = self._parse_extra_params(options.get('extra_params'))
+            self.supports_mars = extra_params.get('mars_connection', 'yes').strip().lower() == 'yes'
+            self.features.can_use_chunked_reads = self.supports_mars
 
-        settings_dict = self.settings_dict
         cursor = self.create_cursor()
 
-        options = settings_dict.get('OPTIONS', {})
         isolation_level = options.get('isolation_level', None)
         if isolation_level:
             cursor.execute('SET TRANSACTION ISOLATION LEVEL %s' % isolation_level)
@@ -942,7 +947,7 @@ class CursorWrapper(object):
             row = self.format_row(row)
         # Any remaining rows in the current set must be discarded
         # before changing autocommit mode when you use FreeTDS
-        if not self.connection.supports_mars:
+        if not self.connection.supports_mars and not self.connection._is_microsoft_driver:
             self.cursor.nextset()
         return row
 

--- a/testapp/tests/test_base.py
+++ b/testapp/tests/test_base.py
@@ -769,6 +769,8 @@ class TestMarsConnectionLive(TestCase):
         self.wrapper.ensure_connection()
 
     def test_fetchone_preserves_remaining_rows(self):
+        if not self.wrapper._is_microsoft_driver:
+            self.skipTest("Row preservation without MARS requires a Microsoft driver")
         self.assertFalse(self.wrapper.supports_mars)
         self.assertFalse(self.wrapper.features.can_use_chunked_reads)
         with self.wrapper.cursor() as cursor:

--- a/testapp/tests/test_base.py
+++ b/testapp/tests/test_base.py
@@ -328,6 +328,67 @@ class TestDatabaseWrapperBuildConnectionString(SimpleTestCase):
         self.assertIn("Encrypt=yes", result)
         self.assertIn("TrustServerCertificate=yes", result)
 
+    def test_mars_connection_defaults(self):
+        for platform in ("nt", "posix"):
+            for driver in ("ODBC Driver 17 for SQL Server",
+                           "ODBC Driver 18 for SQL Server",
+                           "SQL Server Native Client 11.0", "FreeTDS"):
+                with self.subTest(platform=platform, driver=driver):
+                    params = {"NAME": "testdb", "OPTIONS": {}}
+                    with mock.patch("mssql.base.os.name", platform):
+                        result = self.wrapper._build_connection_string(params, driver)
+                    expected = platform == "nt" and driver != "FreeTDS"
+                    self.assertEqual("MARS_Connection=yes" in result, expected)
+
+    def test_explicit_mars_connection_is_not_overridden(self):
+        for platform in ("nt", "posix"):
+            for driver in ("ODBC Driver 17 for SQL Server",
+                           "ODBC Driver 18 for SQL Server"):
+                for mars in ("MARS_Connection=no", "mars_connection=No",
+                             " MARS_Connection = {no}", "MARS_Connection=yes"):
+                    for dsn in (None, "FabricDSN"):
+                        with self.subTest(platform=platform, driver=driver,
+                                          mars=mars, dsn=dsn):
+                            extra = "Authentication=ActiveDirectoryServicePrincipal;" + mars
+                            params = {
+                                "NAME": "warehouse",
+                                "HOST": "example.datawarehouse.fabric.microsoft.com",
+                                "USER": "client-id",
+                                "PASSWORD": "client-secret",
+                                "OPTIONS": {"extra_params": extra, "dsn": dsn},
+                            }
+                            with mock.patch("mssql.base.os.name", platform):
+                                result = self.wrapper._build_connection_string(params, driver)
+                            self.assertEqual(result.lower().count("mars_connection"), 1)
+                            self.assertTrue(result.endswith(extra))
+                            self.assertNotIn("Trusted_Connection=", result)
+
+    def test_mars_keyword_inside_braced_value_does_not_override_default(self):
+        params = {
+            "NAME": "testdb",
+            "OPTIONS": {"extra_params": "APP={example;MARS_Connection=no}"},
+        }
+        with mock.patch("mssql.base.os.name", "nt"):
+            result = self.wrapper._build_connection_string(
+                params, "ODBC Driver 18 for SQL Server"
+            )
+        self.assertIn(";MARS_Connection=yes;", result)
+
+    def test_mars_opt_out_survives_driver_fallback(self):
+        params = {
+            "NAME": "testdb",
+            "OPTIONS": {"extra_params": "MARS_Connection=no"},
+        }
+        with mock.patch("mssql.base.os.name", "nt"), mock.patch(
+            "mssql.base.Database.connect",
+            side_effect=[Exception("Driver not found"), mock.MagicMock()],
+        ) as connect:
+            self.wrapper.get_new_connection(params)
+        self.assertEqual(connect.call_count, 2)
+        for call in connect.call_args_list:
+            self.assertEqual(call.args[0].count("MARS_Connection="), 1)
+            self.assertIn("MARS_Connection=no", call.args[0])
+
     def test_connection_string_freetds(self):
         """Test connection string building for FreeTDS driver."""
         conn_params = {
@@ -644,6 +705,90 @@ class TestDatabaseWrapperBuildConnectionString(SimpleTestCase):
         result = self.wrapper._build_connection_string(conn_params, driver)
 
         self.assertIn("Trusted_Connection=yes", result)
+
+
+class TestMarsConnectionState(SimpleTestCase):
+    def test_effective_mars_setting_and_reinitialization(self):
+        for driver in ("MSODBCSQL18.DLL", "libmsodbcsql.18.dylib",
+                       "SQLNCLI11.DLL", "libtdsodbc.so"):
+            with self.subTest(driver=driver):
+                wrapper = DatabaseWrapper({"OPTIONS": {}}, alias="mars_state")
+                wrapper.connection = mock.MagicMock()
+                wrapper.connection.getinfo.return_value = driver
+                wrapper.get_system_datetime = datetime.datetime(2026, 1, 1)
+                for extra, enabled in (
+                    ("", True), ("MARS_Connection=no", False),
+                    ("mars_connection={No}", False),
+                    ("MARS_Connection=no;MARS_Connection=yes", False),
+                    ("MARS_Connection=yes", True),
+                    ("APP={example;MARS_Connection=no}", True),
+                ):
+                    with self.subTest(extra=extra):
+                        wrapper.settings_dict["OPTIONS"]["extra_params"] = extra
+                        wrapper.init_connection_state()
+                        expected = enabled and driver != "libtdsodbc.so"
+                        self.assertEqual(wrapper.supports_mars, expected)
+                        self.assertEqual(wrapper.features.can_use_chunked_reads, expected)
+
+    def test_fetchone_does_not_discard_microsoft_driver_rows_without_mars(self):
+        wrapper = DatabaseWrapper(
+            {"OPTIONS": {"extra_params": "MARS_Connection=no"}}, alias="mars_rows"
+        )
+        wrapper.connection = mock.MagicMock()
+        wrapper.connection.getinfo.return_value = "MSODBCSQL18.DLL"
+        wrapper.get_system_datetime = datetime.datetime(2026, 1, 1)
+        wrapper.init_connection_state()
+        cursor = wrapper.create_cursor()
+        cursor.cursor.fetchone.side_effect = [(1,), (2,), None]
+        self.assertEqual(cursor.fetchone(), (1,))
+        self.assertEqual(cursor.fetchone(), (2,))
+        self.assertIsNone(cursor.fetchone())
+        cursor.cursor.nextset.assert_not_called()
+
+    def test_freetds_fetchone_keeps_nextset_workaround(self):
+        wrapper = DatabaseWrapper({"OPTIONS": {}}, alias="mars_freetds")
+        wrapper.connection = mock.MagicMock()
+        wrapper.connection.getinfo.return_value = "libtdsodbc.so"
+        wrapper.get_system_datetime = datetime.datetime(2026, 1, 1)
+        wrapper.init_connection_state()
+        cursor = wrapper.create_cursor()
+        cursor.cursor.fetchone.return_value = (1,)
+        self.assertEqual(cursor.fetchone(), (1,))
+        cursor.cursor.nextset.assert_called_once_with()
+
+
+class TestMarsConnectionLive(TestCase):
+    def setUp(self):
+        from django.db import connection
+
+        self.wrapper = connection.copy(alias="mars_live")
+        options = self.wrapper.settings_dict["OPTIONS"]
+        extra = options.get("extra_params") or ""
+        options["extra_params"] = "MARS_Connection=no;" + extra
+        self.addCleanup(self.wrapper.close)
+        self.wrapper.ensure_connection()
+
+    def test_fetchone_preserves_remaining_rows(self):
+        self.assertFalse(self.wrapper.supports_mars)
+        self.assertFalse(self.wrapper.features.can_use_chunked_reads)
+        with self.wrapper.cursor() as cursor:
+            cursor.execute("SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3 ORDER BY n")
+            self.assertEqual(cursor.fetchone(), (1,))
+            self.assertEqual(cursor.fetchone(), (2,))
+            self.assertEqual(cursor.fetchall(), [(3,)])
+
+    def test_cursor_iteration_allows_nested_query(self):
+        from mssql.compiler import _cursor_iter
+
+        cursor = self.wrapper.cursor()
+        cursor.execute("SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3 ORDER BY n")
+        rows = []
+        for chunk in _cursor_iter(cursor, [], None, 1):
+            with self.wrapper.cursor() as nested:
+                nested.execute("SELECT 42")
+                self.assertEqual(nested.fetchone(), (42,))
+            rows.extend(chunk)
+        self.assertEqual(rows, [(1,), (2,), (3,)])
 
 
 class TestCursorWrapperAsSqlType(SimpleTestCase):


### PR DESCRIPTION
Closes #415.

Honor an explicit `MARS_Connection` in `extra_params` instead of adding a conflicting Windows default. Keep runtime MARS and chunked-read flags consistent with the explicit setting.

Preserve remaining rows when calling `fetchone()` with MARS disabled on Microsoft drivers, while retaining the FreeTDS workaround.

Add regression coverage and document the Fabric Warehouse connection configuration. This change does not imply full Warehouse support for Django migrations or other SQL Server features.