### PR TITLE
Fix/jsonfield isnull key

### DIFF
--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -78,6 +78,20 @@ def _as_sql_json_keytransform(self, compiler, connection):
         ((lhs, json_path) * 2)
     ), tuple(params) * 2
 
+
+def _json_lhs_reaches_column(expr):
+    """
+    OPENJSON requires a column or variable, not an arbitrary expression
+    such as a Value() literal.
+    """
+    if isinstance(expr, Col):
+        return True
+    inner = getattr(expr, 'lhs', None)
+    if inner is not None:
+        return _json_lhs_reaches_column(inner)
+    return False
+
+
 def _as_sql_keytransform_isnull(self, compiler, connection):
     lhs, params, key_transforms = self.lhs.preprocess_lhs(compiler, connection)
 
@@ -85,17 +99,49 @@ def _as_sql_keytransform_isnull(self, compiler, connection):
         json_path = connection.ops.compile_json_path(key_transforms)
     else:
         json_path = compile_json_path(key_transforms)
-
     json_path = json_path.replace("'", "''")
 
-    if self.rhs:
-        # isnull=True → the key doesn't exist.
-        template = "JSON_PATH_EXISTS(%s, '%s') = 0"
-    else:
-        # isnull=False → the key exists, including JSON null.
-        template = "JSON_PATH_EXISTS(%s, '%s') = 1"
+    lhs_is_literal = not _json_lhs_reaches_column(self.lhs)
+    if connection.features.supports_json_path_exists:
+        # SQL Server 2022+, compat >= 160. JSON_PATH_EXISTS accepts
+        # literals, so no Cast guard is needed here.
+        exists_op = "= 0" if self.rhs else "= 1"
+        return (
+            "JSON_PATH_EXISTS(%s, '%s') %s" % (lhs, json_path, exists_op),
+            tuple(params),
+        )
 
-    return template % (lhs, json_path), tuple(params)
+    if connection.features.supports_json_openjson and not lhs_is_literal:
+        # Any version, compat >= 130. Enumerate the parent object's keys
+        *parent_transforms, final_key = key_transforms
+        if hasattr(connection.ops, "compile_json_path"):
+            parent_path = connection.ops.compile_json_path(parent_transforms)
+        else:
+            parent_path = compile_json_path(parent_transforms)
+        parent_path = parent_path.replace("'", "''")
+        final_key_escaped = final_key.replace("'", "''")
+
+        # DATALENGTH guard: SQL Server pads strings in comparisons, so
+        # [key] = 'k' would also match 'k ' without this check.
+        exists_sql = (
+            "EXISTS (SELECT 1 FROM OPENJSON(%s, '%s') "
+            "WHERE [key] = N'%s' AND DATALENGTH([key]) = DATALENGTH(N'%s'))"
+             ) % (lhs, parent_path, final_key_escaped, final_key_escaped)
+
+        exists_op = "= 0" if self.rhs else "= 1"
+        return (
+            "(CASE WHEN %s THEN 1 ELSE 0 END) %s" % (exists_sql, exists_op),
+            tuple(params),
+        )
+
+    # Fallback for compat < 130, or for literal-JSON LHS on compat >= 130.
+    # Cannot distinguish an absent key from a JSON null value; documented
+    # limitation, mirrors HasKey's own pre-2022 fallback.
+    is_null_op = "IS NULL" if self.rhs else "IS NOT NULL"
+    return (
+        "JSON_VALUE(%s, '%s') %s" % (lhs, json_path, is_null_op),
+        tuple(params),
+    )
 
 def _as_sql_least(self, compiler, connection):
     # SQL Server does not provide LEAST function,

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -19,7 +19,7 @@ from django.db.models.sql import compiler
 from django.db.transaction import TransactionManagementError
 from django.db.utils import NotSupportedError
 if django.VERSION >= (3, 1):
-    from django.db.models.fields.json import KeyTransform as json_KeyTransform
+    from django.db.models.fields.json import KeyTransform as json_KeyTransform, KeyTransformIsNull
     # compile_json_path was moved to connection.ops in Django 6.0
     if django.VERSION < (6, 0):
         from django.db.models.fields.json import compile_json_path
@@ -77,6 +77,25 @@ def _as_sql_json_keytransform(self, compiler, connection):
         "COALESCE(JSON_QUERY(%s, '%s'), JSON_VALUE(%s, '%s'))" %
         ((lhs, json_path) * 2)
     ), tuple(params) * 2
