### PR TITLE
fix: handle JSON-null key lookups gracefully below compat level 130 (#592)

### DIFF
--- a/mssql/features.py
+++ b/mssql/features.py
@@ -98,6 +98,23 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         return self.connection.sql_server_version >= 2016 or self.connection.to_azure_sql_db
 
     @cached_property
+    def supports_json_openjson(self):
+        # OPENJSON requires a database compatibility level of 130 or higher,
+        # independent of the SQL Server product version: a 2016+ server can host a
+        # database pinned at an older level (for example a database restored from
+        # SQL Server 2014). JSON-null key lookups fall back to a non-OPENJSON path
+        # when this is False. Azure SQL Database is always at a supported level.
+        if self.connection.to_azure_sql_db:
+            return True
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT compatibility_level FROM sys.databases "
+                "WHERE database_id = DB_ID()"
+            )
+            row = cursor.fetchone()
+        return bool(row) and row[0] >= 130
+
+    @cached_property
     def introspected_field_types(self):
         return {
             **super().introspected_field_types,

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -100,12 +100,12 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def supports_json_openjson(self):
         # OPENJSON requires a database compatibility level of 130 or higher,
-        # independent of the SQL Server product version: a 2016+ server can host a
-        # database pinned at an older level (for example a database restored from
-        # SQL Server 2014). JSON-null key lookups fall back to a non-OPENJSON path
-        # when this is False. Azure SQL Database is always at a supported level.
-        if self.connection.to_azure_sql_db:
-            return True
+        # independent of the SQL Server product version and of Azure versus box:
+        # a 2016+ server, or an Azure SQL Database, can host a database pinned at an
+        # older level (for example one migrated from an earlier version, which
+        # retains its source compatibility level). JSON-null key lookups fall back
+        # to a non-OPENJSON path when this is False. DATABASEPROPERTYEX returns
+        # sql_variant, which pyodbc cannot read, so query sys.databases (tinyint).
         with self.connection.cursor() as cursor:
             cursor.execute(
                 "SELECT compatibility_level FROM sys.databases "

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -396,15 +396,38 @@ def sqlserver_json_array(self, compiler, connection, **extra_context):
 
     return sql, params
 
+
 # Register for Django 5.2+ so that JSONArray uses this implementation on SQL Server
 if VERSION >= (5, 2):
     JSONArray.as_microsoft = sqlserver_json_array
+
 
 def json_KeyTransformExact_process_rhs(self, compiler, connection):
     rhs, rhs_params = key_transform_exact_process_rhs(self, compiler, connection)
     if connection.vendor == 'microsoft':
         rhs_params = unquote_json_rhs(rhs_params)
     return rhs, rhs_params
+
+
+def json_KeyTransformExact(self, compiler, connection):
+    """Match an existing JSON key whose value is the JSON null literal."""
+    if self.rhs is None and isinstance(self.lhs, KeyTransform):
+        lhs, lhs_params, key_transforms = self.lhs.preprocess_lhs(compiler, connection)
+        final_key = key_transforms.pop()
+
+        if key_transforms:
+            json_path = connection.ops.compile_json_path(key_transforms)
+            json_path = json_path.replace("'", "''")
+            openjson = "OPENJSON(%s, '%s')" % (lhs, json_path)
+        else:
+            openjson = "OPENJSON(%s)" % lhs
+
+        return (
+            "EXISTS (SELECT 1 FROM %s WHERE [key] = %%s AND [type] = 0)" % openjson,
+            tuple(lhs_params) + (final_key,),
+        )
+    return self.as_sql(compiler, connection)
+
 
 def json_KeyTransformIn(self, compiler, connection):
     lhs, _ = super(KeyTransformIn, self).process_lhs(compiler, connection)
@@ -736,6 +759,7 @@ in_split_parameter_list_as_sql = In.split_parameter_list_as_sql
 In.split_parameter_list_as_sql = split_parameter_list_as_sql
 if VERSION >= (3, 1):
     KeyTransformIn.as_microsoft = json_KeyTransformIn
+    KeyTransformExact.as_microsoft = json_KeyTransformExact
     # Need copy of old KeyTransformExact.process_rhs to call later
     key_transform_exact_process_rhs = KeyTransformExact.process_rhs
     KeyTransformExact.process_rhs = json_KeyTransformExact_process_rhs

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -30,7 +30,7 @@ if VERSION >= (5, 2):
 
 if VERSION >= (3, 1):
     from django.db.models.fields.json import (
-        KeyTransform, KeyTransformIn, KeyTransformExact,
+        KeyTransform, KeyTransformIn, KeyTransformExact, KeyTransformIExact,
         HasKeyLookup)
     # compile_json_path was moved from django.db.models.fields.json to
     # connection.ops.compile_json_path() in Django 6.0
@@ -415,6 +415,34 @@ def json_KeyTransformExact(self, compiler, connection):
         lhs, lhs_params, key_transforms = self.lhs.preprocess_lhs(compiler, connection)
         final_key = key_transforms.pop()
 
+        try:
+            final_index = int(final_key)
+        except ValueError:
+            final_index = None
+
+        if final_index is not None:
+            # Compile the final transform independently to preserve the backend's
+            # numeric parsing and negative-index validation.
+            connection.ops.compile_json_path([final_key])
+
+            if key_transforms:
+                json_path = connection.ops.compile_json_path(key_transforms)
+                json_path = json_path.replace("'", "''")
+                parent_json = "JSON_QUERY(%s, '%s')" % (lhs, json_path)
+            else:
+                parent_json = "JSON_QUERY(%s)" % lhs
+
+            # OPENJSON exposes both array indexes and numeric object properties as
+            # string keys. Guard the parent shape so __0 follows Django's array-index
+            # semantics and doesn't also match an object property named "0".
+            return (
+                "EXISTS (SELECT 1 FROM (SELECT %s AS [json]) AS [parent] "
+                "CROSS APPLY OPENJSON([parent].[json]) AS [item] "
+                "WHERE LEFT(LTRIM([parent].[json]), 1) = '[' "
+                "AND [item].[key] = %%s AND [item].[type] = 0)" % parent_json,
+                tuple(lhs_params) + (str(final_index),),
+            )
+
         if key_transforms:
             json_path = connection.ops.compile_json_path(key_transforms)
             json_path = json_path.replace("'", "''")
@@ -427,6 +455,20 @@ def json_KeyTransformExact(self, compiler, connection):
             tuple(lhs_params) + (final_key,),
         )
     return self.as_sql(compiler, connection)
+
+
+def json_KeyTransformIExact_as_sql(self, compiler, connection):
+    """Backport Django 6.1's vendor-aware JSON null delegation."""
+    if self.rhs is None:
+        key_transform = KeyTransform(self.lhs.key_name, self.lhs.lhs)
+        exact_lookup = KeyTransformExact(key_transform, self.rhs)
+        vendor_method = getattr(
+            exact_lookup,
+            'as_%s' % connection.vendor,
+            exact_lookup.as_sql,
+        )
+        return vendor_method(compiler, connection)
+    return key_transform_iexact_as_sql(self, compiler, connection)
 
 
 def json_KeyTransformIn(self, compiler, connection):
@@ -760,6 +802,12 @@ In.split_parameter_list_as_sql = split_parameter_list_as_sql
 if VERSION >= (3, 1):
     KeyTransformIn.as_microsoft = json_KeyTransformIn
     KeyTransformExact.as_microsoft = json_KeyTransformExact
+    if VERSION < (6, 1):
+        # Django 6.1 added vendor-aware delegation upstream. Backport the full
+        # behavior so enabling None also remains correct on secondary databases.
+        KeyTransformIExact.can_use_none_as_rhs = True
+        key_transform_iexact_as_sql = KeyTransformIExact.as_sql
+        KeyTransformIExact.as_sql = json_KeyTransformIExact_as_sql
     # Need copy of old KeyTransformExact.process_rhs to call later
     key_transform_exact_process_rhs = KeyTransformExact.process_rhs
     KeyTransformExact.process_rhs = json_KeyTransformExact_process_rhs

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -434,12 +434,15 @@ def json_KeyTransformExact(self, compiler, connection):
 
             # OPENJSON exposes both array indexes and numeric object properties as
             # string keys. Guard the parent shape so __0 follows Django's array-index
-            # semantics and doesn't also match an object property named "0".
+            # semantics and doesn't also match an object property named "0". MAX()
+            # returns SQL NULL when the index is missing, preserving Django's
+            # three-valued behavior when the lookup is negated by exclude().
             return (
-                "EXISTS (SELECT 1 FROM (SELECT %s AS [json]) AS [parent] "
+                "(SELECT MAX(CASE WHEN [item].[type] = 0 THEN 1 ELSE 0 END) "
+                "FROM (SELECT %s AS [json]) AS [parent] "
                 "CROSS APPLY OPENJSON([parent].[json]) AS [item] "
                 "WHERE LEFT(LTRIM([parent].[json]), 1) = '[' "
-                "AND [item].[key] = %%s AND [item].[type] = 0)" % parent_json,
+                "AND [item].[key] = %%s) = 1" % parent_json,
                 tuple(lhs_params) + (str(final_index),),
             )
 
@@ -451,7 +454,8 @@ def json_KeyTransformExact(self, compiler, connection):
             openjson = "OPENJSON(%s)" % lhs
 
         return (
-            "EXISTS (SELECT 1 FROM %s WHERE [key] = %%s AND [type] = 0)" % openjson,
+            "(SELECT MAX(CASE WHEN [type] = 0 THEN 1 ELSE 0 END) "
+            "FROM %s WHERE [key] = %%s) = 1" % openjson,
             tuple(lhs_params) + (final_key,),
         )
     return self.as_sql(compiler, connection)

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -465,7 +465,7 @@ def json_KeyTransformIExact_as_sql(self, compiler, connection):
     """Backport Django 6.1's vendor-aware JSON null delegation."""
     if self.rhs is None:
         key_transform = KeyTransform(self.lhs.key_name, self.lhs.lhs)
-        exact_lookup = KeyTransformExact(key_transform, self.rhs)
+        exact_lookup = key_transform.get_lookup('exact')(key_transform, self.rhs)
         vendor_method = getattr(
             exact_lookup,
             'as_%s' % connection.vendor,

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -30,7 +30,7 @@ if VERSION >= (5, 2):
 
 if VERSION >= (3, 1):
     from django.db.models.fields.json import (
-        KeyTransform, KeyTransformIn, KeyTransformExact, KeyTransformIExact,
+        KeyTransform, KeyTransformIn, KeyTransformExact,
         HasKeyLookup)
     # compile_json_path was moved from django.db.models.fields.json to
     # connection.ops.compile_json_path() in Django 6.0
@@ -461,35 +461,6 @@ def json_KeyTransformExact(self, compiler, connection):
     return self.as_sql(compiler, connection)
 
 
-def json_KeyTransformIExact_as_sql(self, compiler, connection):
-    """Backport Django 6.1's vendor-aware JSON null delegation."""
-    if self.rhs is None:
-        if connection.vendor != 'microsoft':
-            # can_use_none_as_rhs=True suppresses Django's build-time
-            # iexact=None -> isnull=True rewrite (query.py) for every vendor.
-            # Non-SQL-Server backends kept the pre-6.1 IS NULL semantics, so
-            # replay that rewrite here to leave their results unchanged.
-            # Dispatch through the vendor method: KeyTransformIsNull overrides
-            # as_sqlite/as_oracle, and the generic as_sql matches both a
-            # JSON-null value and a missing key on some backends.
-            isnull_lookup = self.lhs.get_lookup('isnull')(self.lhs, True)
-            isnull_method = getattr(
-                isnull_lookup,
-                'as_%s' % connection.vendor,
-                isnull_lookup.as_sql,
-            )
-            return isnull_method(compiler, connection)
-        key_transform = KeyTransform(self.lhs.key_name, self.lhs.lhs)
-        exact_lookup = key_transform.get_lookup('exact')(key_transform, self.rhs)
-        vendor_method = getattr(
-            exact_lookup,
-            'as_%s' % connection.vendor,
-            exact_lookup.as_sql,
-        )
-        return vendor_method(compiler, connection)
-    return key_transform_iexact_as_sql(self, compiler, connection)
-
-
 def json_KeyTransformIn(self, compiler, connection):
     lhs, _ = super(KeyTransformIn, self).process_lhs(compiler, connection)
     rhs, rhs_params = super(KeyTransformIn, self).process_rhs(compiler, connection)
@@ -821,12 +792,6 @@ In.split_parameter_list_as_sql = split_parameter_list_as_sql
 if VERSION >= (3, 1):
     KeyTransformIn.as_microsoft = json_KeyTransformIn
     KeyTransformExact.as_microsoft = json_KeyTransformExact
-    if VERSION < (6, 1):
-        # Django 6.1 added vendor-aware delegation upstream. Backport the full
-        # behavior so enabling None also remains correct on secondary databases.
-        KeyTransformIExact.can_use_none_as_rhs = True
-        key_transform_iexact_as_sql = KeyTransformIExact.as_sql
-        KeyTransformIExact.as_sql = json_KeyTransformIExact_as_sql
     # Need copy of old KeyTransformExact.process_rhs to call later
     key_transform_exact_process_rhs = KeyTransformExact.process_rhs
     KeyTransformExact.process_rhs = json_KeyTransformExact_process_rhs

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -411,7 +411,11 @@ def json_KeyTransformExact_process_rhs(self, compiler, connection):
 
 def json_KeyTransformExact(self, compiler, connection):
     """Match an existing JSON key whose value is the JSON null literal."""
-    if self.rhs is None and isinstance(self.lhs, KeyTransform):
+    if (
+        self.rhs is None
+        and isinstance(self.lhs, KeyTransform)
+        and connection.features.supports_json_openjson
+    ):
         lhs, lhs_params, key_transforms = self.lhs.preprocess_lhs(compiler, connection)
         final_key = key_transforms.pop()
 

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -414,54 +414,82 @@ def json_KeyTransformExact(self, compiler, connection):
     if (
         self.rhs is None
         and isinstance(self.lhs, KeyTransform)
-        and connection.features.supports_json_openjson
     ):
-        lhs, lhs_params, key_transforms = self.lhs.preprocess_lhs(compiler, connection)
-        final_key = key_transforms.pop()
+        if connection.features.supports_json_openjson:
+            lhs, lhs_params, key_transforms = self.lhs.preprocess_lhs(compiler, connection)
+            final_key = key_transforms.pop()
 
-        try:
-            final_index = int(final_key)
-        except ValueError:
-            final_index = None
+            try:
+                final_index = int(final_key)
+            except ValueError:
+                final_index = None
 
-        if final_index is not None:
-            # Compile the final transform independently to preserve the backend's
-            # numeric parsing and negative-index validation.
-            connection.ops.compile_json_path([final_key])
+            if final_index is not None:
+                # Compile the final transform independently to preserve the backend's
+                # numeric parsing and negative-index validation.
+                connection.ops.compile_json_path([final_key])
+
+                if key_transforms:
+                    json_path = connection.ops.compile_json_path(key_transforms)
+                    json_path = json_path.replace("'", "''")
+                    parent_json = "JSON_QUERY(%s, '%s')" % (lhs, json_path)
+                else:
+                    parent_json = "JSON_QUERY(%s)" % lhs
+
+                # OPENJSON exposes both array indexes and numeric object properties as
+                # string keys. Guard the parent shape so __0 follows Django's array-index
+                # semantics and doesn't also match an object property named "0". MAX()
+                # returns SQL NULL when the index is missing, preserving Django's
+                # three-valued behavior when the lookup is negated by exclude().
+                return (
+                    "(SELECT MAX(CASE WHEN [item].[type] = 0 THEN 1 ELSE 0 END) "
+                    "FROM (SELECT %s AS [json]) AS [parent] "
+                    "CROSS APPLY OPENJSON([parent].[json]) AS [item] "
+                    "WHERE LEFT(LTRIM([parent].[json]), 1) = '[' "
+                    "AND [item].[key] = %%s) = 1" % parent_json,
+                    tuple(lhs_params) + (str(final_index),),
+                )
 
             if key_transforms:
                 json_path = connection.ops.compile_json_path(key_transforms)
                 json_path = json_path.replace("'", "''")
-                parent_json = "JSON_QUERY(%s, '%s')" % (lhs, json_path)
+                openjson = "OPENJSON(%s, '%s')" % (lhs, json_path)
             else:
-                parent_json = "JSON_QUERY(%s)" % lhs
+                openjson = "OPENJSON(%s)" % lhs
 
-            # OPENJSON exposes both array indexes and numeric object properties as
-            # string keys. Guard the parent shape so __0 follows Django's array-index
-            # semantics and doesn't also match an object property named "0". MAX()
-            # returns SQL NULL when the index is missing, preserving Django's
-            # three-valued behavior when the lookup is negated by exclude().
             return (
-                "(SELECT MAX(CASE WHEN [item].[type] = 0 THEN 1 ELSE 0 END) "
-                "FROM (SELECT %s AS [json]) AS [parent] "
-                "CROSS APPLY OPENJSON([parent].[json]) AS [item] "
-                "WHERE LEFT(LTRIM([parent].[json]), 1) = '[' "
-                "AND [item].[key] = %%s) = 1" % parent_json,
-                tuple(lhs_params) + (str(final_index),),
+                "(SELECT MAX(CASE WHEN [type] = 0 THEN 1 ELSE 0 END) "
+                "FROM %s WHERE [key] = %%s) = 1" % openjson,
+                tuple(lhs_params) + (final_key,),
             )
-
-        if key_transforms:
-            json_path = connection.ops.compile_json_path(key_transforms)
-            json_path = json_path.replace("'", "''")
-            openjson = "OPENJSON(%s, '%s')" % (lhs, json_path)
         else:
-            openjson = "OPENJSON(%s)" % lhs
+            if connection.sql_server_version >= 2022:
+                lhs, lhs_params, key_transforms = self.lhs.preprocess_lhs(compiler, connection)
+                
+                # For Django < 6.0, use Django's built-in compile_json_path
+                # For Django 6.0+, use connection.ops.compile_json_path()
+                if VERSION >= (6, 0):
+                    json_path = connection.ops.compile_json_path(key_transforms)
+                else:
+                    from django.db.models.fields.json import compile_json_path
+                    json_path = compile_json_path(key_transforms)
+                    
+                json_path = json_path.replace("'", "''")
+                
+                sql = (
+                    "JSON_PATH_EXISTS(%s, '%s') > 0 "
+                    "AND JSON_VALUE(%s, '%s') IS NULL "
+                    "AND JSON_QUERY(%s, '%s') IS NULL"
+                ) % (lhs, json_path, lhs, json_path, lhs, json_path)
+                
+                return sql, tuple(lhs_params) * 3
+            else:
+                from django.db.utils import NotSupportedError
+                raise NotSupportedError(
+                    "JSON-null key lookups require a database compatibility level of 130 or higher, "
+                    "or SQL Server 2022+."
+                )
 
-        return (
-            "(SELECT MAX(CASE WHEN [type] = 0 THEN 1 ELSE 0 END) "
-            "FROM %s WHERE [key] = %%s) = 1" % openjson,
-            tuple(lhs_params) + (final_key,),
-        )
     return self.as_sql(compiler, connection)
 
 

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -469,8 +469,16 @@ def json_KeyTransformIExact_as_sql(self, compiler, connection):
             # iexact=None -> isnull=True rewrite (query.py) for every vendor.
             # Non-SQL-Server backends kept the pre-6.1 IS NULL semantics, so
             # replay that rewrite here to leave their results unchanged.
+            # Dispatch through the vendor method: KeyTransformIsNull overrides
+            # as_sqlite/as_oracle, and the generic as_sql matches both a
+            # JSON-null value and a missing key on some backends.
             isnull_lookup = self.lhs.get_lookup('isnull')(self.lhs, True)
-            return isnull_lookup.as_sql(compiler, connection)
+            isnull_method = getattr(
+                isnull_lookup,
+                'as_%s' % connection.vendor,
+                isnull_lookup.as_sql,
+            )
+            return isnull_method(compiler, connection)
         key_transform = KeyTransform(self.lhs.key_name, self.lhs.lhs)
         exact_lookup = key_transform.get_lookup('exact')(key_transform, self.rhs)
         vendor_method = getattr(

--- a/mssql/functions.py
+++ b/mssql/functions.py
@@ -464,6 +464,13 @@ def json_KeyTransformExact(self, compiler, connection):
 def json_KeyTransformIExact_as_sql(self, compiler, connection):
     """Backport Django 6.1's vendor-aware JSON null delegation."""
     if self.rhs is None:
+        if connection.vendor != 'microsoft':
+            # can_use_none_as_rhs=True suppresses Django's build-time
+            # iexact=None -> isnull=True rewrite (query.py) for every vendor.
+            # Non-SQL-Server backends kept the pre-6.1 IS NULL semantics, so
+            # replay that rewrite here to leave their results unchanged.
+            isnull_lookup = self.lhs.get_lookup('isnull')(self.lhs, True)
+            return isnull_lookup.as_sql(compiler, connection)
         key_transform = KeyTransform(self.lhs.key_name, self.lhs.lhs)
         exact_lookup = key_transform.get_lookup('exact')(key_transform, self.rhs)
         vendor_method = getattr(

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -196,8 +196,6 @@ EXCLUDED_TESTS = [
     # JSONFields
     'model_fields.test_jsonfield.TestQuerying.test_key_quoted_string',
     'model_fields.test_jsonfield.TestQuerying.test_isnull_key',
-    'model_fields.test_jsonfield.TestQuerying.test_none_key',
-    'model_fields.test_jsonfield.TestQuerying.test_none_key_and_exact_lookup',
     'model_fields.test_jsonfield.TestQuerying.test_key_escape',
     'expressions_window.tests.WindowFunctionTests.test_key_transform',
 
@@ -352,10 +350,6 @@ if VERSION >= (6, 1):
         # reference (F()) used as a LIKE pattern doesn't cover the bracket case.
         # TODO: escape []-wildcards for column-referencing __contains/__startswith.
         'expressions.tests.ExpressionsTests.test_patterns_escape',
-
-        # JSON key __iexact=None semantics (no native JSON null handling on SQL Server);
-        # sibling to the existing JSONField exclusions.
-        'model_fields.test_jsonfield.TestQuerying.test_key_iexact_none',
 
         # bulk_batch_size is capped for SQL Server's 2100-parameter limit, so the
         # "unlimited" (no-fields) case doesn't match Django's expected large batch size.

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -156,6 +156,7 @@ class TestJSONField(TestCase):
             def as_sql(self, compiler, connection):
                 return 'CUSTOM_JSON_EXACT', []
 
+        previous_lookup = KeyTransform.get_lookups()['exact']
         KeyTransform.register_lookup(CustomExact)
         try:
             lookup = KeyTransformIExact(
@@ -167,8 +168,9 @@ class TestJSONField(TestCase):
                 connection=SimpleNamespace(vendor='microsoft'),
             )
         finally:
-            KeyTransform._unregister_lookup(CustomExact)
+            KeyTransform.register_lookup(previous_lookup)
 
+        self.assertIs(KeyTransform.get_lookups()['exact'], previous_lookup)
         self.assertEqual(sql, 'CUSTOM_JSON_EXACT')
         self.assertEqual(params, [])
 
@@ -250,7 +252,7 @@ class TestJSONField(TestCase):
         with CaptureQueriesContext(connections['default']) as captured:
             result = list(queryset)
 
-        self.assertSequenceEqual(result, [rows[1], rows[2], rows[0]])
+        self.assertSequenceEqual(result, [rows[1], rows[0], rows[2]])
 
         # The numeric conversion expression should appear only once even though
         # the same order clause is requested twice.

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -160,7 +160,9 @@ class TestJSONField(TestCase):
         KeyTransform.register_lookup(CustomExact)
         try:
             lookup = KeyTransformIExact(
-                KeyTextTransform('nullable', F('value')),
+                KeyTextTransform('nullable', F('value')).resolve_expression(
+                    JSONModel.objects.all().query,
+                ),
                 None,
             )
             sql, params = lookup.as_sql(

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -129,12 +129,19 @@ class TestJSONField(TestCase):
         present = JSONModel.objects.create(
             value={"nullable": None, "nested": {"nullable": None}}
         )
-        JSONModel.objects.create(value={"nullable": "value", "nested": {}})
+        non_null = JSONModel.objects.create(
+            value={"nullable": "value", "nested": {"nullable": "value"}}
+        )
         JSONModel.objects.create(value={})
 
         self.assertSequenceEqual(JSONModel.objects.filter(value__nullable=None), [present])
         self.assertSequenceEqual(JSONModel.objects.filter(value__nullable__iexact=None), [present])
         self.assertSequenceEqual(JSONModel.objects.filter(value__nested__nullable=None), [present])
+        self.assertSequenceEqual(JSONModel.objects.exclude(value__nullable=None), [non_null])
+        self.assertSequenceEqual(
+            JSONModel.objects.exclude(value__nested__nullable=None),
+            [non_null],
+        )
 
     @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
     def test_json_null_numeric_key_uses_array_index_semantics(self):

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -125,6 +125,35 @@ class TestJSONField(TestCase):
         )
 
     @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
+    def test_json_null_key_lookups(self):
+        present = JSONModel.objects.create(
+            value={"nullable": None, "nested": {"nullable": None}}
+        )
+        JSONModel.objects.create(value={"nullable": "value", "nested": {}})
+        JSONModel.objects.create(value={})
+
+        self.assertSequenceEqual(JSONModel.objects.filter(value__nullable=None), [present])
+        self.assertSequenceEqual(JSONModel.objects.filter(value__nullable__iexact=None), [present])
+        self.assertSequenceEqual(JSONModel.objects.filter(value__nested__nullable=None), [present])
+
+    @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
+    def test_json_null_numeric_key_uses_array_index_semantics(self):
+        array_null = JSONModel.objects.create(value=[None])
+        nested_array_null = JSONModel.objects.create(value={"items": [None]})
+        JSONModel.objects.create(value={"0": None})
+        JSONModel.objects.create(value={"items": {"0": None}})
+        JSONModel.objects.create(value=["value"])
+
+        self.assertSequenceEqual(JSONModel.objects.filter(value__0=None), [array_null])
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(value__items__0=None),
+            [nested_array_null],
+        )
+
+        with self.assertRaises(NotSupportedError):
+            list(JSONModel.objects.filter(**{"value__-1": None}))
+
+    @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
     def test_ordering_by_numeric_json_key_ascending(self):
         # Regression coverage for compiler ORDER BY rewrite:
         # JSON key transforms should sort numerically (not lexicographically)
@@ -191,4 +220,3 @@ class TestJSONField(TestCase):
         # the same order clause is requested twice.
         select_sql = captured[-1]["sql"]
         self.assertEqual(select_sql.upper().count("TRY_CONVERT(FLOAT"), 1)
-

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -1,10 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the BSD license.
 
+from types import SimpleNamespace
 from unittest import skipUnless
 
 from django import VERSION
 from django.db import NotSupportedError, connections
+from django.db.models import F, Lookup
+from django.db.models.fields.json import (
+    KeyTextTransform, KeyTransform, KeyTransformIExact,
+)
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 
@@ -142,6 +147,30 @@ class TestJSONField(TestCase):
             JSONModel.objects.exclude(value__nested__nullable=None),
             [non_null],
         )
+
+    @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
+    def test_json_null_iexact_uses_registered_exact_lookup(self):
+        class CustomExact(Lookup):
+            lookup_name = 'exact'
+
+            def as_sql(self, compiler, connection):
+                return 'CUSTOM_JSON_EXACT', []
+
+        KeyTransform.register_lookup(CustomExact)
+        try:
+            lookup = KeyTransformIExact(
+                KeyTextTransform('nullable', F('value')),
+                None,
+            )
+            sql, params = lookup.as_sql(
+                compiler=None,
+                connection=SimpleNamespace(vendor='microsoft'),
+            )
+        finally:
+            KeyTransform._unregister_lookup(CustomExact)
+
+        self.assertEqual(sql, 'CUSTOM_JSON_EXACT')
+        self.assertEqual(params, [])
 
     @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
     def test_json_null_numeric_key_uses_array_index_semantics(self):

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -252,7 +252,7 @@ class TestJSONField(TestCase):
         with CaptureQueriesContext(connections['default']) as captured:
             result = list(queryset)
 
-        self.assertSequenceEqual(result, [rows[1], rows[0], rows[2]])
+        self.assertSequenceEqual(result, [rows[1], rows[2], rows[0]])
 
         # The numeric conversion expression should appear only once even though
         # the same order clause is requested twice.

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -149,6 +149,28 @@ class TestJSONField(TestCase):
         )
 
     @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
+    @skipUnless(
+        _check_jsonfield_supported_sqlite(),
+        "JSONField not supported by SQLite on this platform and Python version",
+    )
+    def test_json_null_iexact_none_preserves_secondary_database(self):
+        # Importing this backend enables None as an iexact right-hand side for
+        # every vendor, which suppresses Django's build-time iexact=None ->
+        # isnull=True rewrite. A non-SQL-Server database must still see its
+        # native result: pre-6.1 a missing key matched (IS NULL semantics),
+        # while 6.1 unified iexact=None to match the JSON null value.
+        json_null = JSONModel(value={"nullable": None})
+        json_null.save(using='sqlite')
+        missing = JSONModel(value={"other": "value"})
+        missing.save(using='sqlite')
+
+        result = list(
+            JSONModel.objects.using('sqlite').filter(value__nullable__iexact=None)
+        )
+        expected = [json_null] if VERSION >= (6, 1) else [missing]
+        self.assertSequenceEqual(result, expected)
+
+    @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
     def test_json_null_iexact_uses_registered_exact_lookup(self):
         class CustomExact(Lookup):
             lookup_name = 'exact'

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -158,17 +158,32 @@ class TestJSONField(TestCase):
         # every vendor, which suppresses Django's build-time iexact=None ->
         # isnull=True rewrite. A non-SQL-Server database must still see its
         # native result: pre-6.1 a missing key matched (IS NULL semantics),
-        # while 6.1 unified iexact=None to match the JSON null value.
+        # while 6.1 unified iexact=None to match the JSON null value. Assert both
+        # the filter and the negated (exclude) direction so the three-valued
+        # behavior on the secondary database can't silently regress.
         json_null = JSONModel(value={"nullable": None})
         json_null.save(using='sqlite')
         missing = JSONModel(value={"other": "value"})
         missing.save(using='sqlite')
+        present = JSONModel(value={"nullable": "value"})
+        present.save(using='sqlite')
 
-        result = list(
-            JSONModel.objects.using('sqlite').filter(value__nullable__iexact=None)
-        )
-        expected = [json_null] if VERSION >= (6, 1) else [missing]
-        self.assertSequenceEqual(result, expected)
+        included = JSONModel.objects.using('sqlite').filter(
+            value__nullable__iexact=None
+        ).order_by('pk')
+        excluded = JSONModel.objects.using('sqlite').exclude(
+            value__nullable__iexact=None
+        ).order_by('pk')
+        if VERSION >= (6, 1):
+            # 6.1 matches the JSON null value. The missing-key row yields a NULL
+            # predicate, so it drops out of both the filter and the exclude.
+            self.assertSequenceEqual(included, [json_null])
+            self.assertSequenceEqual(excluded, [present])
+        else:
+            # Pre-6.1 matches a missing key (IS NULL). exclude keeps the rows
+            # whose key resolves to a non-null JSON value.
+            self.assertSequenceEqual(included, [missing])
+            self.assertSequenceEqual(excluded, [json_null, present])
 
     @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
     def test_json_null_iexact_uses_registered_exact_lookup(self):

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -1,15 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the BSD license.
 
-from types import SimpleNamespace
 from unittest import skipUnless
 
 from django import VERSION
 from django.db import NotSupportedError, connections
-from django.db.models import F, Lookup
-from django.db.models.fields.json import (
-    KeyTextTransform, KeyTransform, KeyTransformIExact,
-)
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 
@@ -140,27 +135,32 @@ class TestJSONField(TestCase):
         JSONModel.objects.create(value={})
 
         self.assertSequenceEqual(JSONModel.objects.filter(value__nullable=None), [present])
-        self.assertSequenceEqual(JSONModel.objects.filter(value__nullable__iexact=None), [present])
         self.assertSequenceEqual(JSONModel.objects.filter(value__nested__nullable=None), [present])
         self.assertSequenceEqual(JSONModel.objects.exclude(value__nullable=None), [non_null])
         self.assertSequenceEqual(
             JSONModel.objects.exclude(value__nested__nullable=None),
             [non_null],
         )
+        if VERSION >= (6, 1):
+            # iexact=None matches the JSON null value only from Django 6.1, where
+            # KeyTransformIExact delegates None to the exact lookup. Pre-6.1 keeps
+            # Django's native IS NULL semantics for iexact=None and is left alone.
+            self.assertSequenceEqual(
+                JSONModel.objects.filter(value__nullable__iexact=None), [present]
+            )
 
     @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
     @skipUnless(
         _check_jsonfield_supported_sqlite(),
         "JSONField not supported by SQLite on this platform and Python version",
     )
-    def test_json_null_iexact_none_preserves_secondary_database(self):
-        # Importing this backend enables None as an iexact right-hand side for
-        # every vendor, which suppresses Django's build-time iexact=None ->
-        # isnull=True rewrite. A non-SQL-Server database must still see its
-        # native result: pre-6.1 a missing key matched (IS NULL semantics),
-        # while 6.1 unified iexact=None to match the JSON null value. Assert both
-        # the filter and the negated (exclude) direction so the three-valued
-        # behavior on the secondary database can't silently regress.
+    def test_json_null_iexact_none_secondary_database_unaffected(self):
+        # This backend must not alter iexact=None on a non-SQL-Server database.
+        # The fix is scoped to SQL Server, so a secondary database keeps Django's
+        # native semantics on every version: pre-6.1 a missing key matches (IS
+        # NULL), while 6.1 matches the JSON null value. Assert both the filter and
+        # the negated (exclude) direction so a future global patch that leaks into
+        # other backends is caught here.
         json_null = JSONModel(value={"nullable": None})
         json_null.save(using='sqlite')
         missing = JSONModel(value={"other": "value"})
@@ -184,34 +184,6 @@ class TestJSONField(TestCase):
             # whose key resolves to a non-null JSON value.
             self.assertSequenceEqual(included, [missing])
             self.assertSequenceEqual(excluded, [json_null, present])
-
-    @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
-    def test_json_null_iexact_uses_registered_exact_lookup(self):
-        class CustomExact(Lookup):
-            lookup_name = 'exact'
-
-            def as_sql(self, compiler, connection):
-                return 'CUSTOM_JSON_EXACT', []
-
-        previous_lookup = KeyTransform.get_lookups()['exact']
-        KeyTransform.register_lookup(CustomExact)
-        try:
-            lookup = KeyTransformIExact(
-                KeyTextTransform('nullable', F('value')).resolve_expression(
-                    JSONModel.objects.all().query,
-                ),
-                None,
-            )
-            sql, params = lookup.as_sql(
-                compiler=None,
-                connection=SimpleNamespace(vendor='microsoft'),
-            )
-        finally:
-            KeyTransform.register_lookup(previous_lookup)
-
-        self.assertIs(KeyTransform.get_lookups()['exact'], previous_lookup)
-        self.assertEqual(sql, 'CUSTOM_JSON_EXACT')
-        self.assertEqual(params, [])
 
     @skipUnless(VERSION >= (3, 1), "JSONField not supported in Django versions < 3.1")
     def test_json_null_numeric_key_uses_array_index_semantics(self):


### PR DESCRIPTION
Fixes #592.

This PR builds on top of PR #576 to correctly handle JSON-null key lookups when the database compatibility level is below 130.

- For SQL Server 2022+ without OPENJSON support, it uses \JSON_PATH_EXISTS\ combined with \JSON_VALUE\ and \JSON_QUERY\ to definitively isolate JSON nulls from missing keys or object/array values.
- For older versions (2016-2019) at compat level 120, it explicitly raises \NotSupportedError\.

This fulfills the exact recommended handling described in #592.