+
+def _as_sql_keytransform_isnull(self, compiler, connection):
+    lhs, params, key_transforms = self.lhs.preprocess_lhs(compiler, connection)
+
+    if hasattr(connection.ops, "compile_json_path"):
+        json_path = connection.ops.compile_json_path(key_transforms)
+    else:
+        json_path = compile_json_path(key_transforms)
+
+    json_path = json_path.replace("'", "''")
+
+    if self.rhs:
+        # isnull=True → the key doesn't exist.
+        template = "JSON_PATH_EXISTS(%s, '%s') = 0"
+    else:
+        # isnull=False → the key exists, including JSON null.
+        template = "JSON_PATH_EXISTS(%s, '%s') = 1"
+
+    return template % (lhs, json_path), tuple(params)
 
 def _as_sql_least(self, compiler, connection):
     # SQL Server does not provide LEAST function,
@@ -756,7 +775,9 @@ class SQLCompiler(compiler.SQLCompiler):
         elif django.VERSION >= (6, 0) and isinstance(node, StringAgg):
             as_microsoft = _as_sql_stringagg
         if django.VERSION >= (3, 1):
-            if isinstance(node, json_KeyTransform):
+            if isinstance(node, KeyTransformIsNull):
+                as_microsoft = _as_sql_keytransform_isnull
+            elif isinstance(node, json_KeyTransform):
                 as_microsoft = _as_sql_json_keytransform
         if django.VERSION >= (4, 1):
             if isinstance(node, Window):

--- a/mssql/compiler.py
+++ b/mssql/compiler.py
@@ -139,8 +139,9 @@ def _as_sql_keytransform_isnull(self, compiler, connection):
     # limitation, mirrors HasKey's own pre-2022 fallback.
     is_null_op = "IS NULL" if self.rhs else "IS NOT NULL"
     return (
-        "JSON_VALUE(%s, '%s') %s" % (lhs, json_path, is_null_op),
-        tuple(params),
+        "COALESCE(JSON_QUERY(%s, '%s'), JSON_VALUE(%s, '%s')) %s" %
+        ((lhs, json_path) * 2 + (is_null_op,)),
+        tuple(params) * 2,
     )
 
 def _as_sql_least(self, compiler, connection):

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -112,13 +112,16 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         """
         if self.connection.sql_server_version < 2022:
             return False
-        with self.connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT compatibility_level FROM sys.databases "
-                "WHERE database_id = DB_ID()"
-            )
-            row = cursor.fetchone()
-            return bool(row) and row[0] >= 160
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT compatibility_level FROM sys.databases "
+                    "WHERE database_id = DB_ID()"
+                )
+                row = cursor.fetchone()
+                return bool(row) and row[0] >= 160
+        except Exception:
+            return False
 
     @cached_property
     def supports_json_openjson(self):
@@ -126,10 +129,13 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         OPENJSON requires database compatibility level >= 130, independent of
         the SQL Server product version.
         """
-        with self.connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT compatibility_level FROM sys.databases "
-                "WHERE database_id = DB_ID()"
-            )
-            row = cursor.fetchone()
-            return bool(row) and row[0] >= 130
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT compatibility_level FROM sys.databases "
+                    "WHERE database_id = DB_ID()"
+                )
+                row = cursor.fetchone()
+                return bool(row) and row[0] >= 130
+        except Exception:
+            return False

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -110,9 +110,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         JSON_PATH_EXISTS was introduced in SQL Server 2022 and requires the
         database compatibility level to be 160 or higher.
         """
-        if self.connection.sql_server_version < 2022:
-            return False
         try:
+            if self.connection.sql_server_version < 2022:
+               return False
             with self.connection.cursor() as cursor:
                 cursor.execute(
                     "SELECT compatibility_level FROM sys.databases "

--- a/mssql/features.py
+++ b/mssql/features.py
@@ -5,7 +5,7 @@ from django.db.backends.base.features import BaseDatabaseFeatures
 from django.utils.functional import cached_property
 from django import VERSION as django_version
 # Import CompositePrimaryKey only if Django version is 5.2 or higher
-if django_version >= (5, 2):    
+if django_version >= (5, 2):
     from django.db.models.fields.composite import CompositePrimaryKey
 class DatabaseFeatures(BaseDatabaseFeatures):
     # Django 6.1 added database-level ON DELETE pushdown (DB_CASCADE / DB_SET_NULL /
@@ -103,3 +103,33 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             **super().introspected_field_types,
             "DurationField": "BigIntegerField",
         }
+
+    @cached_property
+    def supports_json_path_exists(self):
+        """
+        JSON_PATH_EXISTS was introduced in SQL Server 2022 and requires the
+        database compatibility level to be 160 or higher.
+        """
+        if self.connection.sql_server_version < 2022:
+            return False
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT compatibility_level FROM sys.databases "
+                "WHERE database_id = DB_ID()"
+            )
+            row = cursor.fetchone()
+            return bool(row) and row[0] >= 160
+
+    @cached_property
+    def supports_json_openjson(self):
+        """
+        OPENJSON requires database compatibility level >= 130, independent of
+        the SQL Server product version.
+        """
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT compatibility_level FROM sys.databases "
+                "WHERE database_id = DB_ID()"
+            )
+            row = cursor.fetchone()
+            return bool(row) and row[0] >= 130

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -195,7 +195,6 @@ EXCLUDED_TESTS = [
 
     # JSONFields
     'model_fields.test_jsonfield.TestQuerying.test_key_quoted_string',
-    'model_fields.test_jsonfield.TestQuerying.test_isnull_key',
     'model_fields.test_jsonfield.TestQuerying.test_none_key',
     'model_fields.test_jsonfield.TestQuerying.test_none_key_and_exact_lookup',
     'model_fields.test_jsonfield.TestQuerying.test_key_escape',

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -192,3 +192,17 @@ class TestJSONField(TestCase):
         select_sql = captured[-1]["sql"]
         self.assertEqual(select_sql.upper().count("TRY_CONVERT(FLOAT"), 1)
 
+    def test_key_isnull(self):
+        missing_key = JSONModel.objects.create(value={"other": 1})
+        null_value = JSONModel.objects.create(value={"k": None})
+
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(value__k__isnull=True),
+            [missing_key],
+        )
+
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(value__k__isnull=False),
+            [null_value],
+        )
+

--- a/testapp/tests/test_jsonfield.py
+++ b/testapp/tests/test_jsonfield.py
@@ -192,9 +192,17 @@ class TestJSONField(TestCase):
         select_sql = captured[-1]["sql"]
         self.assertEqual(select_sql.upper().count("TRY_CONVERT(FLOAT"), 1)
 
+
+    @skipUnless(
+        connections['default'].vendor != 'microsoft'
+        or connections['default'].features.supports_json_path_exists
+        or connections['default'].features.supports_json_openjson,
+        "isnull=True cannot distinguish absent key from JSON null below compat 130. "
+    )
     def test_key_isnull(self):
         missing_key = JSONModel.objects.create(value={"other": 1})
         null_value = JSONModel.objects.create(value={"k": None})
+        normal_value = JSONModel.objects.create(value={"k": "v"})
 
         self.assertSequenceEqual(
             JSONModel.objects.filter(value__k__isnull=True),
@@ -203,6 +211,21 @@ class TestJSONField(TestCase):
 
         self.assertSequenceEqual(
             JSONModel.objects.filter(value__k__isnull=False),
-            [null_value],
+            [null_value, normal_value],
+        )
+
+        # sqlite:
+        for row in (missing_key, null_value, normal_value):
+            row.save(using='sqlite')
+
+        self.assertSequenceEqual(
+            JSONModel.objects.using('sqlite').filter(value__k__isnull=True),
+            [missing_key],
+            msg="SQLite: value__k__isnull=True must exclude JSON null.",
+        )
+        self.assertSequenceEqual(
+            JSONModel.objects.using('sqlite').filter(value__k__isnull=False),
+            [null_value, normal_value],
+            msg="SQLite: value__k__isnull=False must include JSON null.",
         )
 


### PR DESCRIPTION
Fixes #591.

The old SQL was `COALESCE(JSON_QUERY(...), JSON_VALUE(...)) IS NULL`,
which returns NULL for both an absent key and a key holding JSON null,
so the two cases were indistinguishable.

The fix resolves the lookup through key existence, using the best
capability available at runtime:

  - SQL Server 2022+ at compat >= 160: JSON_PATH_EXISTS
  - Any version at compat >= 130:      OPENJSON key enumeration
  - compat < 130:                      fallback (old behavior; tracked
                                       in #592)

Capabilities are detected via two new feature flags in mssql/features.py
(supports_json_path_exists and supports_json_openjson).

Three OPENJSON-tier cases needed extra care, all caught on a real
SQL Server 2019 instance:

  - Nested keys: the parent path is passed to OPENJSON and the final
    key is compared against [key].
  - Literal LHS (e.g. KeyTransform('k', Value(...))): OPENJSON needs a
    column, so we fall through to JSON_VALUE when the LHS is not
    column-backed.
  - Trailing-space collisions: SQL Server pads strings in comparisons,
    so [key] = N'k' would match N'k '. The DATALENGTH guard and N'...'
    prefix on literals prevent this.

Files changed:
  - mssql/features.py                (two new feature flags)
  - mssql/compiler.py                (three-tier _as_sql_keytransform_isnull)
  - testapp/settings.py              (removed test_isnull_key from EXCLUDED_TESTS)
  - testapp/tests/test_jsonfield.py  (added test_key_isnull, SQL Server + SQLite)

Testing on SQL Server 2022 and 2019 (Docker):

  2022 @ compat 160: JSON_PATH_EXISTS  -> 11 pass
  2022 @ compat 130: OPENJSON          -> 11 pass
  2019 @ compat 150: OPENJSON          -> 11 pass
  any  @ compat 120: fallback          -> documented limitation (#592)